### PR TITLE
feat: simpler configs with `defineUnlighthouseConfig()`

### DIFF
--- a/docs/content/1.guide/guides/0.config.md
+++ b/docs/content/1.guide/guides/0.config.md
@@ -11,16 +11,9 @@ however, you may want to create a separate configuration file when dealing with 
 By default, a `unlighthouse.config.ts` file within the `root` (or `cwd`) directory will be read.
 You can change the name of the configuration file with the `configFile` option, or `--config-file` flag for the CLI.
 
-### Local dependency - with Typescript
-
-When you load Unlighthouse into your project as a dev dependency and you're using Typescript, you can make use of proper
-configuration types.
-
 ```ts unlighthouse.config.ts
 /// <reference types="unlighthouse" />
-import { defineConfig } from 'unlighthouse'
-
-export default defineConfig({
+export default defineUnlighthouseConfig({
   // examplebtn-basic
   site: 'unlighthouse.dev',
   scanner: {
@@ -30,28 +23,12 @@ export default defineConfig({
 })
 ```
 
-### Global dependency
-
-You can still provide a configuration file when using Unlighthouse globally, however, you won't be able to make use of
-the types or `defineConfig` function, instead you'll need to export a plain object.
-
-```ts unlighthouse.config.ts
-export default {
-  // example
-  site: 'unlighthouse.dev',
-  scanner: {
-    exclude: ['/private-zone/*']
-  },
-  debug: true,
-}
-```
-
 See the list of config options in the [Config Reference](/api/config).
 
 ## Example
 
 ```ts unlighthouse.config.ts
-export default {
+export default defineUnlighthouseConfig({
   site: 'harlanzw.com',
   scanner: {
     // exclude specific routes
@@ -68,5 +45,5 @@ export default {
     throttle: true,
   },
   debug: true,
-}
+})
 ```

--- a/docs/content/2.integrations/4.vite.md
+++ b/docs/content/2.integrations/4.vite.md
@@ -48,7 +48,7 @@ When you run your Vite app, it will give you the URL of client, only once you vi
 ```ts vite.config.ts
 import Unlighthouse from '@unlighthouse/vite'
 
-export default defineConfig({
+export default defineUnlighthouseConfig({
   plugins: [
     Unlighthouse({
       // config
@@ -66,7 +66,7 @@ You will need to hook into the plugin using the following code.
 ```ts vite.config.ts
 import { useUnlighthouse } from 'unlighthouse'
 
