### PR TITLE
feat(core): improved auth with `cookies` and `extraHeaders` support

### DIFF
--- a/docs/content/1.guide/guides/authentication.md
+++ b/docs/content/1.guide/guides/authentication.md
@@ -1,0 +1,84 @@
+# Authentication
+
+Unlighthouse is built to support scanning sites that require authentication. 
+
+## Basic Authentication
+
+To use basic authentication, provide the `auth` option in your configuration file:
+
+```ts
+// unlighthouse.config.ts
+export default{
+  auth: {
+    username: 'username',
+    password: 'password',
+  },
+};
+```
+
+Alternatively, you can provide the `--auth` flag to the CLI.
+
+```bash
+unlighthouse --site <your-site> --auth username:password
+```
+
+## Cookies
+
+To use cookies, provide the `cookies` option in your configuration file:
+
+```ts
+// unlighthouse.config.ts
+export default{
+  cookies: [
+    {
+      name: 'my-jwt-token',
+      value: '<token>',
+      // optional extras
+      domain: 'your-site.com',
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ],
+};
+```
+
+Alternatively, you can provide the `--cookies` flag to the CLI.
+
+```bash
+unlighthouse --site <your-site> --cookies "my-jwt-token=<token>"
+```
+
+You can provide multiple cookies by separating them with a `;`.
+
+```bash
+unlighthouse --site <your-site> --cookies my-jwt-token=<token>;my-other-cookie=value
+```
+
+## Custom Headers
+
+If providing cookies or basic auth is not enough, you can provide custom headers to be sent with each request.
+
+To use custom headers, provide the `extraHeaders` option in your configuration file:
+
+```ts
+// unlighthouse.config.ts
+export default{
+  extraHeaders: {
+    'x-custom-auth': '<token>>',
+  },
+};
+```
+
+Alternatively, you can provide the `--extra-headers` flag to the CLI.
+
+```bash
+unlighthouse --site <your-site> --extra-headers x-custom-header:custom-value
+```
+
+You can provide multiple headers by separating them with a `,`.
+
+```bash
+unlighthouse --site <your-site> --extra-headers x-custom-header:custom-value,x-other-header:other-value
+```

--- a/docs/content/3.api/config.md
+++ b/docs/content/3.api/config.md
@@ -65,10 +65,25 @@ Display the loggers' debug messages.
 
 ### auth
 
-- **Type:** `false|{ username: string, password: string }`
+- **Type:** `false | { username: string, password: string }`
 - **Default:** `false`
 
