### PR TITLE
feat(config): add config.auth param to provide basic auth credentials

### DIFF
--- a/docs/content/3.api/config.md
+++ b/docs/content/3.api/config.md
@@ -63,6 +63,13 @@ Where to emit lighthouse reports and the runtime client.
 
 Display the loggers' debug messages.
 
+### auth
+
+- **Type:** `false|{ username: string, password: string }`
+- **Default:** `false`
+
+Optional basic auth credentials
+
 ### hooks
 
 - **Type:** `NestedHooks<UnlighthouseHooks>`

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -12,7 +12,7 @@ export const validateHost = async (resolvedConfig: ResolvedUserConfig) => {
   if (resolvedConfig.site) {
     // test HTTP response from site
     logger.debug(`Testing Site \`${resolvedConfig.site}\` is valid.`)
-    const { valid, response, error, redirected, redirectUrl } = await fetchUrlRaw(resolvedConfig.site)
+    const { valid, response, error, redirected, redirectUrl } = await fetchUrlRaw(resolvedConfig.site, resolvedConfig)
     if (!valid) {
       // something is wrong with the site, bail
       if (response?.status)

--- a/packages/core/lighthouse.d.ts
+++ b/packages/core/lighthouse.d.ts
@@ -293,6 +293,8 @@ declare module 'lighthouse' {
       precomputedLanternData?: PrecomputedLanternData | null
       /** The budget.json object for LightWallet. */
       budgets?: Array<Budget> | null
+      /** Optional extra headers */
+      extraHeaders?: { [key: string]: string }
     }
 
     /**

--- a/packages/core/src/puppeteer/tasks/html.ts
+++ b/packages/core/src/puppeteer/tasks/html.ts
@@ -15,7 +15,7 @@ export const extractHtmlPayload: (page: Page, route: string) => Promise<{ succes
 
   // if we don't need to execute any javascript we can do a less expensive fetch of the URL
   if (resolvedConfig.scanner.skipJavascript) {
-    const { valid, response, redirected, redirectUrl } = await fetchUrlRaw(route)
+    const { valid, response, redirected, redirectUrl } = await fetchUrlRaw(route, resolvedConfig)
     if (!valid || !response)
       return { success: false, message: `Invalid response from URL ${route} code: ${response?.status || '404'}.` }
 

--- a/packages/core/src/puppeteer/tasks/lighthouse.ts
+++ b/packages/core/src/puppeteer/tasks/lighthouse.ts
@@ -94,6 +94,10 @@ export const runLighthouseTask: PuppeteerTask = async (props) => {
   // ignore csp errors
   await page.setBypassCSP(true)
 
+  if (resolvedConfig.auth) {
+    page.authenticate(resolvedConfig.auth)
+  }
+
   // Wait for Lighthouse to open url, then allow hook to run
   browser.on('targetchanged', async (target) => {
     const page = await target.page()

--- a/packages/core/src/resolveConfig.ts
+++ b/packages/core/src/resolveConfig.ts
@@ -50,6 +50,14 @@ export const resolveUserConfig: (userConfig: UserConfig) => Promise<ResolvedUser
     }
   }
 
+  if (config.auth) {
+    config.lighthouseOptions.extraHeaders = config.lighthouseOptions.extraHeaders || {}
+    if (!config.lighthouseOptions.extraHeaders['Authorization']) {
+      const credentials = `${config.auth.username}:${config.auth.password}`
+      config.lighthouseOptions.extraHeaders["Authorization"] = 'Basic ' + Buffer.from(credentials).toString("base64")
+    }
+  }
+
   if (config.client?.columns) {
     // filter out any columns for categories we're not showing
     config.client.columns = pick(config.client.columns, ['overview', ...config.lighthouseOptions.onlyCategories as UnlighthouseTabs[]])

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -249,6 +249,12 @@ export interface ResolvedUserConfig {
    */
   cache: boolean
   /**
+   * Optional basic auth credentials
+   *
+   * @default false
+   */
+  auth: false | { username: string, password: string }
+  /**
    * Load the configuration from a custom config file.
    * By default, it attempts to load configuration from `unlighthouse.config.ts`.
    *

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -5,9 +5,9 @@ import { ensureDirSync } from 'fs-extra'
 import sanitize from 'sanitize-filename'
 import slugify from 'slugify'
 import { hasProtocol, joinURL, withLeadingSlash, withTrailingSlash, withoutLeadingSlash, withoutTrailingSlash } from 'ufo'
-import type { AxiosResponse } from 'axios'
+import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 import axios from 'axios'
-import type { NormalisedRoute, UnlighthouseRouteReport } from './types'
+import type { NormalisedRoute, ResolvedUserConfig, UnlighthouseRouteReport } from './types'
 import { useUnlighthouse } from './unlighthouse'
 
 export const ReportArtifacts = {
@@ -118,16 +118,27 @@ export const formatBytes = (bytes: number, decimals = 2) => {
   return `${parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`
 }
 
-export async function fetchUrlRaw(url: string): Promise<{ error?: any; redirected?: boolean; redirectUrl?: string; valid: boolean; response?: AxiosResponse }> {
+export async function fetchUrlRaw(url: string, resolvedConfig: ResolvedUserConfig): Promise<{ error?: any; redirected?: boolean; redirectUrl?: string; valid: boolean; response?: AxiosResponse }> {
+  const axiosOptions: AxiosRequestConfig = {}
+  if (resolvedConfig.auth) {
+    axiosOptions.auth = resolvedConfig.auth
+  }
+
   try {
     const response = await axios.get(url, {
       // allow all SSL's
       httpsAgent: new https.Agent({
         rejectUnauthorized: false,
       }),
+      ...axiosOptions,
     })
-    const redirected = response.request.res.responseUrl && response.request.res.responseUrl !== url
-    const redirectUrl = response.request.res.responseUrl
+    let responseUrl = response.request.res.responseUrl
+    if (responseUrl && axiosOptions.auth) {
+      // remove auth credentials from url (e.g. https://user:passwd@domain.de)
+      responseUrl = responseUrl.replace(/(?<=https?:\/\/)(.+@)/g, '')
+    }
+    const redirected = responseUrl && responseUrl !== url;
+    const redirectUrl = responseUrl;
     if (response.status < 200 || (response.status >= 300 && !redirected)) {
       return {
         valid: false,


### PR DESCRIPTION
### Description

Adds the config.auth parameter to the configuration options.
If provided this parameter will authorize requests to the site with via basic auth.

### Linked Issues

_none_

### Additional context

_none_
