### PR TITLE
fix(ci): expandedJson summary should only have avg

### DIFF
--- a/packages/cli/src/reporters/jsonExpanded.ts
+++ b/packages/cli/src/reporters/jsonExpanded.ts
@@ -37,7 +37,7 @@ export function reportJsonExpanded(unlighthouseRouteReports): ReportJsonExpanded
             displayValue: metric.displayValue,
           },
         }), {})
-      return <ExpandedRouteReport> {
+      return <ExpandedRouteReport>{
         path: report.route.path,
         score: report.report?.score,
         categories,
@@ -69,10 +69,11 @@ function extractCategoriesFromRoutes(routes: ExpandedRouteReport[]) {
   const categoriesWithAllScores = routes.reduce((prev, curr) => {
     return Object.keys(curr.categories).reduce((target, categoryKey) => {
       const scores = target[categoryKey] ? target[categoryKey].scores : []
+      const { score, ...strippedCategory } = curr.categories[categoryKey]
       return {
         ...target,
         [categoryKey]: {
-          ...curr.categories[categoryKey],
+          ...strippedCategory,
           scores: [...scores, curr.categories[categoryKey].score],
         },
       }
@@ -95,8 +96,7 @@ function extractCategoriesFromRoutes(routes: ExpandedRouteReport[]) {
           ) / categoriesWithAllScores[key].scores.length
         ).toFixed(2),
       )
-      const { ...strippedCategory }
-        = categoriesWithAllScores[key]
+      const { scores, ...strippedCategory } = categoriesWithAllScores[key]
       return { ...prev, [key]: { ...strippedCategory, averageScore } }
     },
     {} as {
@@ -111,15 +111,16 @@ function extractMetricsFromRoutes(routes: ExpandedRouteReport[]) {
       const numericValues = target[metricKey]
         ? target[metricKey].numericValues
         : []
+      const { numericValue, displayValue, ...strippedMetric } = curr.metrics[metricKey]
       return {
         ...target,
         [metricKey]: {
-          ...curr.metrics[metricKey],
+          ...strippedMetric,
           numericValues: [...numericValues, curr.metrics[metricKey].numericValue],
         },
       }
     }, prev)
-  }, {} as { [key: string]: Omit<MetricScore, 'numericValue'> & { numericValues: number[] } })
+  }, {} as { [key: string]: Omit<MetricScore, 'numericValue' | 'displayValue'> & { numericValues: number[] } })
 
   // average metrics
   return Object.keys(metricsWithAllNumericValues).reduce(
@@ -132,7 +133,7 @@ function extractMetricsFromRoutes(routes: ExpandedRouteReport[]) {
           ) / metricsWithAllNumericValues[key].numericValues.length
         ).toFixed(2),
       )
-      const { ...strippedMetric }
+      const { numericValues, ...strippedMetric }
         = metricsWithAllNumericValues[key]
       return { ...prev, [key]: { ...strippedMetric, averageNumericValue } }
     },

--- a/packages/cli/src/reporters/types.ts
+++ b/packages/cli/src/reporters/types.ts
@@ -41,7 +41,6 @@ export interface MetricAverageScore {
   description: string
   averageNumericValue: number
   numericUnit: string
-  displayValue: string
 }
 
 export interface ReportJsonExpanded {


### PR DESCRIPTION
I tried out the new feature I helped with, and I think a merge went wrong somewhere. The summary contained more data than it should.

This PR will fix https://github.com/harlan-zw/unlighthouse/issues/113 and only show the average values for metrics and categories under summary.