### PR TITLE
fix: show lighthouse runtime error when re-queuing failed routes

### DIFF
--- a/packages/core/src/puppeteer/tasks/lighthouse.ts
+++ b/packages/core/src/puppeteer/tasks/lighthouse.ts
@@ -154,7 +154,7 @@ export const runLighthouseTask: PuppeteerTask = async (props) => {
   }
 
   if (report.categories.performance && !report.categories.performance.score) {
-    logger.warn(`Lighthouse failed to run performance audits for "${routeReport.route.path}", adding back to queue.`)
+    logger.warn(`Lighthouse failed to run performance audits for "${routeReport.route.path}", adding back to queue${report.runtimeError ? `: ${report.runtimeError.message}` : '.'}`)
     routeReport.tasks.runLighthouseTask = 'failed-retry'
     return routeReport
   }


### PR DESCRIPTION
For me, an absent NODE_EXTRA_CA_CERTS environment variable caused the lighthouse tasks to fail due to invalid TLS certificates after an upgrade in a containerized environment. In that case, the existing error message wasn't helpful, because the same URL worked fine on the host where the certificate was correctly installed and picked up.
