### PR TITLE
doc: fix a typo in the Integrations/CI documentation

### DIFF
--- a/docs/content/2.integrations/1.ci.md
+++ b/docs/content/2.integrations/1.ci.md
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Dependencies
-        run: npm add @unlighthouse/cli puppeteer
+        run: npm install @unlighthouse/cli puppeteer
 
       - name: Unlighthouse assertions and client
         run: unlighthouse-ci --site <your-site> --budget 75 --build-static


### PR DESCRIPTION
### Description

This PR solves a typo in the Integrations/CI documentation. 

Correction: `npm add -g @unlighthouse/cli puppeteer` -> `npm install -g @unlighthouse/cli puppeteer`

Pipeline that fails to use Unlighthouse with `npm add -g @unlighthouse/cli puppeteer`
- https://github.com/NielsPilgaard/Jordnaer/actions/runs/5098092340/jobs/9165031035

Pipeline that successfully uses Unlighthouse with `npm install -g @unlighthouse/cli puppeteer`
- https://github.com/NielsPilgaard/Jordnaer/actions/runs/5098112456/jobs/9165064644

The failure in the last link is not caused by Unlighthouse

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
