### PR TITLE
fix(host): wire visited-client hook so autoStartOnVisit actually fires

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,19 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
+    "better-sqlite3": "catalog:dependencies",
     "bumpp": "catalog:",
+    "drizzle-orm": "catalog:dependencies",
     "eslint": "catalog:",
+    "fs-extra": "catalog:dependencies",
+    "h3": "catalog:dependencies",
     "obuild": "catalog:",
     "publint": "catalog:",
     "rolldown": "catalog:",
+    "tinyexec": "catalog:dependencies",
     "typescript": "catalog:",
     "vite": "catalog:dependencies",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/packages/unlighthouse/src/host.ts
+++ b/packages/unlighthouse/src/host.ts
@@ -37,6 +37,7 @@ import { historySubscriber } from './data/history/tracking'
 import { createSitesStore } from './data/sites'
 import { resolveUserConfig } from './resolveConfig'
 import { mountServer } from './server'
+import { createServerHooks } from './server-hooks'
 import { normaliseHost } from './util'
 
 /**
@@ -345,10 +346,18 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
 
     const { handlerCtx } = ensurePorts()
 
+    // Indirection so callers (tests, integrations) can override `host.start`
+    // after construction and still have autoStartOnVisit honour the override.
+    const serverHooks = createServerHooks({
+      autoStartOnVisit: behavior.autoStartOnVisit,
+      start: () => result.start(),
+      logger,
+    })
+
     const mountDeps = {
       resolvedConfig,
       runtimeSettings: rs as RuntimeSettings,
-      hooks: { callHook: async () => {} } as any,
+      hooks: serverHooks,
       ws,
       logger,
     }
@@ -384,7 +393,10 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
     })
   }
 
-  return {
+  // `result` is referenced lazily by `setServerContext` (via `() => result.start()`)
+  // so callers can override `host.start` after construction. Safe at runtime because
+  // setServerContext is invoked from the outside, after this function returns.
+  const result: UnlighthouseHost = {
     core: new Proxy({} as UnlighthouseCore, {
       get(_, prop) {
         const { core } = ensurePorts()
@@ -411,4 +423,5 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
     }),
     start,
   }
+  return result
 }

--- a/packages/unlighthouse/src/server-hooks.ts
+++ b/packages/unlighthouse/src/server-hooks.ts
@@ -1,0 +1,42 @@
+// Server-side hook bus wiring. Extracted from `host.ts` so behavior wiring
+// (auto-start on dashboard visit, etc.) can be unit-tested without spinning
+// up the full host (sqlite, fs, drizzle).
+
+import type { Logger } from '@unlighthouse/contracts'
+import type { LegacyWorkerHooks } from '@unlighthouse/core/crawlers'
+import type { Hookable } from 'hookable'
+import { createHooks } from 'hookable'
+
+export interface ServerHooksDeps {
+  /** When true, the first `visited-client` event triggers `start()`. */
+  autoStartOnVisit?: boolean
+  /** Called once on the first `visited-client`. */
+  start: () => Promise<unknown>
+  logger?: Logger
+}
+
+/**
+ * Build the server-side hook bus passed to `mountServer`. Subscribes to
+ * `visited-client` when `autoStartOnVisit` is enabled — idempotent: a flood of
+ * visit events from concurrent SPA loads only triggers `start()` once.
+ */
+export function createServerHooks(deps: ServerHooksDeps): Hookable<LegacyWorkerHooks> {
+  const hooks = createHooks<LegacyWorkerHooks>()
+
+  if (deps.autoStartOnVisit) {
+    let started = false
+    hooks.hook('visited-client', async () => {
+      if (started)
+        return
+      started = true
+      try {
+        await deps.start()
+      }
+      catch (err) {
+        deps.logger?.error?.('[unlighthouse] autoStartOnVisit failed', err)
+      }
+    })
+  }
+
+  return hooks
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,12 +264,24 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      better-sqlite3:
+        specifier: catalog:dependencies
+        version: 12.10.0
       bumpp:
         specifier: 'catalog:'
         version: 11.1.0
+      drizzle-orm:
+        specifier: catalog:dependencies
+        version: 0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
+      fs-extra:
+        specifier: catalog:dependencies
+        version: 11.3.5
+      h3:
+        specifier: catalog:dependencies
+        version: 1.15.11
       obuild:
         specifier: 'catalog:'
         version: 0.4.35(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.6.1)(magicast@0.5.1)(typescript@6.0.3)
@@ -279,6 +291,9 @@ importers:
       rolldown:
         specifier: 'catalog:'
         version: 1.0.0
+      tinyexec:
+        specifier: catalog:dependencies
+        version: 1.1.2
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -288,6 +303,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.7.0)(jsdom@26.1.0)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
   packages/audit-pool:
     dependencies:
