### PR TITLE
[CI] Read 'buildStatic' from the resolvedConfig rather than the command options

### DIFF
--- a/packages/cli/src/ci.ts
+++ b/packages/cli/src/ci.ts
@@ -97,7 +97,7 @@ async function run() {
           .sort((a, b) => a.path.localeCompare(b.path)),
       )
 
-      if (options.buildStatic) {
+      if (resolvedConfig.ci?.buildStatic) {
         logger.info('Generating static client.')
         const { runtimeSettings } = useUnlighthouse()
         await generateClient({ static: true })


### PR DESCRIPTION
### Description

If you call the `unlighthouse-ci` with the `--config-file path/to/unlighthouse.config.ts`, the `ci.buildStatic` configuration in that config is ignored. The `buildStatic` is therefore only determined by the `--build-static` command option.
I think this was meant to be taken from `resolvedConfig`, just like `resolvedConfig.ci?.budget` a few lines above.

### Linked Issues

_none_


### Additional context

_nothing_