-export default defineConfig({
+export default defineUnlighthouseConfig({
   plugins: [
     Pages({
       // ...
@@ -89,7 +89,7 @@ in the root directory.
 ### Example
 
 ```js vite.config.ts
-export default defineConfig({
+export default defineUnlighthouseConfig({
   plugins: [
     Unlighthouse({
       scanner: {

--- a/docs/content/3.api/index.md
+++ b/docs/content/3.api/index.md
@@ -30,18 +30,19 @@ Functions exposed from the `@unlighthouse/core` package.
   )
   ```
 
-### defineConfig
+### defineUnlighthouseConfig
 
 - **Type:** `(userConfig: UserConfig) => Promise<UnlighthouseContext>`
 
   A simple define wrapper to provide typings to config definitions. This is primarily used when creating a
   config file `unlighthouse.config.ts`
+  
+  Powered by [c12](https://github.com/unjs/c12).
 
   ```ts
-  /// <reference types="unlighthouse" />
-  import { defineConfig } from 'unlighthouse'
+  import { defineUnlighthouseConfig } from 'unlighthouse/config'
 
-  export default defineConfig({
+  export default defineUnlighthouseConfig({
     site: 'harlanzw.com'
   })
   ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "@unrouted/preset-api": "^0.6.0",
     "@unrouted/preset-node": "^0.6.0",
     "axios": "^1.8.1",
+    "c12": "^3.0.2",
     "cheerio": "1.0.0",
     "chrome-launcher": "^1.1.2",
     "consola": "^3.4.0",

--- a/packages/unlighthouse/bin/unlighthouse-ci.cjs
+++ b/packages/unlighthouse/bin/unlighthouse-ci.cjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import('@unlighthouse/cli/ci')

--- a/packages/unlighthouse/bin/unlighthouse-ci.mjs
+++ b/packages/unlighthouse/bin/unlighthouse-ci.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '@unlighthouse/cli/ci'

--- a/packages/unlighthouse/bin/unlighthouse.cjs
+++ b/packages/unlighthouse/bin/unlighthouse.cjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import('@unlighthouse/cli')

--- a/packages/unlighthouse/bin/unlighthouse.mjs
+++ b/packages/unlighthouse/bin/unlighthouse.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '@unlighthouse/cli'

--- a/packages/unlighthouse/config.cjs
+++ b/packages/unlighthouse/config.cjs
@@ -1,0 +1,7 @@
+function defineUnlighthouseConfig (config) {
+  return config
+}
+
+module.exports = {
+  defineUnlighthouseConfig,
+}

--- a/packages/unlighthouse/config.d.ts
+++ b/packages/unlighthouse/config.d.ts
@@ -1,0 +1,7 @@
+import type { UserConfig } from '@unlighthouse/core'
+import type { ConfigLayerMeta, DefineConfig } from 'c12'
+
+export { UserConfig } from 'nuxt/schema'
+
+export interface DefineUnlighthouseConfig extends DefineConfig<UserConfig, ConfigLayerMeta> {}
+export declare const defineUnlighthouseConfig: DefineUnlighthouseConfig

--- a/packages/unlighthouse/config.js
+++ b/packages/unlighthouse/config.js
@@ -1,0 +1,5 @@
+function defineUnlighthouseConfig (config) {
+  return config
+}
+
+export { defineUnlighthouseConfig }

--- a/packages/unlighthouse/index.d.ts
+++ b/packages/unlighthouse/index.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/index'
-export { default } from './dist/index'

--- a/packages/unlighthouse/package.json
+++ b/packages/unlighthouse/package.json
@@ -22,20 +22,26 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    }
+      "types": "./types.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./config": {
+      "types": "./config.d.ts",
+      "import": "./config.js",
+      "require": "./config.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
-  "types": "index.d.ts",
+  "types": "./types.d.ts",
   "bin": {
-    "unlighthouse": "bin/unlighthouse.cjs",
-    "unlighthouse-ci": "bin/unlighthouse-ci.cjs"
+    "unlighthouse": "bin/unlighthouse.mjs",
+    "unlighthouse-ci": "bin/unlighthouse-ci.mjs"
   },
   "files": [
-    "*.d.ts",
+    "types.d.ts",
+    "types.d.mts",
     "dist"
   ],
   "engines": {

--- a/packages/unlighthouse/types.d.mts
+++ b/packages/unlighthouse/types.d.mts
@@ -1,0 +1,7 @@
+export * from './dist/index.js'
+
+declare global {
+  import type { UserConfig } from '@unlighthouse/core'
+
+  const defineUnlighthouseConfig: UserConfig | (() => UserConfig) | (() => Promise<UserConfig>)
+}

--- a/packages/unlighthouse/types.d.ts
+++ b/packages/unlighthouse/types.d.ts
@@ -1,0 +1,7 @@
+import type { DefineUnlighthouseConfig } from 'unlighthouse/config'
+
+export * from './dist/index'
+
+declare global {
+  const defineUnlighthouseConfig: DefineUnlighthouseConfig
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       axios:
         specifier: ^1.8.1
         version: 1.8.1
+      c12:
+        specifier: ^3.0.2
+        version: 3.0.2(magicast@0.3.5)
       cheerio:
         specifier: 1.0.0
         version: 1.0.0
@@ -1872,6 +1875,14 @@ packages:
       magicast:
         optional: true
 
+  c12@3.0.2:
+    resolution: {integrity: sha512-6Tzk1/TNeI3WBPpK0j/Ss4+gPj3PUJYbWl/MWDJBThFvwNGNkXtd7Cz8BJtD4aRwoGHtzQD0SnxamgUiBH0/Nw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -2966,6 +2977,10 @@ packages:
     resolution: {integrity: sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==}
     hasBin: true
 
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3909,6 +3924,11 @@ packages:
 
   nypm@0.5.4:
     resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  nypm@0.6.0:
+    resolution: {integrity: sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
@@ -7054,6 +7074,23 @@ snapshots:
     optionalDependencies:
       magicast: 0.3.5
 
+  c12@3.0.2(magicast@0.3.5):
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.1.8
+      defu: 6.1.4
+      dotenv: 16.4.7
+      exsolve: 1.0.1
+      giget: 2.0.0
+      jiti: 2.4.2
+      ohash: 2.0.10
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.1.0
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
+
   cac@6.7.14: {}
 
   cacheable-lookup@5.0.4: {}
@@ -8282,6 +8319,15 @@ snapshots:
       pathe: 2.0.3
       tar: 6.2.1
 
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.0
+      defu: 6.1.4
+      node-fetch-native: 1.6.6
+      nypm: 0.6.0
+      pathe: 2.0.3
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -9487,6 +9533,14 @@ snapshots:
       pkg-types: 1.3.1
       tinyexec: 0.3.2
       ufo: 1.5.4
+
+  nypm@0.6.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.0
+      pathe: 2.0.3
+      pkg-types: 2.1.0
+      tinyexec: 0.3.2
 
   object-assign@4.1.1: {}
 

--- a/test/ci.test.ts
+++ b/test/ci.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { execa } from 'execa'
 
 export const cacheDir = resolve(__dirname, '.cache')
-export const ci = resolve(__dirname, '../packages/unlighthouse/bin/unlighthouse-ci.cjs')
+export const ci = resolve(__dirname, '../packages/unlighthouse/bin/unlighthouse-ci.mjs')
 
 beforeAll(async () => {
   await fs.remove(cacheDir)


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Configuring Unlighthouse is done through an `unlighthouse.config.ts` which is simple enough, however the types for it are quite annoying.

To try and simplify this migrate to [c12](https://github.com/unjs/c12) with added support for not having to import the new config util `defineUnlighthouseConfig()`.

The below should now work with types if Unlighthouse is added globally :crossed_fingers: 

```ts
export default defineUnlighthouseConfig({
  site: 'harlanzw.com'
})
```

We still support `defineConfig` from `unlighthouse` but it's now deprecated in favour of this way.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/harlan-zw/unlighthouse/issues/262

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
