### PR TITLE
fix(client): repair web UI broken by HeadlessUI removal

### DIFF
--- a/packages/client/App.vue
+++ b/packages/client/App.vue
@@ -132,6 +132,27 @@ const getDropdownActions = computed(() => (report) => {
 })
 
 useTitle(`${website.replace(/https?:\/\/(www.)?/, '')} | Unlighthouse`)
+
+const tabListEl = ref<HTMLElement | null>(null)
+function onTabKeydown(e: KeyboardEvent, key: number) {
+  const count = filteredTabs.value.length
+  let next = key
+  if (e.key === 'ArrowDown' || e.key === 'ArrowRight')
+    next = (key + 1) % count
+  else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft')
+    next = (key - 1 + count) % count
+  else if (e.key === 'Home')
+    next = 0
+  else if (e.key === 'End')
+    next = count - 1
+  else
+    return
+  e.preventDefault()
+  changedTab(next)
+  nextTick(() => {
+    tabListEl.value?.querySelectorAll<HTMLButtonElement>('[role="tab"]')[next]?.focus()
+  })
+}
 </script>
 
 <template>
@@ -141,33 +162,31 @@ useTitle(`${website.replace(/https?:\/\/(www.)?/, '')} | Unlighthouse`)
       <main class="xl:flex mt-2 mb-2">
         <div class="flex justify-between max-h-[95%] flex-col xl:ml-3 mx-3 mr-0 w-full xl:mr-5 xl:w-[250px] xl:mb-0">
           <div>
-            <TabGroup vertical @change="changedTab">
-              <TabList class="xl:block xl:space-x-0 flex space-x-2 mb-3">
-                <Tab
-                  v-for="(category, key) in filteredTabs"
-                  :key="key"
-                  v-slot="{ selected }"
-                  as="template"
-                >
-                  <btn-tab
-                    :selected="selected"
-                  >
-                    <span class="inline-flex items-center space-x-1">
-                      <UIcon :name="category.icon" class="inline text-sm opacity-40 h-4 w-4" />
-                      <span>{{ category.label }}</span>
-                      <tooltip v-if="category.label === 'Performance'" class="text-left">
-                        <UIcon name="i-carbon-warning" class="inline text-xs mx-1" />
-                        <template #tooltip>
-                          <div class="mb-2">Lighthouse is running with variability. Performance scores should not be considered accurate.</div>
-                          <div>Unlighthouse is running <span class="underline">with{{ throttle ? '' : 'out' }} throttling</span> which will also effect scores.</div>
-                        </template>
-                      </tooltip>
-                    </span>
-                    <metric-guage v-if="shouldShowCategoryScore(category, key)" :score="categoryScores[key - 1]" :stripped="true" class="dark:font-bold" :class="selected ? ['dark:bg-teal-900 bg-blue-100 rounded px-2'] : []" />
-                  </btn-tab>
-                </Tab>
-              </TabList>
-            </TabGroup>
+            <div ref="tabListEl" role="tablist" aria-orientation="vertical" class="xl:block xl:space-x-0 flex space-x-2 mb-3">
+              <btn-tab
+                v-for="(category, key) in filteredTabs"
+                :key="key"
+                role="tab"
+                :aria-selected="activeTab === key"
+                :tabindex="activeTab === key ? 0 : -1"
+                :selected="activeTab === key"
+                @click="changedTab(key)"
+                @keydown="onTabKeydown($event, key)"
+              >
+                <span class="inline-flex items-center space-x-1">
+                  <UIcon :name="category.icon" class="inline text-sm opacity-40 h-4 w-4" />
+                  <span>{{ category.label }}</span>
+                  <tooltip v-if="category.label === 'Performance'" class="text-left">
+                    <UIcon name="i-carbon-warning" class="inline text-xs mx-1" />
+                    <template #tooltip>
+                      <div class="mb-2">Lighthouse is running with variability. Performance scores should not be considered accurate.</div>
+                      <div>Unlighthouse is running <span class="underline">with{{ throttle ? '' : 'out' }} throttling</span> which will also effect scores.</div>
+                    </template>
+                  </tooltip>
+                </span>
+                <metric-guage v-if="shouldShowCategoryScore(category, key)" :score="categoryScores[key - 1]" :stripped="true" class="dark:font-bold" :class="activeTab === key ? ['dark:bg-teal-900 bg-blue-100 rounded px-2'] : []" />
+              </btn-tab>
+            </div>
             <div v-if="dynamicSampling" class="text-sm opacity-70 mt-3">
               <p>Dynamically sampling is enabled, not all pages are being scanned.</p>
               <p><a href="https://unlighthouse.dev/guide/guides/dynamic-sampling" target="_blank" class="underline">Learn more</a></p>

