### PR TITLE
fix: dashboard empty when opened after scan completes

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 import type { CliOptions } from './types'
 import { setMaxListeners } from 'node:events'
 import { platform } from 'node:os'
-import { createUnlighthouse, useLogger } from '@unlighthouse/core'
+import { createUnlighthouse, generateClient, useLogger } from '@unlighthouse/core'
 import { createServer } from '@unlighthouse/server'
 import { x } from 'tinyexec'
 import createCli from './createCli'
@@ -57,6 +57,13 @@ async function run() {
     // Clear the progress display
     unlighthouse.worker.clearProgressDisplay()
     logger.success(`Unlighthouse has finished scanning ${unlighthouse.resolvedConfig.site}: ${unlighthouse.worker.reports().length} routes in ${seconds}s.`)
+
+    // Regenerate the client payload with completed reports so the dashboard
+    // shows data even when opened after the scan finishes.
+    // Pass unlighthouse context explicitly — unctx's global context is not
+    // available inside async hook callbacks.
+    await generateClient({}, unlighthouse)
+
     await unlighthouse.worker.cluster.close().catch(() => {})
   })
 

--- a/packages/client/components/LighthouseThreeD.vue
+++ b/packages/client/components/LighthouseThreeD.vue
@@ -5,7 +5,7 @@ import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { FBXLoader } from 'three/addons/loaders/FBXLoader.js'
 import { ref } from 'vue'
-import { basePath } from '../logic'
+import { basePath, scanMeta } from '../logic'
 
 const canvasRef = ref<HTMLCanvasElement>()
 const lighthouseRef = ref<HTMLDivElement>()

--- a/packages/client/logic/state.ts
+++ b/packages/client/logic/state.ts
@@ -5,7 +5,7 @@ import CellScoreSingle from '../components/Cell/CellScoreSingle.vue'
 import CellScoresOverview from '../components/Cell/CellScoresOverview.vue'
 import { useFetch } from './fetch'
 import { sorting } from './search'
-import { categories, columns, isStatic, resolveArtifactPath, wsUrl } from './static'
+import { apiUrl, categories, columns, isStatic, resolveArtifactPath, wsUrl } from './static'
 
 export const activeTab = ref(0)
 
@@ -104,6 +104,17 @@ export const resultColumns = computed(() => {
 
 export const wsReports: Map<string, UnlighthouseRouteReport> = reactive(new Map<string, UnlighthouseRouteReport>())
 
+// Seed wsReports from payload data so the dashboard has data immediately
+// even when opened after the scan finishes (WebSocket won't replay past events)
+const payloadReports = window.__unlighthouse_payload?.reports
+if (!isStatic && Array.isArray(payloadReports)) {
+  payloadReports.forEach((report) => {
+    if (report?.route?.path) {
+      wsReports.set(report.route.path, report)
+    }
+  })
+}
+
 export const unlighthouseReports = computed<UnlighthouseRouteReport[]>(() => {
   if (isStatic) {
     return window.__unlighthouse_payload?.reports || []
@@ -194,10 +205,13 @@ export async function wsConnect() {
       console.warn('WebSocket connection closed')
     }
 
+    // Use native fetch instead of VueUse's useFetch composable for reliability —
+    // the composable can have reactivity issues when called inside async functions
     try {
-      const reports = await useFetch('/reports').get().json<UnlighthouseRouteReport[]>()
-      if (reports.data.value && Array.isArray(reports.data.value)) {
-        reports.data.value.forEach((report) => {
+      const response = await fetch(`${apiUrl}/reports`)
+      const reports: UnlighthouseRouteReport[] = await response.json()
+      if (Array.isArray(reports)) {
+        reports.forEach((report) => {
           if (report?.route?.path) {
             wsReports.set(report.route.path, report)
           }

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -68,12 +68,15 @@ export async function generateClient(options: GenerateClientOptions = {}, unligh
   }
   // avoid exposing sensitive cookie / header options
   staticData.options.lighthouseOptions = { onlyCategories: resolvedConfig.lighthouseOptions.onlyCategories }
-  if (options.static) {
-    staticData.reports = worker.reports().map((r) => {
+  // Always include completed reports in payload so the dashboard has data
+  // even when opened after the scan finishes (WebSocket won't replay past events)
+  const completedReports = worker.reports().filter(r => r.tasks.inspectHtmlTask === 'completed')
+  if (completedReports.length > 0) {
+    staticData.reports = completedReports.map((r) => {
       return {
         ...r,
-        // avoid exposing user paths
-        artifactPath: '',
+        // In static mode, avoid exposing user paths
+        ...(options.static ? { artifactPath: '' } : {}),
       }
     })
   }


### PR DESCRIPTION
## Summary

The dashboard shows a blank page when opened after a scan finishes. This fixes three root causes:

- **`payload.js` never updated**: Generated at server startup with `reports: []` and never regenerated. Reports were only included when `options.static === true` (CI mode only). Now always includes completed reports.
- **`unctx` context lost in async hook**: `useUnlighthouse()` inside the `worker-finished` hook returned a stale context with 0 reports. Fixed by passing the `unlighthouse` context explicitly to `generateClient()`.
- **Client had no fallback for late-joining**: In dynamic mode, data came exclusively via WebSocket which doesn't replay past events. Now seeds `wsReports` from `payload.js` on load and uses native `fetch()` instead of VueUse's `useFetch` composable for reliable initial data loading.
- **Missing import**: `LighthouseThreeD.vue` used `scanMeta` without importing it, causing a `ReferenceError`.

## Changed files

| File | Change |
|---|---|
| `packages/core/src/build.ts` | Always include completed reports in `payload.js` |
| `packages/cli/src/cli.ts` | Regenerate payload after scan via `worker-finished` hook |
| `packages/client/logic/state.ts` | Seed `wsReports` from payload + use native `fetch` |
| `packages/client/components/LighthouseThreeD.vue` | Add missing `scanMeta` import |

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c0e578bc-40a3-429e-80ec-ec24a8c159a2" />
