### PR TITLE
fix(ci): exit code 1 when budget assertions fail

### DIFF
--- a/packages/cli/src/ci.ts
+++ b/packages/cli/src/ci.ts
@@ -116,7 +116,7 @@ async function run() {
         logger.info('For deployment demos, see https://unlighthouse.com/docs/deployment')
       }
     }
-    process.exit(0)
+    process.exit(hadError ? 1 : 0)
   })
 }
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR allows the `unlighthouse-ci` to exit with code 1 when budget assertions fail, this could be helpful in scripts/ci settings.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
