### PR TITLE
fix(core): wire scan.start input into core.run()

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -25,6 +25,7 @@ export type {
   UnlighthouseCore,
   UnlighthouseCoreOptions,
   UnlighthouseCoreRunOptions,
+  UnlighthouseCoreRunOverrides,
 } from './ports/core'
 export * from './ports/crawler'
 export * from './ports/seed-source'

--- a/packages/contracts/src/ports/core.ts
+++ b/packages/contracts/src/ports/core.ts
@@ -63,8 +63,32 @@ export interface CrawlSession {
   done: Promise<{ scanId: ScanId, summary: ScanSummary }>
 }
 
+/**
+ * Per-run config overrides. Merged on top of the host-supplied `config` for the
+ * lifetime of a single session — lets API callers (`scan.start`) thread the
+ * command input (site/device/categories/auditor/ciBuild) into the scan without
+ * mutating shared `Core` state. The overrides do not persist beyond the session.
+ */
+export interface UnlighthouseCoreRunOverrides {
+  site?: string
+  device?: 'mobile' | 'desktop'
+  /** Lighthouse categories — mapped onto `lighthouseOptions.onlyCategories`. */
+  categories?: Array<'performance' | 'accessibility' | 'seo' | 'best-practices'>
+  /** Sample count — mapped onto `scanner.samples`. */
+  sampleSize?: number
+  /** Auditor provider name — selects from `config.auditor` when it's a router. */
+  auditor?: string
+  /** CI metadata persisted on the scans row. */
+  ciBuild?: {
+    branch?: string
+    hash?: string
+    message?: string
+  }
+}
+
 export interface UnlighthouseCoreRunOptions {
   signal?: AbortSignal
+  overrides?: UnlighthouseCoreRunOverrides
 }
 
 export interface UnlighthouseCore {

--- a/packages/core/src/api/handlers/scan.ts
+++ b/packages/core/src/api/handlers/scan.ts
@@ -30,8 +30,16 @@ export const scanStart: Handler<typeof ScanStart> = {
   async run(input, ctx) {
     if (ctx.core.session())
       throw new UnlighthouseError({ code: 'ACTIVE_SCAN_CONFLICT', message: 'A scan is already in flight' })
-    // TODO: thread `input` (site/device/categories/auditor/ciBuild) into ctx.config before run().
-    const session = ctx.core.run()
+    const session = ctx.core.run({
+      overrides: {
+        site: input.site,
+        device: input.device,
+        sampleSize: input.sampleSize,
+        categories: input.categories,
+        auditor: input.auditor,
+        ciBuild: input.ciBuild,
+      },
+    })
     return {
       scanId: session.scanId,
       site: input.site,

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -12,6 +12,7 @@ import type {
   UnlighthouseCore,
   UnlighthouseCoreOptions,
   UnlighthouseCoreRunOptions,
+  UnlighthouseCoreRunOverrides,
 } from '@unlighthouse/contracts'
 import type { Hookable } from 'hookable'
 import {
@@ -43,6 +44,37 @@ function nowIso(): string {
 function generateScanId(): ScanId {
   // Cast through unknown: ScanId is a branded string; runtime is plain UUID.
   return globalThis.crypto.randomUUID() as unknown as ScanId
+}
+
+/**
+ * Apply `UnlighthouseCoreRunOverrides` on top of the resolved config for a
+ * single session. Returns a new object; never mutates the input. Unknown
+ * override fields are no-ops. `categories` maps onto
+ * `lighthouseOptions.onlyCategories` (Lighthouse-native shape).
+ */
+function mergeOverrides(
+  base: UnlighthouseConfig,
+  overrides?: UnlighthouseCoreRunOverrides,
+): UnlighthouseConfig {
+  if (!overrides)
+    return base
+  const next: UnlighthouseConfig = { ...base }
+  if (overrides.site)
+    next.site = overrides.site
+  if (overrides.device || overrides.sampleSize != null) {
+    next.scanner = {
+      ...(base.scanner ?? {}),
+      ...(overrides.device ? { device: overrides.device } : {}),
+      ...(overrides.sampleSize != null ? { samples: overrides.sampleSize } : {}),
+    }
+  }
+  if (overrides.categories && overrides.categories.length) {
+    next.lighthouseOptions = {
+      ...(base.lighthouseOptions ?? {}),
+      onlyCategories: overrides.categories,
+    }
+  }
+  return next
 }
 
 function toStructuredError(err: unknown): { code: string, message: string, cause?: unknown } {
@@ -83,7 +115,7 @@ export function createUnlighthouseCore(opts: UnlighthouseCoreOptions): Unlightho
     }
 
     const session = createSession({
-      config,
+      config: mergeOverrides(config, runOpts?.overrides),
       storage: opts.storage,
       auditor: opts.auditor,
       seeds: opts.seeds,
@@ -91,6 +123,7 @@ export function createUnlighthouseCore(opts: UnlighthouseCoreOptions): Unlightho
       hooks,
       logger,
       userSignal: runOpts?.signal,
+      overrides: runOpts?.overrides,
     })
 
     currentSession = session
@@ -120,10 +153,11 @@ interface SessionDeps {
   hooks: Hookable<HookMap>
   logger: LoggerLike | undefined
   userSignal?: AbortSignal
+  overrides?: UnlighthouseCoreRunOverrides
 }
 
 function createSession(deps: SessionDeps): CrawlSession {
-  const { storage, auditor, seeds, crawler, hooks, logger, userSignal } = deps
+  const { storage, auditor, seeds, crawler, hooks, logger, userSignal, overrides } = deps
 
   const scanId = generateScanId()
   const startedAt = nowIso()
@@ -244,17 +278,20 @@ function createSession(deps: SessionDeps): CrawlSession {
   // ── Orchestration ──────────────────────────────────────────────────────
   async function orchestrate(): Promise<void> {
     const site = (deps.config.site ?? '') as string
+    const scannerDevice = deps.config.scanner?.device
+    const device: 'mobile' | 'desktop'
+      = scannerDevice === 'mobile' || scannerDevice === 'desktop' ? scannerDevice : 'mobile'
 
     await storage.scans.create({
       scanId,
       site: site as never,
-      device: 'mobile',
+      device,
       status: 'starting',
       startedAt,
       completedAt: null,
-      ciBranch: null,
-      ciCommit: null,
-      ciCommitMessage: null,
+      ciBranch: overrides?.ciBuild?.branch ?? null,
+      ciCommit: overrides?.ciBuild?.hash ?? null,
+      ciCommitMessage: overrides?.ciBuild?.message ?? null,
     })
 
     await emit('scan:created', { scanId, site: site as never, startedAt })

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -335,6 +335,52 @@ describe('createUnlighthouseCore orchestration', () => {
     await session.done.catch(() => {})
   })
 
+  it('run({ overrides }): site/device/ciBuild are persisted onto the scans row', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: { site: 'https://default.example', scanner: { device: 'mobile' } },
+      auditor: passingAuditor(),
+      seeds: emptySeeds,
+      crawler: discoveryCrawler(['https://override.example/a']),
+      storage,
+    })
+
+    const session = core.run({
+      overrides: {
+        site: 'https://override.example',
+        device: 'desktop',
+        ciBuild: { branch: 'feat/x', hash: 'deadbeef', message: 'wip' },
+      },
+    })
+    await session.done
+
+    const scan = await storage.scans.get(session.scanId)
+    expect(scan?.site).toBe('https://override.example')
+    expect(scan?.device).toBe('desktop')
+    expect(scan?.ciBranch).toBe('feat/x')
+    expect(scan?.ciCommit).toBe('deadbeef')
+    expect(scan?.ciCommitMessage).toBe('wip')
+  })
+
+  it('run() without overrides: falls back to host config (default device=mobile, no ci)', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: baseConfig,
+      auditor: passingAuditor(),
+      seeds: emptySeeds,
+      crawler: discoveryCrawler(['https://example.com/a']),
+      storage,
+    })
+    const session = core.run()
+    await session.done
+    const scan = await storage.scans.get(session.scanId)
+    expect(scan?.site).toBe('https://example.com')
+    expect(scan?.device).toBe('mobile')
+    expect(scan?.ciBranch).toBeNull()
+    expect(scan?.ciCommit).toBeNull()
+    expect(scan?.ciCommitMessage).toBeNull()
+  })
+
   it('audit error: emits scan:route-failed, completes with stats.failed=1', async () => {
     const urls = ['https://example.com/a', 'https://example.com/b', 'https://example.com/c']
     const storage = memoryStorage()

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -295,6 +295,35 @@ describe('handlers — scan.start / scan.rescanAll / history.rescan', () => {
     expect(result.scanId).toBe('newscan')
   })
 
+  it('scan.start threads input (site/device/categories/sampleSize/auditor/ciBuild) into core.run(overrides)', async () => {
+    const handlers = createHandlers()
+    const ctx = makeCtx()
+    let receivedOpts: any = null
+    ;(ctx as any).core = {
+      session: () => null,
+      run: (opts?: any) => {
+        receivedOpts = opts
+        return stubSession({ scanId: 'newscan' as CrawlSession['scanId'] })
+      },
+    }
+    await handlers['scan.start'].run({
+      site: 'https://example.com',
+      device: 'desktop',
+      sampleSize: 3,
+      categories: ['performance', 'seo'],
+      auditor: 'psi',
+      ciBuild: { branch: 'main', hash: 'abc123', message: 'release' },
+    } as never, ctx)
+    expect(receivedOpts?.overrides).toEqual({
+      site: 'https://example.com',
+      device: 'desktop',
+      sampleSize: 3,
+      categories: ['performance', 'seo'],
+      auditor: 'psi',
+      ciBuild: { branch: 'main', hash: 'abc123', message: 'release' },
+    })
+  })
+
   it('scan.rescanAll throws ACTIVE_SCAN_CONFLICT when a session is in flight', async () => {
     const handlers = createHandlers()
     const ctx = makeCtx()


### PR DESCRIPTION
## What

`scan.start` accepts `{ site, device, sampleSize, categories, auditor, ciBuild }`, validates them with Zod, then drops every field. `core.run()` always reads from host config and `scans.create` writes hardcoded `device: 'mobile'` / `ciBranch: null`.

So the API lies: send `device: 'desktop'`, get a mobile scan.

## How

New `overrides` field on `UnlighthouseCoreRunOptions`. `scan.start` builds it from the input, passes it to `core.run({ overrides })`. Core merges it on top of the base config for one session (never mutates the original).

Mapping:
- `device`, `sampleSize` → `scanner.*`
- `categories` → `lighthouseOptions.onlyCategories`
- `site` → top level
- `ciBuild.{branch,hash,message}` → `scans` row columns

Orchestration now reads `scanner.device` instead of hardcoding `'mobile'`.

## Why it matters

- UI device selector starts working
- `ciBranch` / `ciCommit` actually populate, so `history.list?ciBranch=...` and `compare.*` filters return real rows instead of always-null
- Per-request overrides don't touch shared `Core` state — needed for multi-tenant later

## Not done here

`auditor` override is accepted but no-op. Auditor is bound at `Core` construction; making it per-run is a bigger refactor that ties into per-tenant `Core` instances.

## Tests

- `handlers.test.ts`: asserts every input field reaches `core.run(opts.overrides)`
- `core.test.ts`: asserts overrides land on the `scans` row; second test guards the no-overrides path still writes `device='mobile'` + null CI
- 279/279 targeted, 320/322 full suite. The 2 failures are `test/ci.test.ts` needing a built `dist/cli/ci.mjs` — pre-existing.