### PR TITLE
Add new configuration property "sitemapPath" to change the sitemap path

### DIFF
--- a/packages/cli/src/ci.ts
+++ b/packages/cli/src/ci.ts
@@ -14,6 +14,7 @@ async function run() {
 
   cli.option('--budget <budget>', 'Budget (1-100), the minimum score which can pass.')
   cli.option('--build-static <build-static>', 'Build a static website for the reports which can be uploaded.')
+  cli.option('--sitemap-path <sitemap-path>', 'Set a custom path for the sitemap.')
 
   const { options } = cli.parse() as unknown as { options: CiOptions }
 

--- a/packages/cli/src/createCli.ts
+++ b/packages/cli/src/createCli.ts
@@ -20,6 +20,7 @@ export default function createCli() {
   cli.option('--mobile', 'Simulate device as mobile.')
 
   cli.option('--site <site>', 'Host URL to scan')
+  cli.option('--sitemap-path <sitemap-path>', 'Sitemap path to use for scanning.')
   cli.option('--samples <samples>', 'Specify the amount of samples to run.')
   cli.option('--throttle', 'Enable the throttling')
   cli.option('--enable-javascript', 'When inspecting the HTML wait for the javascript to execute. Useful for SPAs.')

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -17,6 +17,7 @@ export interface CliOptions {
   disableI18nPages?: boolean
   enableJavascript?: boolean
   disableJavascript?: boolean
+  sitemapPath?: string
 }
 
 export interface CiOptions extends CliOptions {

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -66,6 +66,9 @@ export function pickOptions(options: CiOptions | CliOptions): UserConfig {
   if (options.enableJavascript)
     picked.scanner.skipJavascript = false
 
+  if (options.sitemapPath)
+    picked.scanner.sitemapPath = options.sitemapPath
+
   else if (options.disableJavascript)
     picked.scanner.skipJavascript = true
 

--- a/packages/core/src/discovery/routes.ts
+++ b/packages/core/src/discovery/routes.ts
@@ -36,7 +36,7 @@ export const resolveReportableRoutes: () => Promise<NormalisedRoute[]> = async (
 
   // if sitemap scanning is enabled
   if (resolvedConfig.scanner.sitemap) {
-    const sitemapUrls = await extractSitemapRoutes(resolvedConfig.site)
+    const sitemapUrls = await extractSitemapRoutes(resolvedConfig.site, resolvedConfig.scanner.sitemapPath)
     if (sitemapUrls.length) {
       logger.info(`Discovered ${sitemapUrls.length} routes from sitemap.xml.`)
       sitemapUrls.forEach(url => urls.add(url))

--- a/packages/core/src/discovery/sitemap.ts
+++ b/packages/core/src/discovery/sitemap.ts
@@ -18,7 +18,13 @@ export const extractSitemapRoutes = async (site: string, sitemapPath?: string) =
     debug: unlighthouse.resolvedConfig.debug,
   })
 
-  const sitemapUrl = `${site}/${sitemapPath || 'sitemap.xml'}`
+  let sitemapUrl = `${site}/sitemap.xml`
+  // if sitemapPath exists, check if start with "/" and remove it
+  if (sitemapPath) {
+    sitemapPath = sitemapPath.startsWith('/') ? sitemapPath.slice(1) : sitemapPath
+    sitemapUrl = `${site}/${sitemapPath}`
+  }
+
   logger.debug(`Attempting to fetch sitemap at ${sitemapUrl}`)
   const { sites } = await sitemap.fetch(sitemapUrl)
   logger.debug(`Fetched sitemap with ${sites.length} URLs.`)

--- a/packages/core/src/discovery/sitemap.ts
+++ b/packages/core/src/discovery/sitemap.ts
@@ -8,7 +8,7 @@ import { useLogger } from '../logger'
  *
  * @param site
  */
-export const extractSitemapRoutes = async (site: string) => {
+export const extractSitemapRoutes = async (site: string, sitemapPath?: string) => {
   // make sure we're working from the host name
   site = new $URL(site).origin
   const unlighthouse = useUnlighthouse()
@@ -18,7 +18,7 @@ export const extractSitemapRoutes = async (site: string) => {
     debug: unlighthouse.resolvedConfig.debug,
   })
 
-  const sitemapUrl = `${site}/sitemap.xml`
+  const sitemapUrl = `${site}/${sitemapPath || 'sitemap.xml'}`
   logger.debug(`Attempting to fetch sitemap at ${sitemapUrl}`)
   const { sites } = await sitemap.fetch(sitemapUrl)
   logger.debug(`Fetched sitemap with ${sites.length} URLs.`)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -400,6 +400,12 @@ export interface ResolvedUserConfig {
      */
     sitemap: boolean
     /**
+     * Path where get the sitemap.
+     *
+     * @default undefined
+     */
+    sitemapPath?: string
+    /**
      * Alias to switch the device used for scanning.
      * Set to false if you want to manually configure it.
      *

--- a/test/fixtures/unitedpets.config.ts
+++ b/test/fixtures/unitedpets.config.ts
@@ -1,6 +1,7 @@
 export default {
   site: 'https://unitedpets.com',
   outputPath: 'unitedpets-uci',
+  routerPrefix: '/skin-unlighthouse',
   ci: {
     // budget: {
     //   performance: 50,

--- a/test/fixtures/unitedpets.config.ts
+++ b/test/fixtures/unitedpets.config.ts
@@ -1,0 +1,19 @@
+export default {
+  site: 'https://unitedpets.com',
+  outputPath: 'unitedpets-uci',
+  ci: {
+    // budget: {
+    //   performance: 50,
+    //   accessibility: 100,
+    //   'best-practices': 90,
+    //   seo: 90,
+    // },
+    buildStatic: true
+  },
+  scanner: {
+    sitemapPath: 'sitemap/index.xml',
+    maxRoutes: 50,
+    device: 'desktop'
+  },
+  debug: true
+}


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello, this is my first PR, i needed a way to have a custom path for the sitemap.xml file instead of the hardcoded `/sitemap.xml`, so i added a new configuration property called `sitemapPath` that is a `string | undefined` and can be set via cli/ci/configuration file 

Example configuration file:
```
export default {
  site: 'https://google.com',
  outputPath: 'google-ci-2246',
  ci: {
    buildStatic: true
  },
  scanner: {
    sitemapPath: 'sitemap/index.xml',
    maxRoutes: 50,
    device: 'desktop'
  },
  debug: true
}

```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->