@@ -8918,10 +8936,6 @@ packages:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
@@ -9834,7 +9848,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
 
   '@apify/consts@2.52.1': {}
 
@@ -11200,7 +11214,7 @@ snapshots:
       semver: 7.7.3
       srvx: 0.9.8
       std-env: 3.10.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       ufo: 1.6.4
       youch: 4.1.0-beta.13
     transitivePeerDependencies:
@@ -17519,7 +17533,7 @@ snapshots:
       consola: 3.4.2
       pathe: 2.0.3
       pkg-types: 2.3.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
 
   object-assign@4.1.1: {}
 
@@ -19017,8 +19031,6 @@ snapshots:
 
   tinyclip@0.1.12: {}
 
-  tinyexec@1.1.1: {}
-
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
@@ -19563,7 +19575,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)

--- a/test/host-visited-client.test.ts
+++ b/test/host-visited-client.test.ts
@@ -1,0 +1,106 @@
+// End-to-end regression for `behavior.autoStartOnVisit`.
+//
+// Before this fix `host.ts` passed a dummy hookable to `mountServer`
+// (`{ callHook: async () => {} }`), so the `visited-client` event the SPA
+// root route fires went to /dev/null. `autoStartOnVisit` was a tracked-
+// but-ignored flag.
+//
+// Test strategy:
+//   - real `createUnlighthouseHost` (no module mocks)
+//   - real h3 app on a real ephemeral HTTP port
+//   - real `fetch` against `GET /`
+//   - `host.start` is overwritten with a spy; `host.ts` calls it via
+//     `result.start()` indirection so the override is honoured
+//
+// If `host.ts` regresses to the dummy hookable, the autoStart spy is never
+// called and the autoStartOnVisit=true assertions fail.
+
+import type { Server } from 'node:http'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createApp, toNodeListener } from 'h3'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createUnlighthouseHost } from 'unlighthouse'
+
+interface HostFixture {
+  server: Server
+  baseUrl: string
+  start: ReturnType<typeof vi.fn>
+}
+
+async function bootHost(opts: { autoStartOnVisit: boolean }): Promise<HostFixture> {
+  const root = mkdtempSync(join(tmpdir(), 'unl-host-'))
+  const outputPath = join(root, '.unlighthouse')
+
+  const host = await createUnlighthouseHost({
+    userConfig: {
+      site: 'https://example.com',
+      root,
+      outputPath,
+      cache: false,
+    },
+    behavior: { ws: null, autoStartOnVisit: opts.autoStartOnVisit },
+  })
+
+  // Spy on start — host.ts captures `result.start` via indirection, so this
+  // override is what autoStartOnVisit will actually call.
+  const startSpy = vi.fn(async () => ({ scanId: 'spy' }))
+  host.start = startSpy
+
+  const app = createApp()
+  const server = createServer(toNodeListener(app))
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()))
+  const addr = server.address()
+  const port = typeof addr === 'object' && addr ? addr.port : 0
+  const baseUrl = `http://127.0.0.1:${port}`
+
+  await host.setServerContext({ url: `${baseUrl}/`, server, app })
+
+  // host derives generatedClientPath inside setServerContext. Drop an
+  // index.html there so the SPA fallback returns 200 (the bug exists
+  // regardless of body, but a real 200 makes the test reflect reality).
+  const clientPath = host.runtimeSettings.generatedClientPath
+  if (clientPath)
+    writeFileSync(join(clientPath, 'index.html'), '<html>ok</html>')
+
+  return { server, baseUrl, start: startSpy }
+}
+
+describe('autoStartOnVisit — end-to-end (real host + real HTTP)', () => {
+  describe('when behavior.autoStartOnVisit = true', () => {
+    let fx: HostFixture
+    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: true }) })
+    afterAll(async () => { await new Promise(r => fx.server.close(() => r(null))) })
+
+    it('GET / triggers host.start() exactly once', async () => {
+      await fetch(`${fx.baseUrl}/`)
+      expect(fx.start).toHaveBeenCalledTimes(1)
+    })
+
+    it('repeated visits do not trigger start() again (idempotent)', async () => {
+      await fetch(`${fx.baseUrl}/`)
+      await fetch(`${fx.baseUrl}/some/spa/route`)
+      await fetch(`${fx.baseUrl}/`)
+      expect(fx.start).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when behavior.autoStartOnVisit = false', () => {
+    let fx: HostFixture
+    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: false }) })
+    afterAll(async () => { await new Promise(r => fx.server.close(() => r(null))) })
+
+    it('GET / does NOT trigger host.start()', async () => {
+      await fetch(`${fx.baseUrl}/`)
+      expect(fx.start).not.toHaveBeenCalled()
+    })
+
+    it('repeated visits still do not trigger start()', async () => {
+      await fetch(`${fx.baseUrl}/`)
+      await fetch(`${fx.baseUrl}/spa/route`)
+      expect(fx.start).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from 'vite'
 
 const r = (p: string) => resolve(__dirname, p)
 
+// Workspace path aliases for tests. Shared runtime deps (drizzle-orm, h3,
+// zod, fs-extra, tinyexec, better-sqlite3) are declared as root devDeps in
+// package.json so pnpm resolves them normally — no version-pinned paths.
 export const alias: AliasOptions = {
   'unlighthouse/cli': r('./packages/unlighthouse/src/cli/cli.ts'),
   'unlighthouse': r('./packages/unlighthouse/src/'),
@@ -13,15 +16,6 @@ export const alias: AliasOptions = {
   '@unlighthouse/core': r('./packages/core/src/'),
   '@unlighthouse/cloudflare': r('./packages/cloudflare/src/'),
   '@unlighthouse/mcp': r('./packages/mcp/src/'),
-  // pnpm install at the root is blocked by an unrelated semver@6.3.1
-  // trust-downgrade; pin shared deps used by tests at the workspace store path.
-  'zod': r('./node_modules/.pnpm/zod@4.4.3/node_modules/zod'),
-  'h3': r('./packages/core/node_modules/h3'),
-  'fs-extra': r('./node_modules/.pnpm/fs-extra@11.3.5/node_modules/fs-extra'),
-  'tinyexec': r('./node_modules/.pnpm/tinyexec@1.1.2/node_modules/tinyexec'),
-  'better-sqlite3': r('./node_modules/.pnpm/better-sqlite3@12.10.0/node_modules/better-sqlite3'),
-  'drizzle-orm/better-sqlite3': r('./node_modules/.pnpm/drizzle-orm@0.45.2_@opentelemetry+api@1.9.0_@types+better-sqlite3@7.6.13_@types+pg@8.6.1_better-sqlite3@12.10.0/node_modules/drizzle-orm/better-sqlite3'),
-  'drizzle-orm': r('./node_modules/.pnpm/drizzle-orm@0.45.2_@opentelemetry+api@1.9.0_@types+better-sqlite3@7.6.13_@types+pg@8.6.1_better-sqlite3@12.10.0/node_modules/drizzle-orm'),
 }
 
 export default defineConfig({


### PR DESCRIPTION
## What

`createUnlighthouseHost` was handing `mountServer` a dummy hookable:

```ts
hooks: { callHook: async () => {} } as any
```

So the \`visited-client\` event fired by the SPA root route (\`server.ts:89\`) went nowhere. \`behavior.autoStartOnVisit\` was a flag with no working code path behind it — integrations that wanted "start the scan when the user opens the dashboard" had no way to actually do that.

## How

- **\`server-hooks.ts\` (new):** \`createServerHooks\` builds a real \`Hookable<LegacyWorkerHooks>\`. When \`autoStartOnVisit\` is true it subscribes to \`visited-client\` and calls \`start()\` once. Idempotent on repeated visits. Errors from \`start()\` are swallowed + logged so a flaky boot can't 500 the SPA load.
- **\`host.ts\`:** passes \`createServerHooks({ ... })\` to \`mountServer\` instead of the dummy. \`start\` is wrapped in \`() => result.start()\` indirection so callers (tests, integrations) can override \`host.start\` after construction.

## Test infra cleanup (folded in because the integration test needs it)

- **\`vitest.config.ts\`:** dropped hardcoded \`node_modules/.pnpm/<hash>\` aliases for drizzle-orm/h3/zod/fs-extra/tinyexec/better-sqlite3. Those paths drift on every install — the pnpm hash flipped recently and silently broke \`storage-port.test.ts\` (one of the pre-existing failures).
- **\`package.json\`:** added the 6 packages above as root devDependencies so pnpm resolves them normally. No more hand-pinned paths.

## Tests

\`test/host-visited-client.test.ts\` boots a real \`createUnlighthouseHost\` on a real ephemeral HTTP port and drives \`fetch\` against \`GET /\`. No module mocks.

Bug-then-fix verified: reproduced the dummy hookable in-tree, watched the new test fail; restored the fix, watched it pass.

- Targeted: 4/4
- Full suite: **354/356** (was 320/322 before this PR — +32 tests now run because the drizzle alias fix unbreaks them). The 2 still-failing tests are pre-existing \`ci.test.ts\` cases that need a built \`dist/cli/ci.mjs\`.
- Typecheck: clean. Also clears the two pre-existing \`zod\` / \`tinyexec\` "Cannot find module" errors as a side effect of the devDep additions.