### PR TITLE
feat(core): chromium fallback installer if system chrome is missing

### DIFF
--- a/docs/content/1.guide/1.getting-started/0.index.md
+++ b/docs/content/1.guide/1.getting-started/0.index.md
@@ -13,11 +13,8 @@ npx unlighthouse --site <your-site>
 # OR pnpm dlx unlighthouse --site <your-site>
 ```
 
-If you don't have an accessible chrome installation, you can use the `unlighthouse-puppeteer` binary.
-
-```bash
-npx unlighthouse-puppeteer --site example.com
-```
+By default Unlighthouse will attempt to use your system Chrome / Chromium install.
+If you these are missing, a Chromium binary will be installed on your system.
 
 To learn more about the CLI and the arguments, head over to [CLI Integration](/integrations/cli).
 

--- a/docs/content/1.guide/guides/chrome-dependency.md
+++ b/docs/content/1.guide/guides/chrome-dependency.md
@@ -1,0 +1,34 @@
+# Chrome Dependency
+
+Unlighthouse aims to keep the installation size small, for this reason it depends natively on your locally installed
+Chrome.
+
+As a fallback, it will download a Chromium binary for you.
+
+## Disabling system chrome
+
+You can disable the system chrome usage by providing `chrome.useSystem: false`. This will force the fallback installer to run.
+
+## Customizing the fallback installer
+
+When Chrome can't be found on your system or if the `chrome.useSystem: false` flag is passed, then a fallback will be attempted.
+
+This fallback will download a chrome binary for your system and use that path.
+
+There are a number of options you can customize on this.
+
+- `chrome.useDownloadFallback` - Disables the fallback installer
+- `chrome.downloadFallbackVersion` - Which version of chromium to use (default `1095492`)
+- `chrome.downloadFallbackCacheDir` - Where the binary should be saved (default `$home/.unlighthouse`)
+
+## Using your own chrome path
+
+You can provide your own chrome path by setting `puppeteerOptions.executablePath`.
+
+```ts
+export default {
+  puppeteerOptions: {
+    executablePath: '/usr/bin/chrome'
+  }
+}
+```

--- a/docs/content/2.integrations/0.cli.md
+++ b/docs/content/2.integrations/0.cli.md
@@ -15,20 +15,6 @@ npx unlighthouse --site <your-site>
 # OR pnpm dlx unlighthouse --site <your-site>
 ```
 
