### PR TITLE
fix(core): delete artifacts recursively, allowing route requeuing

### DIFF
--- a/packages/core/src/puppeteer/worker.ts
+++ b/packages/core/src/puppeteer/worker.ts
@@ -190,7 +190,7 @@ export async function createUnlighthouseWorker(tasks: Record<UnlighthouseTask, T
     logger.info(`Submitting \`${report.route.path}\` for a re-queue.`)
     // clean up artifacts
     Object.values(ReportArtifacts).forEach((artifact) => {
-      fs.rmSync(join(report.artifactPath, artifact), { force: true })
+      fs.rmSync(join(report.artifactPath, artifact), { force: true, recursive: true })
     })
     routeReports.delete(report.reportId)
     // arbitrary wait for HMR, lil dodgy


### PR DESCRIPTION
### Description

Deleting existing artifacts failed when requeueing a route via UI. This was caused by   the missing `recursive`-flag... 

### Linked Issues
#126