--- a/packages/client/components/Btn/BtnTab.vue
+++ b/packages/client/components/Btn/BtnTab.vue
@@ -5,16 +5,14 @@ defineProps<{
 </script>
 
 <template>
-  <div class="flex items-center focus:outline-none justify-between">
-    <button
-      class="space-x-2 focus:outline-none focus:ring-1 ring-offset-blue-400 ring-white ring-opacity-60 flex flex-col text-xs lg:px-2 lg:flex-row lg:py-1 lg:text-sm items-center justify-between w-full leading-5 transition font-medium text-blue-700 rounded-lg cursor-pointer"
-      :class="[
-        selected
-          ? 'bg-blue-900 text-white shadow'
-          : 'dark:text-blue-100 dark:hover:bg-white/12 dark:hover:text-white text-blue-900/70 hover:bg-blue-200',
-      ]"
-    >
-      <slot />
-    </button>
-  </div>
+  <button
+    class="space-x-2 focus:outline-none focus:ring-1 ring-offset-blue-400 ring-white ring-opacity-60 flex flex-col text-xs lg:px-2 lg:flex-row lg:py-1 lg:text-sm items-center justify-between w-full leading-5 transition font-medium text-blue-700 rounded-lg cursor-pointer"
+    :class="[
+      selected
+        ? 'bg-blue-900 text-white shadow'
+        : 'dark:text-blue-100 dark:hover:bg-white/12 dark:hover:text-white text-blue-900/70 hover:bg-blue-200',
+    ]"
+  >
+    <slot />
+  </button>
 </template>

--- a/packages/client/components/Tooltip.vue
+++ b/packages/client/components/Tooltip.vue
@@ -4,23 +4,21 @@ const isShowing = ref(false)
 
 <template>
   <div v-if="$slots.tooltip" class="relative" @mouseleave="isShowing = false">
-    <TransitionRoot
+    <Transition
       appear
-      :show="isShowing"
-      as="template"
-      enter="transform transition duration-400"
-      enter-from="opacity-0 scale-50"
-      enter-to="opacity-100 scale-100"
-      leave="transform duration-200 transition ease-in-out"
-      leave-from="opacity-100 scale-100 "
-      leave-to="opacity-0 scale-95 "
+      enter-active-class="transform transition duration-400"
+      enter-from-class="opacity-0 scale-50"
+      enter-to-class="opacity-100 scale-100"
+      leave-active-class="transform duration-200 transition ease-in-out"
+      leave-from-class="opacity-100 scale-100"
+      leave-to-class="opacity-0 scale-95"
     >
-      <div role="tooltip" class="max-w-[500px] z-500 flex -left-[80px] absolute w-auto min-w-[320px] max-h-[500px] overflow-y-auto z-10 top-[99%] inline-block bg-gray-900/99 font-medium shadow-xs text-white py-2 px-3 text-sm rounded-lg">
+      <div v-if="isShowing" role="tooltip" class="max-w-[500px] z-500 flex -left-[80px] absolute w-auto min-w-[320px] max-h-[500px] overflow-y-auto z-10 top-[99%] inline-block bg-gray-900/99 font-medium shadow-xs text-white py-2 px-3 text-sm rounded-lg">
         <div>
           <slot name="tooltip" />
         </div>
       </div>
-    </TransitionRoot>
+    </Transition>
     <span @mouseenter="isShowing = true">
       <slot />
     </span>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #304

### ❓ Type of change

- [x] 🐞 Bug fix
- [ ] 📖 Documentation
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@headlessui/vue` was removed in 0.17.8 but `Tab`, `TabGroup`, `TabList` and `TransitionRoot` were still referenced in `App.vue` and `Tooltip.vue`, so the web UI crashed on load with `Failed to resolve component: Tab` and a destructuring error from the missing `v-slot="{ selected }"` scope.

Replace the tab group with a native `role="tablist"` implementation driven by the existing `activeTab` state, wire up ARIA attributes and arrow/Home/End keyboard navigation, flatten `BtnTab` to a single `<button>` so tab semantics land on the focusable element, and swap the tooltip's `<TransitionRoot>` for Vue's built-in `<Transition>`.