### PR TITLE
Fix MetricGuage styling bug

### DIFF
--- a/packages/client/components/MetricGuage.vue
+++ b/packages/client/components/MetricGuage.vue
@@ -24,18 +24,17 @@ const guageModifiers = computed(() => {
 const guageArcStyle = computed(() => {
   // r = 56
   const r = 56
-  // stroke-width = 8
   const n = 2 * Math.PI * r
   const rotationOffset = 0.25 * 8 / n
 
-  let o = score.value * n - r / 2
+  let o = score.value * n
   if (score.value === 1)
     o = n
 
   return {
     opacity: score.value === 0 ? '0' : 1,
-    transform: `rotate(${360 * rotationOffset - 90}deg)`,
-    strokeDasharray: `${Math.max(o, 0)}, ${n}`,
+    transform: 'rotate(-90deg)',
+    strokeDasharray: `${o}, ${n}`,
   }
 })
 </script>
@@ -62,7 +61,7 @@ const guageArcStyle = computed(() => {
           ref="arc"
           class="guage-arc"
           r="56"
-          cx="60"
+          cx="20"
           cy="60"
           stroke-width="8"
           :style="guageArcStyle"


### PR DESCRIPTION
### Description

The circle arc wasn't completely aligned to the center, it was a bit on top of the Y axis, so I fixed it.
Additionally, there was a problem with the calculation (for example, 100% wasn't a perfect circle), so I fixed its function as well.
Looks like everything is working as expected now.

<img width="606" alt="image" src="https://github.com/harlan-zw/unlighthouse/assets/54068415/01df8483-ab97-4c4c-856c-2b87bbf57004">

### Linked Issues
- [#173](https://github.com/harlan-zw/unlighthouse/issues/173)
Couldn't find a related issue so I just created a [new one](https://github.com/harlan-zw/unlighthouse/issues/173) (173), If there's already related issue, please approve the commit and delete both the old one, and the new one I've created.

