### PR TITLE
doc: grammar mistake in getting started

### DIFF
--- a/docs/content/1.guide/1.getting-started/0.index.md
+++ b/docs/content/1.guide/1.getting-started/0.index.md
@@ -14,7 +14,7 @@ npx unlighthouse --site <your-site>
 ```
 
 By default Unlighthouse will attempt to use your system Chrome / Chromium install.
-If you these are missing, a Chromium binary will be installed on your system.
+If these are missing, a Chromium binary will be installed on your system.
 
 To learn more about the CLI and the arguments, head over to [CLI Integration](/integrations/cli).
 


### PR DESCRIPTION
### Description

This fixes a small typo/grammar mistake in the guide.