-Optional basic auth credentials
+Optional basic auth credentials.
+
+### cookies
+
+- **Type:** ` false | CookieParam[]`
+- **Default:** `false`
+
+Provide cookies to be set for Axios and Puppeteer requests.
+
+
+### extraHeaders
+
+- **Type:** ` false | Record<string, string>`
+- **Default:** `false`
+
+Provide extra headers to be set for Axios and Puppeteer requests.
 
 ### hooks
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -2,6 +2,9 @@ export interface CliOptions {
   host?: string
   help?: boolean
   urls?: string
+  auth?: string
+  cookies?: string
+  extraHeaders?: string
   excludeUrls?: string
   includeUrls?: string
   site?: string

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -98,6 +98,27 @@ export function pickOptions(options: CiOptions | CliOptions): UserConfig {
   if (options.disableDynamicSampling)
     picked.scanner.dynamicSampling = false
 
+  if (options.auth) {
+    const [username, password] = options.auth.split(':')
+    picked.auth = { username, password }
+  }
+
+  if (options.cookies) {
+    picked.cookies = options.cookies.split(';').map((cookie) => {
+      const [name, value] = cookie.split('=')
+      return { name, value }
+    })
+  }
+
+  if (options.extraHeaders) {
+    picked.extraHeaders = picked.extraHeaders || {}
+    options.extraHeaders.split(',').forEach((header) => {
+      const [name, value] = header.split('=')
+      // @ts-expect-error untyped
+      picked.extraHeaders[name] = value
+    })
+  }
+
   const config = pick(options, [
     // root level options
     'samples',

--- a/packages/core/src/puppeteer/tasks/lighthouse.ts
+++ b/packages/core/src/puppeteer/tasks/lighthouse.ts
@@ -95,7 +95,13 @@ export const runLighthouseTask: PuppeteerTask = async (props) => {
   await page.setBypassCSP(true)
 
   if (resolvedConfig.auth)
-    page.authenticate(resolvedConfig.auth)
+    await page.authenticate(resolvedConfig.auth)
+
+  if (resolvedConfig.cookies)
+    await page.setCookie(...resolvedConfig.cookies)
+
+  if (resolvedConfig.extraHeaders)
+    await page.setExtraHTTPHeaders(resolvedConfig.extraHeaders)
 
   // Wait for Lighthouse to open url, then allow hook to run
   browser.on('targetchanged', async (target) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,7 @@ import type { LH } from 'lighthouse'
 import type { LaunchOptions, Page } from 'puppeteer-core'
 import type { Hookable, NestedHooks } from 'hookable'
 import type { App } from 'h3'
+import type { AxiosRequestConfig } from 'axios'
 import type { Cluster, TaskFunction } from '../cluster'
 import type { WS } from './router'
 
@@ -254,6 +255,18 @@ export interface ResolvedUserConfig {
    * @default false
    */
   auth: false | { username: string; password: string }
+  /**
+   * Cookies to add to HTTP requests.
+   *
+   * @default false
+   */
+  cookies: false | { name: string; value: string; [v: string]: string }[]
+  /**
+   * Extra headers to provide for any HTTP requests.
+   *
+   * @default false
+   */
+  extraHeaders: false | Record<string, string>
   /**
    * Load the configuration from a custom config file.
    * By default, it attempts to load configuration from `unlighthouse.config.ts`.
@@ -642,6 +655,12 @@ export interface UnlighthouseHooks {
    * @param page
    */
   'puppeteer:before-goto': (page: Page) => HookResult
+  /**
+   * Modify the options used when making a fetch with axios.
+   *
+   * @param options
+   */
+  'fetch:options': (options: { url: string; options: AxiosRequestConfig }) => HookResult
 }
 
 /**

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -123,14 +123,27 @@ export async function fetchUrlRaw(url: string, resolvedConfig: ResolvedUserConfi
   if (resolvedConfig.auth)
     axiosOptions.auth = resolvedConfig.auth
 
+  axiosOptions.headers = axiosOptions.headers || {}
+
+  if (resolvedConfig.cookies) {
+    axiosOptions.headers.Cookie = resolvedConfig.cookies
+      .map(cookie => `${cookie.name}=${cookie.value}`)
+      .join('; ')
+  }
+
+  if (resolvedConfig.extraHeaders)
+    axiosOptions.headers = { ...resolvedConfig.extraHeaders, ...axiosOptions.headers }
+
+  axiosOptions.httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+  })
+  axiosOptions.withCredentials = true
+  // allow modification of axios options
+  const fetchOptions = { url, options: axiosOptions }
+  const unlighthouse = useUnlighthouse()
+  await unlighthouse.hooks.callHook('fetch:options', fetchOptions)
   try {
-    const response = await axios.get(url, {
-      // allow all SSL's
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: false,
-      }),
-      ...axiosOptions,
-    })
+    const response = await axios.get(fetchOptions.url, fetchOptions.options)
     let responseUrl = response.request.res.responseUrl
     if (responseUrl && axiosOptions.auth) {
       // remove auth credentials from url (e.g. https://user:passwd@domain.de)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,24 +1,24 @@
-import { expect, it, describe } from 'vitest'
-import createCli from "../packages/cli/src/createCli";
-import {pickOptions} from "../packages/cli/src/util";
+import { describe, expect, it } from 'vitest'
+import createCli from '../packages/cli/src/createCli'
+import { pickOptions } from '../packages/cli/src/util'
 
 const argsv = (args: string[]) => ['node', 'unlighthouse.js', '--site', 'unlighthouse.dev', ...args]
 
 describe('cli args', () => {
-  it('cache on', async() => {
+  it('cache on', async () => {
     const cli = createCli()
     const { options } = cli.parse(argsv(['--cache']))
     const picked = pickOptions(options)
     expect(picked.cache).toBeTruthy()
   })
-  it('cache off', async() => {
+  it('cache off', async () => {
     const cli = createCli()
     const { options } = cli.parse(argsv(['--no-cache']))
     const picked = pickOptions(options)
     expect(picked.cache).toBeFalsy()
   })
 
-  it('urls csv', async() => {
+  it('urls csv', async () => {
     const cli = createCli()
     const { options } = cli.parse(argsv(['--urls', '/my-path,/second-path', '--debug']))
     expect(options.urls).toMatchInlineSnapshot('"/my-path,/second-path"')
@@ -28,6 +28,61 @@ describe('cli args', () => {
         "/my-path",
         "/second-path",
       ]
+    `)
+  })
+
+  it('cookies - single', async () => {
+    const cli = createCli()
+    const { options } = cli.parse(argsv(['--cookies', 'foo=bar']))
+    const picked = pickOptions(options)
+    expect(picked.cookies).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "foo",
+          "value": "bar",
+        },
+      ]
+    `)
+  })
+
+  it('cookies - multiple', async () => {
+    const cli = createCli()
+    const { options } = cli.parse(argsv(['--cookies', 'my-jwt-token=<token>;my-other-cookie=value']))
+    const picked = pickOptions(options)
+    expect(picked.cookies).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "my-jwt-token",
+          "value": "<token>",
+        },
+        {
+          "name": "my-other-cookie",
+          "value": "value",
+        },
+      ]
+    `)
+  })
+
+  it ('extraHeaders - single', async () => {
+    const cli = createCli()
+    const { options } = cli.parse(argsv(['--extraHeaders', 'foo=bar']))
+    const picked = pickOptions(options)
+    expect(picked.extraHeaders).toMatchInlineSnapshot(`
+      {
+        "foo": "bar",
+      }
+    `)
+  })
+
+  it ('extraHeaders - multiple', async () => {
+    const cli = createCli()
+    const { options } = cli.parse(argsv(['--extraHeaders', 'foo=bar,my-other-header=value']))
+    const picked = pickOptions(options)
+    expect(picked.extraHeaders).toMatchInlineSnapshot(`
+      {
+        "foo": "bar",
+        "my-other-header": "value",
+      }
     `)
   })
 })


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR makes a number of improvements around authentication:
- Support `cookies` through CLI and config
- Support `auth` through CLI (config support already existed)
- Support `extraHeaders` through CLI and config
- Adds a `fetch:options` hook to modify the axios request options
- Enables the axios option `withCredentials` by default

It also adds an Authentication page to the documentation.

### Linked Issues

Fixes https://github.com/harlan-zw/unlighthouse/issues/88


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
