### PR TITLE
fix(ci): decrease verbosity of `expandedJson` with new metadata

### DIFF
--- a/packages/cli/src/reporters/types.ts
+++ b/packages/cli/src/reporters/types.ts
@@ -6,11 +6,7 @@ export interface CategoryScore {
 }
 
 export interface MetricScore {
-  id: string
-  title: string
-  description: string
   numericValue: number
-  numericUnit: string
   displayValue: string
 }
 
@@ -29,18 +25,23 @@ export interface ExpandedRouteReport extends SimpleRouteReport {
 }
 
 export interface CategoryAverageScore {
-  key: string
-  id: string
-  title: string
   averageScore: number
 }
 
 export interface MetricAverageScore {
+  averageNumericValue: number
+}
+
+export interface MetricMetadata {
   id: string
   title: string
   description: string
-  averageNumericValue: number
   numericUnit: string
+}
+
+export interface CategoryMetadata {
+  id: string
+  title: string
 }
 
 export interface ReportJsonExpanded {
@@ -54,6 +55,14 @@ export interface ReportJsonExpanded {
     }
   }
   routes: ExpandedRouteReport[]
+  metadata: {
+    metrics: {
+      [key: string]: MetricMetadata
+    }
+    categories: {
+      [key: string]: CategoryMetadata
+    }
+  }
 }
 
 export type ReportJsonSimple = SimpleRouteReport[]

--- a/packages/cli/test/json-reports.test.ts
+++ b/packages/cli/test/json-reports.test.ts
@@ -20,6 +20,24 @@ describe('reporter', () => {
     expect(actual.routes[0].score).toBeDefined()
   })
 
+  it('has metadata information generated as part of the report', () => {
+    const actual = generateReportPayload('jsonExpanded', lighthouseReport)
+    expect(actual.metadata).toBeDefined()
+    expect(actual.metadata.metrics).toBeDefined()
+    expect(actual.metadata.metrics['largest-contentful-paint']).toBeDefined()
+    expect(actual.metadata.metrics['cumulative-layout-shift']).toBeDefined()
+    expect(actual.metadata.metrics['first-contentful-paint']).toBeDefined()
+    expect(actual.metadata.metrics['total-blocking-time']).toBeDefined()
+    expect(actual.metadata.metrics['max-potential-fid']).toBeDefined()
+    expect(actual.metadata.metrics.interactive).toBeDefined()
+
+    expect(actual.metadata.categories).toBeDefined()
+    expect(actual.metadata.categories.performance).toBeDefined()
+    expect(actual.metadata.categories.accessibility).toBeDefined()
+    expect(actual.metadata.categories.seo).toBeDefined()
+    expect(actual.metadata.categories['best-practices']).toBeDefined()
+  })
+
   it('has category information for json expanded report', () => {
     const actual = generateReportPayload('jsonExpanded', lighthouseReport)
 

--- a/test/ci.test.ts
+++ b/test/ci.test.ts
@@ -27,6 +27,7 @@ describe('ci', () => {
 
     expect(output.summary).toBeDefined()
     expect(output.summary.score).toBeDefined()
+    expect(output.metadata).toBeDefined()
     expect(output.routes[0].path).toBeDefined()
     expect(output.routes[0].score).toBeDefined()
     expect(output.routes[0].categories).toBeDefined()


### PR DESCRIPTION
The payload for the ci report had repeated information that could be considered metadata. Extracting the metadata to its own property will drastically reduce the payload size.

Fixes: https://github.com/harlan-zw/unlighthouse/issues/115