### PR TITLE
fix: align the box which is unaligned from the sailboat emoji

### DIFF
--- a/packages/core/src/unlighthouse.ts
+++ b/packages/core/src/unlighthouse.ts
@@ -330,9 +330,7 @@ export async function createUnlighthouse(userConfig: UserConfig, provider?: Prov
       }
       catch {}
 
-      const title = [
-        `⛵  ${colorize('bold', colorize('blueBright', AppName))} ${colorize('dim', `${provider?.name} @ v${version}`)}`,
-      ]
+      const title = [`⛵\u200D ${colorize('bold', colorize('blueBright', AppName))} ${colorize('dim', `${provider?.name} @ v${version}`)}`]
       if (Number(latestTag.replace('v', '').replace('.', '')) > Number(version.replace('.', ''))) {
         title.push(...[
           '',

--- a/packages/core/src/unlighthouse.ts
+++ b/packages/core/src/unlighthouse.ts
@@ -330,7 +330,9 @@ export async function createUnlighthouse(userConfig: UserConfig, provider?: Prov
       }
       catch {}
 
-      const title = [`⛵\u200D ${colorize('bold', colorize('blueBright', AppName))} ${colorize('dim', `${provider?.name} @ v${version}`)}`]
+      const title = [
+        `⛵\u200D  ${colorize('bold', colorize('blueBright', AppName))} ${colorize('dim', `${provider?.name} @ v${version}`)}`,
+      ]
       if (Number(latestTag.replace('v', '').replace('.', '')) > Number(version.replace('.', ''))) {
         title.push(...[
           '',


### PR DESCRIPTION
### Description

The sailboat emoji in some fonts can have a length greater than one, causing a misalignment in the box. I added a zero width character so the box wouldn't be misaligned. 

Before:
<img width="1165" alt="Screenshot 2025-03-14 at 22 34 20" src="https://github.com/user-attachments/assets/66acd418-0ed9-49df-bf2a-a114b4d5e3a4" />

<img width="1107" alt="Screenshot 2025-03-14 at 22 35 16" src="https://github.com/user-attachments/assets/4200d437-1378-4ab4-b757-f1362759da6d" />


After:

<img width="1164" alt="Screenshot 2025-03-14 at 22 37 24" src="https://github.com/user-attachments/assets/5194210a-15fc-4c58-b377-a8c74ea5bde1" />

<img width="1202" alt="Screenshot 2025-03-14 at 22 36 11" src="https://github.com/user-attachments/assets/e7b71bd3-4029-40a0-bf5c-022f0451f970" />




