### PR TITLE
fix(config): ensure `config.lighthouseOptions.onlyCategories` tab order

### DIFF
--- a/packages/core/src/resolveConfig.ts
+++ b/packages/core/src/resolveConfig.ts
@@ -35,8 +35,16 @@ export const resolveUserConfig: (userConfig: UserConfig) => Promise<ResolvedUser
     // normalise site
     config.site = normaliseHost(config.site)
   }
-  if (!config.lighthouseOptions)
+  if (config.lighthouseOptions) {
+    if (config.lighthouseOptions.onlyCategories?.length) {
+      // restrict categories values and copy order of columns from the default config
+      // @ts-ignore 'defaultConfig.lighthouseOptions' is always set in default config
+      config.lighthouseOptions.onlyCategories = defaultConfig.lighthouseOptions.onlyCategories
+        .filter(column => config.lighthouseOptions.onlyCategories.includes(column))
+    }
+  } else {
     config.lighthouseOptions = {}
+  }
   // for local urls we disable throttling
   if (!config.site || config.site.includes('localhost') || !config.scanner?.throttle) {
     config.lighthouseOptions.throttlingMethod = 'provided'


### PR DESCRIPTION
### Description

When I was writing my config I added different categories to the `lighthouseOptions.onlyCategories` parameter like this:
```javascript
{
    [...]
    lighthouseOptions: {
        onlyCategories: ['accessibility', 'best-practices', 'seo', 'performance']
    }
}
```
When adding them, I ignored their order and just appended new elements in the end.
When I generated a report I noticed that this order was adopted by the tab list on the report page.

So my Navigation looked like this:
- Overview
- Accessibility
- Best Practices
- SEO
- Performance

But once I clicked on the navigation elements, they would open another tab.
I could click `Accessibility` but it would open the `Performance` view.

The same switch could be observed with the guage element next to them.
`Accessibility` displayed the average value of the `Performance` category.
Everything except the label would be related to the element, which would in the regular order be position in this spot.

To fix this issue, I added some code to order the user inputs in the same order as the default config.
Additionally this code filters out every none standard or mistyped values as they would also confuse the system.

### Linked Issues

_none_

### Additional context

Things to evaluate:
1. I'm not sure if restricting the selectable values to ['performance', 'accessibility', 'best-practices', 'seo'] can have any side effects on custom configuration. That's probably something you have more insights to determine.
2. An alternative solution would be to fix the behaviour of the TabList element and allow other orders. But I think I prefer this solution as it is uniform with with the lighthouse outputs.