### PR TITLE
feat(core): merge robots.txt disallows and sitemaps into config 

### DIFF
--- a/docs/components/content/Home.vue
+++ b/docs/components/content/Home.vue
@@ -8,7 +8,7 @@ const scanFeatures = [
   {
     icon: '🐞',
     title: 'Automated URL Discovery',
-    content: '<p>Fast, configurable URL discovery using sitemap.xml parsing, internal link crawling and project file scanning.</p>',
+    content: '<p>Fast, configurable URL discovery using robots.txt, sitemap.xml, internal link crawling and project file scanning.</p>',
   },
   {
     icon: '🍣',

--- a/docs/content/1.guide/1.getting-started/how-it-works.md
+++ b/docs/content/1.guide/1.getting-started/how-it-works.md
@@ -50,7 +50,9 @@ hooks.hookOnce('visited-client', () => {
 Discovery of the [route definitions](/api/glossary/#route-definition) is attempted. A virtual router for the route
 definitions is created.
 
-Start collecting the list of URLs to work with from the sitemap.xml, if no sitemap is discovered, the home page will be
+Attempt to read the robots.txt to disocver the sitemap and excluded routes.  
+
+With the sitemap.xml, we collect the list of URLs to work with, if no sitemap is discovered, the home page will be
 scanned.
 
 ### Worker

--- a/docs/content/1.guide/guides/url-discovery.md
+++ b/docs/content/1.guide/guides/url-discovery.md
@@ -5,14 +5,50 @@ Unlighthouse comes with multiple methods for URL discovery in the form of crawli
 
 1. Add the specified `site` from `--site` or config
 2. Manually providing URLs via the `--urls` flag or `urls` on the provider.
-3. `sitemap` - Reading sitemap.xml, if it exists 
-4. `crawler` - Inspecting internal links 
-5. Using provided static [route definitions](/api/glossary/#route-definition)
+3. `robotsTxt` - Reading robots.txt, if it exists. Provides sitemap URLs and disallowed paths.
+4. `sitemap` - Reading sitemap.xml, if it exists 
+5. `crawler` - Inspecting internal links 
+6. Using provided static [route definitions](/api/glossary/#route-definition)
+
+## Robots.txt
+
+When a robots.txt is found, it will attempt to read the sitemap and disallowed paths.
+
+### Disabling robots
+
+You may not want to use the robots.txt in all occasions. For example if you want to scan 
+URLs which are disallowed.
+
+  ```ts
+  export default {
+    scanner: {
+      // disable robots.txt scanning
+      robotsTxt: false
+    }
+  }
+  ```
 
 
-## Sitemap
+## Sitemap.xml
 
-When a sitemap is with a medium-sized threshold (50 URLS), it will disable the crawler.
+By default, the sitemap config will be read from your `/robots.txt`. Otherwise, it will fall back to using `/sitemap.xml`.
+
+Note: When a sitemap exists with over 50 paths, it will disable the crawler.
+
+### Manual sitemap paths
+
+You may provide an array of sitemap paths to scan.
+
+```ts
+export default {
+  scanner: {
+    sitemap: [
+      '/sitemap.xml',
+      '/sitemap2.xml'
+    ]
+  }
+}
+```
 
 ### Disabling scan
 

--- a/docs/content/3.api/config.md
+++ b/docs/content/3.api/config.md
@@ -280,12 +280,25 @@ redundant route reports.
 
 See [Change Dynamic Sampling Limit](/guide/recipes/large-sites#change-dynamic-sampling-limit) for more information.
 
-### scanner.sitemap
+### scanner.robotsTxt
 
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether the sitemap.xml will be attempted to be read from the site.
+Should the robots.txt file be used for configuration.
+
+Sitemap paths and disallows paths will be used to configure the scanner.
+
+### scanner.sitemap
+
+- **Type:** `boolean | string[]`
+- **Default:** `true`
+
+Either an array of sitemap paths, or a boolean to enable/disable sitemap scanning.
+
+By default, when `true` is provided or an empty array, it will try and load the sitemap from `/sitemap.xml`.
+
+Note: If you have `robotsTxt` enabled it will load sitemap config from here.
 
 ### scanner.device
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -67,7 +67,7 @@ What's included
   #title
   Zero-config Link Crawling
   #description
-  Fast, configurable URL discovery using sitemap.xml parsing, internal link crawling and project file scanning.
+  Fast, configurable URL discovery using robots.txt, sitemap.xml, internal link crawling and project file scanning.
   ::
 
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cli:hzw": "node packages/cli/dist/cli.mjs --root /home/harlan/sites/harlanzw.com/ --debug",
     "cli:ody": "node packages/cli/dist/cli.mjs --root /home/harlan/sites/odysseytraveller.com-app/ --debug",
     "cli:windi": "node packages/cli/dist/cli.mjs --site https://windicss.org/",
-    "cli:nuxt": "node packages/cli/dist/cli.mjs --site https://v3.nuxtjs.org/",
+    "cli:nuxt": "node packages/cli/dist/cli.mjs --site https://nuxt.com/",
     "cli:vue": "node packages/cli/dist/cli.mjs --config-file test/fixtures/staging-vue.config.ts --debug",
     "ci:vue": "node packages/cli/dist/ci.mjs --config-file test/fixtures/staging-vue.config.ts --build-static --debug",
     "ci:react": "node packages/cli/dist/ci.mjs --config-file test/fixtures/react-beta.config.ts --build-static --debug",

--- a/packages/cli/src/createCli.ts
+++ b/packages/cli/src/createCli.ts
@@ -27,6 +27,8 @@ export default function createCli() {
   cli.option('--enable-i18n-pages', 'Enable scanning pages which use x-default.')
   cli.option('--disable-i18n-pages', 'Disable scanning pages which use x-default.')
   cli.option('--urls <urls>', 'Specify explicit relative URLs as a comma-seperated list.')
+  cli.option('--disable-robots-txt', 'Disables the robots.txt crawling.')
+  cli.option('--disable-sitemap', 'Disables the sitemap.xml crawling.')
   cli.option('-d, --debug', 'Debug. Enable debugging in the logger.')
 
   return cli

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -17,6 +17,8 @@ export interface CliOptions {
   disableI18nPages?: boolean
   enableJavascript?: boolean
   disableJavascript?: boolean
+  disableRobotsTxt?: boolean
+  disableSitemap?: boolean
 }
 
 export interface CiOptions extends CliOptions {

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -82,6 +82,12 @@ export function pickOptions(options: CiOptions | CliOptions): UserConfig {
   else if (options.mobile)
     picked.scanner.device = 'mobile'
 
+  if (options.disableRobotsTxt)
+    picked.scanner.robotsTxt = false
+
+  if (options.disableSitemap)
+    picked.scanner.sitemap = false
+
   if (options.urls)
     picked.urls = options.urls.split(',')
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -199,6 +199,7 @@ export const defaultConfig: UserConfig = {
     crawler: true,
     dynamicSampling: 5,
     sitemap: true,
+    robotsTxt: true,
     device: 'mobile',
   },
   // @ts-expect-error provided by server package, may not be provided in CI mode

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,2 +1,4 @@
 export * from './routes'
 export * from './routeDefinitions'
+export * from './robotsTxt'
+export * from './sitemap'

--- a/packages/core/src/discovery/robotsTxt.ts
+++ b/packages/core/src/discovery/robotsTxt.ts
@@ -1,0 +1,81 @@
+import { $URL } from 'ufo'
+import type { ResolvedUserConfig } from '../types'
+import { useUnlighthouse } from '../unlighthouse'
+import { useLogger } from '../logger'
+import { fetchUrlRaw } from '../util'
+
+export interface RobotsTxtParsed {
+  sitemaps: string[]
+  disallows: string[]
+}
+
+/**
+ * Fetches the robots.txt file.
+ * @param site
+ */
+export async function fetchRobotsTxt(site: string): Promise<false | string> {
+  site = new $URL(site).origin
+  const unlighthouse = useUnlighthouse()
+  const logger = useLogger()
+  // we scan the robots.txt content for the sitemaps
+  logger.debug(`Scanning ${site}/robots.txt`)
+  const robotsTxt = await fetchUrlRaw(
+    `${site}/robots.txt`,
+    unlighthouse.resolvedConfig,
+  )
+  if (!robotsTxt.valid || !robotsTxt.response) {
+    logger.warn('You seem to be missing a robots.txt.')
+    return false
+  }
+  logger.debug('Found robots.txt')
+  return robotsTxt.response.data as string
+}
+
+/**
+ * Parses the robots.txt data.
+ */
+export function parseRobotsTxt(robotsTxt: string): RobotsTxtParsed {
+  const lines = robotsTxt.split('\n')
+  // make sure we're working from the host name
+  const sitemaps = lines
+    .filter(line => line.startsWith('Sitemap'))
+    // split only on the first instance of :
+    .map(line => line.split(/:(.+)/)[1].trim())
+  // get excludes
+  const disallows = lines
+    .filter(line => line.startsWith('Disallow'))
+    // split only on the first instance of :
+    .map((line) => {
+      const sections = line.trim().split(/:(.+)/)
+      if (sections.length >= 2) {
+        const [, path] = sections
+        return path.trim()
+      }
+      return false
+    })
+    .filter(Boolean) as string[]
+  return {
+    sitemaps,
+    disallows,
+  }
+}
+
+export function mergeRobotsTxtConfig(config: ResolvedUserConfig, { disallows, sitemaps }: RobotsTxtParsed): void {
+  // for diallow we add it to the exclude list
+  if (disallows.length) {
+    // skip any disallows that are root level
+    disallows = disallows.filter(path => path !== '/')
+    // convert robots.txt paths to regex paths
+    disallows = disallows.map((path) => {
+      if (path.includes('*'))
+        path = path.replace(/\*/g, '.*')
+      else
+        path = `${path}.*`
+      return path
+    })
+    config.scanner.exclude = [...new Set([...(config.scanner.exclude || []), ...disallows])]
+  }
+
+  if (config.scanner.sitemap !== false && sitemaps.length)
+    config.scanner.sitemap = [...new Set([...(Array.isArray(config.scanner.sitemap) ? config.scanner.sitemap : []), ...sitemaps])]
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -398,7 +398,13 @@ export interface ResolvedUserConfig {
      *
      * @default true
      */
-    sitemap: boolean
+    sitemap: boolean | string[]
+    /**
+     * Whether the robots.txt will be attempted to be read from the site.
+     *
+     * @default true
+     */
+    robotsTxt: boolean
     /**
      * Alias to switch the device used for scanning.
      * Set to false if you want to manually configure it.

--- a/packages/core/src/unlighthouse.ts
+++ b/packages/core/src/unlighthouse.ts
@@ -289,7 +289,7 @@ export const createUnlighthouse = async (userConfig: UserConfig, provider?: Prov
       if (resolvedConfig.urls?.length)
         mode = 'Manual'
 
-      if (resolvedConfig.scanner.sitemap)
+      if (resolvedConfig.scanner.sitemap !== false)
         mode += 'Sitemap'
 
       if (resolvedConfig.scanner.crawler)

--- a/packages/core/test/robots.test.ts
+++ b/packages/core/test/robots.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import { mergeRobotsTxtConfig, parseRobotsTxt } from '../src/discovery'
+import { asRegExp } from '../src/util'
+import type { ResolvedUserConfig } from '../src'
+
+describe('Robots', () => {
+  it ('parses example #1', () => {
+    const parsed = parseRobotsTxt(`
+# START YOAST BLOCK
+# ---------------------------
+User-agent: *
+Disallow:
+
+Sitemap: https://kootingalpecancompany.com/sitemap_index.xml
+# ---------------------------
+# END YOAST BLOCK
+`)
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "disallows": [],
+        "sitemaps": [
+          "https://kootingalpecancompany.com/sitemap_index.xml",
+        ],
+      }
+    `)
+  })
+
+  it('parses example #2', () => {
+    const parsed = parseRobotsTxt(`
+    User-agent: *
+Disallow: /account/
+Disallow: /dashboard/
+Disallow: /admin/
+Disallow: /mod/
+Allow: /$
+Allow: /wiki/
+`)
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "disallows": [
+          "/account/",
+          "/dashboard/",
+          "/admin/",
+          "/mod/",
+        ],
+        "sitemaps": [],
+      }
+    `)
+
+    const resolvedConfig = { scanner: { exclude: [], sitemap: [] } } as any as ResolvedUserConfig
+    mergeRobotsTxtConfig(resolvedConfig, parsed)
+
+    expect(resolvedConfig).toMatchInlineSnapshot(`
+      {
+        "scanner": {
+          "exclude": [
+            "/account/.*",
+            "/dashboard/.*",
+            "/admin/.*",
+            "/mod/.*",
+          ],
+          "sitemap": [],
+        },
+      }
+    `)
+
+    // blocked
+    expect(asRegExp(resolvedConfig.scanner.exclude![0]).test('/account/test')).toBeTruthy()
+  })
+
+  it ('parsed example #3', () => {
+    const parsed = parseRobotsTxt(`
+    User-agent: bingbot
+Crawl-delay: 10
+User-agent: YandexBot
+Crawl-delay: 20
+User-agent: *
+Disallow: /CVS
+Disallow: /*.svn$
+Disallow: /*.idea$
+Disallow: /*.sql$
+Disallow: /*.tgz$
+
+## Specific Disallow for filters
+## But accept pages
+
+Disallow: *brand=*
+Disallow: *color=*
+Disallow: *color_filter=*
+Disallow: *material_filter=*
+Disallow: *fitting_filter=*
+Disallow: *asc=price*
+Disallow: *desc=price*
+Disallow: *asc=name*
+Disallow: *desc=name*
+Disallow: *food_type=*
+Disallow: *tags=*
+Disallow: *size=*
+
+## Exclude other parametric for pop-ups
+Disallow: *search=*
+Disallow: *popup=*
+Disallow: *successRedirect=*
+
+## Do not crawl checkout and user account pages
+Disallow: */user/*
+Disallow: */checkout/*
+Disallow: */wishlist/*
+
+Sitemap: https://unitedpets.com/sitemap/index.xml
+`)
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "disallows": [
+          "/CVS",
+          "/*.svn$",
+          "/*.idea$",
+          "/*.sql$",
+          "/*.tgz$",
+          "*brand=*",
+          "*color=*",
+          "*color_filter=*",
+          "*material_filter=*",
+          "*fitting_filter=*",
+          "*asc=price*",
+          "*desc=price*",
+          "*asc=name*",
+          "*desc=name*",
+          "*food_type=*",
+          "*tags=*",
+          "*size=*",
+          "*search=*",
+          "*popup=*",
+          "*successRedirect=*",
+          "*/user/*",
+          "*/checkout/*",
+          "*/wishlist/*",
+        ],
+        "sitemaps": [
+          "https://unitedpets.com/sitemap/index.xml",
+        ],
+      }
+    `)
+
+    const resolvedConfig = { scanner: { exclude: [], sitemap: [] } } as any as ResolvedUserConfig
+    mergeRobotsTxtConfig(resolvedConfig, parsed)
+    expect(resolvedConfig).toMatchInlineSnapshot(`
+      {
+        "scanner": {
+          "exclude": [
+            "/CVS.*",
+            "/.*.svn$",
+            "/.*.idea$",
+            "/.*.sql$",
+            "/.*.tgz$",
+            ".*brand=.*",
+            ".*color=.*",
+            ".*color_filter=.*",
+            ".*material_filter=.*",
+            ".*fitting_filter=.*",
+            ".*asc=price.*",
+            ".*desc=price.*",
+            ".*asc=name.*",
+            ".*desc=name.*",
+            ".*food_type=.*",
+            ".*tags=.*",
+            ".*size=.*",
+            ".*search=.*",
+            ".*popup=.*",
+            ".*successRedirect=.*",
+            ".*/user/.*",
+            ".*/checkout/.*",
+            ".*/wishlist/.*",
+          ],
+          "sitemap": [
+            "https://unitedpets.com/sitemap/index.xml",
+          ],
+        },
+      }
+    `)
+
+    function isScannable(path: string) {
+      return resolvedConfig.scanner.exclude!.filter(rule => asRegExp(rule).test(path)).length === 0
+    }
+    expect(isScannable('/CVS')).toBeFalsy()
+    expect(isScannable('/test/checkout/')).toBeFalsy()
+    expect(isScannable('/?size=big')).toBeFalsy()
+    expect(isScannable('/my-product')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR completes the robots.txt integration. It will now read your robots.txt and merge in appropriate rules, including:
- `Disallow` -> `scanner.exclude`. This will avoid scanning URLs that shouldn't be included.
- `Sitemap` -> `scanner.sitemap`. Adds any sitemap entries, supporting an array of URLs

### Linked Issues

Maybe fixes https://github.com/harlan-zw/unlighthouse/issues/58
Fixes https://github.com/harlan-zw/unlighthouse/issues/47

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
