### PR TITLE
fix: missing property in lighthouse normalization 

### DIFF
--- a/packages/core/src/puppeteer/tasks/lighthouse.ts
+++ b/packages/core/src/puppeteer/tasks/lighthouse.ts
@@ -46,6 +46,7 @@ export const normaliseLighthouseResult = (result: LH.Result): LighthouseReport =
       'audits.redirects',
       // performance computed
       'audits.first-contentful-paint',
+      'audits.largest-contentful-paint',
       'audits.total-blocking-time',
       'audits.max-potential-fid',
       'audits.interactive',


### PR DESCRIPTION

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes missing largest-contentful-paint in results. 

### Linked Issues
fix #31