-### Chromium Dependency
-
-Unlighthouse aims to keep the installation size small, for this reason it depends natively on your locally installed
-chrome.
-
-If you get errors about puppeteer or chrome not being available, the easiest way to resolve it is 
-with the `unlighthouse-puppeteer` binary.
-
-```bash
-unlighthouse-puppeteer --site example.com
-```
-
-You will need to use `unlighthouse-puppeteer` anywhere it says `unlighthouse`.
-
 ## Usage
 
 Once installed globally you'll have access to Unlighthouse through the `unlighthouse` binary.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     }
   },
   "dependencies": {
+    "@puppeteer/browsers": "^1.2.0",
     "@types/wrap-ansi": "^8.0.1",
     "@unlighthouse/client": "workspace:../client",
     "@unrouted/core": "0.5.0",

--- a/packages/core/src/resolveConfig.ts
+++ b/packages/core/src/resolveConfig.ts
@@ -1,14 +1,19 @@
-import { join } from 'path'
+import { join } from 'node:path'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { createDefu, defu } from 'defu'
 import { pick } from 'lodash-es'
 import { pathExists } from 'fs-extra'
+import { computeExecutablePath, install } from '@puppeteer/browsers'
+import type { InstallOptions } from '@puppeteer/browsers'
 import { Launcher } from 'chrome-launcher'
-import puppeteer from 'puppeteer-core'
-import { resolve } from 'mlly'
 import type { ResolvedUserConfig, UnlighthouseTabs, UserConfig } from './types'
 import { defaultConfig } from './constants'
 import { normaliseHost, withSlashes } from './util'
 import { useLogger } from './logger'
+import puppeteer from 'puppeteer-core'
+import { resolve } from 'mlly'
+
 
 /**
  * A provided configuration from the user may require runtime transformations to avoid breaking app functionality.
@@ -59,6 +64,13 @@ export const resolveUserConfig: (userConfig: UserConfig) => Promise<ResolvedUser
     }
   }
 
+  config.chrome = defu(config.chrome || {}, {
+    useSystem: true,
+    useDownloadFallback: true,
+    downloadFallbackVersion: 1095492,
+    downloadFallbackCacheDir: join(homedir(), '.unlighthouse'),
+  })
+
   if (config.auth) {
     config.lighthouseOptions.extraHeaders = config.lighthouseOptions.extraHeaders || {}
     if (!config.lighthouseOptions.extraHeaders.Authorization) {
@@ -107,6 +119,7 @@ export const resolveUserConfig: (userConfig: UserConfig) => Promise<ResolvedUser
     config.routerPrefix = withSlashes(config.routerPrefix)
 
   config.puppeteerOptions = config.puppeteerOptions || {}
+  config.puppeteerClusterOptions = config.puppeteerClusterOptions || {}
   // @ts-expect-error untyped
   config.puppeteerOptions = defu({
     // set viewport
@@ -118,30 +131,58 @@ export const resolveUserConfig: (userConfig: UserConfig) => Promise<ResolvedUser
     ignoreHTTPSErrors: true,
   }, config.puppeteerOptions)
 
+  let foundChrome = !!config.puppeteerOptions?.executablePath
   // if user is using the default chrome binary options
-  if (!config.puppeteerOptions?.executablePath && !config.puppeteerClusterOptions?.puppeteer) {
+  if (config.chrome.useSystem && !foundChrome) {
     // we'll try and resolve their local chrome
     const chromePath = Launcher.getFirstInstallation()
     if (chromePath) {
-      logger.debug(`Found chrome at \`${chromePath}\`.`)
+      logger.info(`Using system chrome located at: \`${chromePath}\`.`)
       // set default to puppeteer core
-      config.puppeteerClusterOptions = defu({ puppeteer }, config.puppeteerClusterOptions || {})
+      config.puppeteerClusterOptions.puppeteer = puppeteer
       // point to our pre-installed chrome version
-      config.puppeteerOptions!.executablePath = Launcher.getFirstInstallation()
-    }
-    else {
-      // if we can't find their local chrome, we just need to make sure they have puppeteer, this is a similar check
-      // puppeteer-cluster will do, but we can provide a nicer error
-      try {
-        await resolve('puppeteer')
-      }
-      catch (e) {
-        logger.fatal('Failed to find a chrome / chromium binary to run. Add the puppeteer dependency to your project to resolve.', e)
-        logger.info('Run the following: \`npm install -g puppeteer\`')
-        process.exit(0)
-      }
+      config.puppeteerOptions!.executablePath = chromePath
+      foundChrome = true
     }
   }
-
+  if (!foundChrome) {
+    // if we can't find their local chrome, we just need to make sure they have puppeteer, this is a similar check
+    // puppeteer-cluster will do, but we can provide a nicer error
+    try {
+      await resolve('puppeteer')
+      foundChrome = true
+      logger.info('Using puppeteer dependency for chrome.')
+    }
+    catch (e) {
+      logger.debug('Puppeteer does not exist as a dependency.', e)
+    }
+  }
+  if (config.chrome.useDownloadFallback && !foundChrome) {
+    const browserOptions = {
+      cacheDir: join(homedir(), '.unlighthouse'),
+      buildId: '1095492',
+      browser: 'chromium',
+    } as InstallOptions
+    const chromePath = computeExecutablePath(browserOptions)
+    if (!existsSync(chromePath)) {
+      logger.warn('Failed to find chromium, attempting to download it instead.')
+      let lastPercent = 0
+      await install({
+        ...browserOptions,
+        downloadProgressCallback: (downloadedBytes, toDownloadBytes) => {
+          const percent = Math.round(downloadedBytes / toDownloadBytes * 100)
+          if (percent % 5 === 0 && lastPercent !== percent) {
+            logger.info(`Downloading chromium: ${percent}%`)
+            lastPercent = percent
+          }
+        },
+      })
+    }
+    logger.info(`Using temporary downloaded chromium v1095492 located at: ${chromePath}`)
+    config.puppeteerOptions!.executablePath = chromePath
+    foundChrome = true
+  }
+  if (!foundChrome)
+    throw new Error('Failed to find chrome. Please ensure you have a valid chrome installed.')
   return config as ResolvedUserConfig
 }

--- a/packages/core/src/resolveConfig.ts
+++ b/packages/core/src/resolveConfig.ts
@@ -8,13 +8,12 @@ import { pathExists } from 'fs-extra'
 import { computeExecutablePath, install } from '@puppeteer/browsers'
 import type { InstallOptions } from '@puppeteer/browsers'
 import { Launcher } from 'chrome-launcher'
+import puppeteer from 'puppeteer-core'
+import { resolve } from 'mlly'
 import type { ResolvedUserConfig, UnlighthouseTabs, UserConfig } from './types'
 import { defaultConfig } from './constants'
 import { normaliseHost, withSlashes } from './util'
 import { useLogger } from './logger'
-import puppeteer from 'puppeteer-core'
-import { resolve } from 'mlly'
-
 
 /**
  * A provided configuration from the user may require runtime transformations to avoid breaking app functionality.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
-import type http from 'http'
-import type https from 'https'
+import type http from 'node:http'
+import type https from 'node:https'
 import type { $URL } from 'ufo'
 import type { LH } from 'lighthouse'
 import type { LaunchOptions, Page } from 'puppeteer-core'
@@ -451,6 +451,33 @@ export interface ResolvedUserConfig {
     sameDomainDelay: number
     puppeteer: any
   }>
+
+  chrome: {
+    /**
+     * Should chrome be attempted to be used from the system.
+     *
+     * @default true
+     */
+    useSystem: boolean
+    /**
+     * If no chrome can be found in the system, should a download fallback be attempted.
+     *
+     * @default true
+     */
+    useDownloadFallback: boolean
+    /**
+     * When downloading the fallback which version of chrome should be used.
+     *
+     * @default 1095492
+     */
+    downloadFallbackVersion: string | number
+    /**
+     * The directory to install the downloaded fallback browser.
+     *
+     * @default $home/.unlighthouse
+     */
+    downloadFallbackCacheDir: string
+  }
 }
 
 export type DeepPartial<T> = T extends Function ? T : (T extends object ? { [P in keyof T]?: DeepPartial<T[P]>; } : T)

