### PR TITLE
fix: display of network request time

### DIFF
--- a/packages/client/components/Cell/CellNetworkRequests.vue
+++ b/packages/client/components/Cell/CellNetworkRequests.vue
@@ -48,7 +48,7 @@ const requestsMapped = computed(() => {
             <div v-for="(item, key) in group.items" :key="key" class="mb-1 flex text-xs ">
               <span class="break-all opacity-90 flex-grow"><a :href="item.url" class="hover:no-underline underline">{{ item.url.replace(website, '') }}</a></span>
               <span class="opacity-70 whitespace-nowrap ml-1 flex-shrink break-none">{{ formatBytes(item.transferSize) }}</span>
-              <span class="opacity-70 whitespace-nowrap ml-1 flex-shrink">{{ Math.round(item.endTime - item.startTime) }}ms</span>
+              <span class="opacity-70 whitespace-nowrap ml-1 flex-shrink">{{ Math.round(item.networkEndTime - item.networkRequestTime) }}ms</span>
             </div>
           </template>
         </tooltip>


### PR DESCRIPTION


### Description

Network timing always displays `NaN ms` 

<img width="423" alt="image" src="https://github.com/harlan-zw/unlighthouse/assets/22201189/0a123172-3063-40ab-8d76-469ff2a6ab29">
