### PR TITLE
docs: update ci options list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unlighthouse scans your entire site using Google Lighthouse,<br> with a modern U
 <tbody>
 <td align="center">
 <img width="2000" height="0" /><br>
-Status: <b><a href="https://github.com/harlan-zw/unlighthouse/releases/tag/v0.11.0">v0.11 Released 🎉</a></b><br>
+Status: <b><a href="https://github.com/harlan-zw/unlighthouse/releases/tag/v0.12.2">v0.12.2 Released 🎉</a></b><br>
 <sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
 <img width="2000" height="0" />
 </td>
@@ -61,7 +61,7 @@ If you run into any issues with Unlighthouse, the first step should be to re-run
 # NPM
 npx unlighthouse --site unlighthouse.dev --debug
 # or PNPM
-pnpm dlx unlighthouse --site unlighthouse.dev  --debug
+pnpm dlx unlighthouse --site unlighthouse.dev --debug
 ```
 
 ## Docs

--- a/docs/content/2.integrations/1.ci.md
+++ b/docs/content/2.integrations/1.ci.md
@@ -111,6 +111,7 @@ Configuring the CLI can be done either through the CI arguments or through a con
 | `--reporter <reporter>` | Which reporter to use. Options are csv, json, csvExpanded, jsonExpanded, lighthouseServer.      |
 | `--lhci-host <lhci host>`    | URL of your LHCI server. Needed in combination with the lighthouseServer reporter.|
 | `--lhci-build-token <lhci buildToken>`    | LHCI build token, used to add data. Needed in combination with the lighthouseServer reporter.|
+| `--lhci-auth <username>:<password>`    | Basic auth for your LHCI server.                               |
 | `--build-static`        | Build a static website for the reports which can be uploaded.                 |
 | `--cache`               | Enable the caching.                                                           |
 | `--no-cache`            | Disable the caching.                                                          |
@@ -122,7 +123,7 @@ Configuring the CLI can be done either through the CI arguments or through a con
 | `--disable-javascript`  | When inspecting the HTML, don't wait for the javascript to execute.           |
 | `--enable-i18n-pages`   | Enable scanning pages which use x-default.                                    |
 | `--disable-i18n-pages`  | Disable scanning pages which use x-default.                                   |
-| `--disable-dynamic-sampling` | Disable dynamic sampling.                                                 |
+| `--disable-dynamic-sampling` | Disable dynamic sampling.                                                |
 | `-d, --debug`           | Debug. Enable debugging in the logger.                                        |
 | `-h, --help`            | Display available CLI options                                                 |
 


### PR DESCRIPTION
### Description

This updates the CI Options list with the new `--lhci-auth` option under the Integrations guide doc.

### Linked Issues

https://github.com/harlan-zw/unlighthouse/issues/214

### Additional context

Missing mention of the `lhci-auth` option in the Integrations guide after the 0.12.2 release.