--- a/packages/unlighthouse-puppeteer/README.md
+++ b/packages/unlighthouse-puppeteer/README.md
@@ -1,5 +1,7 @@
 # unlighthouse-puppeteer
 
+Note: This package is now deprecated. The Unlighthouse CLI will install any browser dependencies needed.
+
 Alias package for [Unlighthouse](https://github.com/harlan-zw/unlighthouse) with puppeteer as a dependency.
 
 ## License

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@puppeteer/browsers':
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@5.0.4)
       '@types/wrap-ansi':
         specifier: ^8.0.1
         version: 8.0.1
@@ -1667,7 +1670,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
       '@types/responselike': 1.0.0
     dev: false
 
@@ -1763,7 +1766,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
     dev: false
 
   /@types/lodash-es@4.17.7:
@@ -1799,7 +1802,6 @@ packages:
 
   /@types/node@20.1.3:
     resolution: {integrity: sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==}
-    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1823,7 +1825,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
     dev: false
 
   /@types/semver@7.5.0:
@@ -1876,7 +1878,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
     dev: false
     optional: true
 
@@ -3827,7 +3829,7 @@ packages:
     resolution: {integrity: sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       tapable: 2.2.1
     dev: true
 
@@ -5924,7 +5926,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /keyv@4.4.1:
     resolution: {integrity: sha512-PzByhNxfBLnSBW2MZi1DF+W5+qB/7BMpOokewqIvqS8GFtP7xHm2oeGU72Y1fhtfOv/FiEnI4+nyViYDmUChnw==}
@@ -9377,7 +9379,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /wcwidth@1.0.1:


### PR DESCRIPTION

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds a fallback strategy to download a chromium binary when a chromium instance can't be found.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes #16, #71, #87

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
