### PR TITLE
feat(mcp): connect MCP host to real SQLite + curate the tool surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
+    "@modelcontextprotocol/sdk": "catalog:",
     "better-sqlite3": "catalog:dependencies",
     "bumpp": "catalog:",
     "drizzle-orm": "catalog:dependencies",

--- a/packages/contracts/src/commands/events.ts
+++ b/packages/contracts/src/commands/events.ts
@@ -20,6 +20,11 @@ export const EventsSubscribe = defineCommand({
     replay: z.coerce.number().int().nonnegative().max(10_000).optional(),
   }),
   output: HookEventUnion,
+  // Streaming tools over MCP stdio are projected through progress
+  // notifications and haven't been exercised end-to-end. Until that path is
+  // tested + documented, keep agents off it — scan.status polling is the
+  // safe substitute for "is this scan done yet".
+  mcp: { hidden: true },
 })
 
 // ── events.tail ─────────────────────────────────────────────────────────────
@@ -37,4 +42,5 @@ export const EventsTail = defineCommand({
   }),
   output: HookEventUnion,
   exitCodes: { SCAN_NOT_FOUND: 64 },
+  mcp: { hidden: true },
 })

--- a/packages/contracts/src/commands/history.ts
+++ b/packages/contracts/src/commands/history.ts
@@ -42,6 +42,8 @@ export const HistoryDelete = defineCommand({
   output: z.object({
     deleted: z.array(ScanId),
   }),
+  // Bulk destructive op. Agent has no business deleting user history.
+  mcp: { hidden: true },
 })
 
 // ── history.rescan ──────────────────────────────────────────────────────────
@@ -60,4 +62,7 @@ export const HistoryRescan = defineCommand({
     sourceScanId: ScanId,
   }),
   exitCodes: { SCAN_NOT_FOUND: 64, ACTIVE_SCAN_CONFLICT: 9 },
+  // Agent can call scan.start with explicit config if a fresh scan is needed;
+  // "rescan from history" is a UI convenience that conflicts with active scans.
+  mcp: { hidden: true },
 })

--- a/packages/contracts/src/commands/meta.ts
+++ b/packages/contracts/src/commands/meta.ts
@@ -107,4 +107,8 @@ export const AuditorsTest = defineCommand({
       .optional(),
   }),
   cli: { hidden: true },
+  // Fires a real Lighthouse run against an arbitrary URL — agent-controlled
+  // input could SSRF to internal hosts or burn a Chrome slot. Triggering a
+  // live audit is what scan.start is for; this is a dev-only diagnostic.
+  mcp: { hidden: true },
 })

--- a/packages/contracts/src/commands/pack.ts
+++ b/packages/contracts/src/commands/pack.ts
@@ -9,7 +9,7 @@ import { defineCommand } from './define'
 // ── pack.run ────────────────────────────────────────────────────────────────
 export const PackRunCmd = defineCommand({
   name: 'pack.run',
-  description: 'Execute a registered pack against a scan and return its typed report.',
+  description: 'Run a Lighthouse pack (cross-route analysis) against a finished scan. Returns a typed report — e.g. "images" lists routes with unoptimised LCP images, "cwv" returns p75 Core Web Vitals, "seo-basics" returns failing audits grouped by rule. Call pack.list first to discover available packs. Use scanId from history.list. Output is cached so re-running the same (scanId, pack) is free; pass refresh:true to bust.',
   input: z.object({
     scanId: ScanId,
     pack: z.string().min(1),
@@ -38,7 +38,7 @@ export const PackRunCmd = defineCommand({
 // ── pack.list ───────────────────────────────────────────────────────────────
 export const PackList = defineCommand({
   name: 'pack.list',
-  description: 'List the packs registered on this host (built-in + community).',
+  description: 'List packs available for pack.run. Built-ins include "overview" (top-level scores), "cwv" (Core Web Vitals), "images" (lazy-load + sizing + alt), "js-bundle" (unused JS/CSS, third parties), "a11y-quick-wins" (top accessibility wins), "seo-basics" (indexability + meta). Returns name, description, version, and auditor count for each.',
   input: z.object({}),
   output: z.object({
     packs: z.array(z.object({

--- a/packages/contracts/src/commands/route.ts
+++ b/packages/contracts/src/commands/route.ts
@@ -28,4 +28,6 @@ export const RouteRescan = defineCommand({
     metrics: ExtractedMetrics,
   }),
   exitCodes: { ROUTE_NOT_FOUND: 66, SCAN_NOT_FOUND: 64 },
+  // Mutates an existing scan's data and needs a live auditor — UI flow only.
+  mcp: { hidden: true },
 })

--- a/packages/contracts/src/commands/scan.ts
+++ b/packages/contracts/src/commands/scan.ts
@@ -73,6 +73,9 @@ export const ScanCancel = defineCommand({
     cancelledAt: z.iso.datetime(),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
+  // Live-flow orchestration — only makes sense from the UI / CLI that owns the
+  // running scan. An MCP client cancelling somebody else's session is hostile.
+  mcp: { hidden: true },
 })
 
 // ── scan.pause ──────────────────────────────────────────────────────────────
@@ -85,6 +88,7 @@ export const ScanPause = defineCommand({
     status: ScanStatus,
   }),
   exitCodes: { NOT_SUPPORTED: 65, SCAN_NOT_FOUND: 64 },
+  mcp: { hidden: true },
 })
 
 // ── scan.resume ─────────────────────────────────────────────────────────────
@@ -97,6 +101,7 @@ export const ScanResume = defineCommand({
     status: ScanStatus,
   }),
   exitCodes: { NOT_SUPPORTED: 65, SCAN_NOT_FOUND: 64 },
+  mcp: { hidden: true },
 })
 
 // ── scan.delete ─────────────────────────────────────────────────────────────
@@ -109,6 +114,8 @@ export const ScanDelete = defineCommand({
     deleted: z.literal(true),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
+  // Destructive + irreversible. Keep behind UI/CLI confirmation flows.
+  mcp: { hidden: true },
 })
 
 // ── scan.meta ───────────────────────────────────────────────────────────────
@@ -133,6 +140,9 @@ export const ScanCurrent = defineCommand({
   description: 'Return the current in-flight scanId, or null.',
   input: z.object({}),
   output: z.object({ scanId: ScanId.nullable() }),
+  // "Current" is a UI/CLI session concept — there's no notion of a per-request
+  // "current scan" in MCP. Agents pass scanIds explicitly via history.list.
+  mcp: { hidden: true },
 })
 
 // ── scan.rescanAll ──────────────────────────────────────────────────────────
@@ -145,6 +155,9 @@ export const ScanRescanAll = defineCommand({
     queued: z.number().int().nonnegative(),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64, ACTIVE_SCAN_CONFLICT: 9 },
+  // Drops all routes for an existing scan. Destructive enough to keep
+  // behind a deliberate UI / CLI flow.
+  mcp: { hidden: true },
 })
 
 // ── scan.summary ────────────────────────────────────────────────────────────
@@ -153,7 +166,7 @@ export const ScanRescanAll = defineCommand({
 // built-in `overview` pack on the host. Agent entry point.
 export const ScanSummaryCmd = defineCommand({
   name: 'scan.summary',
-  description: 'Terse, template-grouped overview of a scan. Sub-1KB JSON. The agent entry point.',
+  description: 'Agent entry point: a terse, template-grouped overview of a finished scan in sub-1KB JSON. Returns category averages (perf/a11y/seo/best-practices), passing/needs-work/poor distribution, the worst 5 routes by score, and template groups. Use this first to decide where to drill in — then call pack.run with a specific pack (e.g. "images", "cwv") for actionable findings, or query.routes / scan.results for raw per-route data.',
   input: z.object({
     scanId: ScanId,
     device: Device.optional(),

--- a/packages/contracts/src/commands/sites.ts
+++ b/packages/contracts/src/commands/sites.ts
@@ -40,6 +40,9 @@ export const SitesCreate = defineCommand({
     device: Device.optional(),
   }),
   output: z.object({ site: Site }),
+  // Persistent registry mutation. Adding ghost sites across restarts is a
+  // hostile-agent vector; site setup belongs in the UI / CLI.
+  mcp: { hidden: true },
 })
 
 export const SitesDelete = defineCommand({
@@ -48,4 +51,7 @@ export const SitesDelete = defineCommand({
   input: z.object({ id: z.string() }),
   output: z.object({ id: z.string(), deleted: z.literal(true) }),
   exitCodes: { SITE_NOT_FOUND: 64 },
+  // Destructive — pairs with history.delete in the "agent has no business
+  // deleting user data" category.
+  mcp: { hidden: true },
 })

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,2 +1,2 @@
-export * from './projection'
-export * from './stdio'
+export * from './projection.ts'
+export * from './stdio.ts'

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,8 +1,8 @@
 // stdio transport entrypoint used by `bin/unlighthouse-mcp`.
 
-import type { CreateMcpServerOptions } from './projection'
+import type { CreateMcpServerOptions } from './projection.ts'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { createMcpServer } from './projection'
+import { createMcpServer } from './projection.ts'
 
 export async function startStdioServer(opts: CreateMcpServerOptions): Promise<void> {
   const server = createMcpServer(opts)

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/unlighthouse/build.config.ts
+++ b/packages/unlighthouse/build.config.ts
@@ -4,7 +4,7 @@ export default defineBuildConfig({
   entries: [
     {
       type: 'bundle',
-      input: ['./src/index.ts', './src/cli/cli.ts', './src/cli/ci.ts', './src/lighthouse.ts'],
+      input: ['./src/index.ts', './src/cli/cli.ts', './src/cli/ci.ts', './src/cli/mcp.ts', './src/lighthouse.ts'],
     },
   ],
 })

--- a/packages/unlighthouse/src/cli/mcp.ts
+++ b/packages/unlighthouse/src/cli/mcp.ts
@@ -1,17 +1,32 @@
 // Entry point for `unlighthouse-mcp` (bin) and `unlighthouse mcp` (subcommand).
-// Boots a stdio MCP server projecting the 22-command registry.
+// Boots a stdio MCP server projecting the command registry.
+//
+// Storage is the same drizzle+unstorage stack the HTTP host uses, pointed at
+// the resolved `outputPath`. That means MCP clients see the user's real scan
+// history, cached pack runs, and blob-stored LHRs — not an empty in-memory
+// world. Without this, history.list returns [] and pack.run can't be invoked
+// because there's no scanId to feed it.
 
 import type { UnlighthouseConfig } from '@unlighthouse/contracts'
 import { createUnlighthouseCore } from '@unlighthouse/core'
 import { createHandlers } from '@unlighthouse/core/api/handlers'
 import { crawleeCrawler } from '@unlighthouse/core/crawlers'
 import { fuseSeeds, manualSeeds } from '@unlighthouse/core/seeds'
-import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { createStorage } from '@unlighthouse/core/storage'
+import { drizzleStorage, INIT_SQL_STATEMENTS } from '@unlighthouse/core/storage/drizzle'
+import { unstorageBlobs } from '@unlighthouse/core/storage/unstorage-blobs'
 import { startStdioServer } from '@unlighthouse/mcp'
+import Database from 'better-sqlite3'
 import { createConsola } from 'consola'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import fs from 'fs-extra'
+import { isAbsolute, join, resolve } from 'node:path'
+import objectHash from 'object-hash'
+import fsDriver from 'unstorage/drivers/fs'
 import { version } from '../../package.json'
 import { resolveAuditor } from '../auditor'
 import { resolveConfig } from '../config/resolve'
+import { normaliseHost } from '../util'
 
 function resolveManualUrls(urls: UnlighthouseConfig['urls']): string[] | (() => string[] | Promise<string[]>) {
   if (typeof urls === 'function') {
@@ -23,13 +38,163 @@ function resolveManualUrls(urls: UnlighthouseConfig['urls']): string[] | (() => 
   return urls ?? []
 }
 
+// Minimal flag parsing — keep this dependency-free so the stdio entrypoint
+// boots fast. The CLI's full citty surface is overkill here; we only need to
+// know which site (= which `.unlighthouse/<site>/<hash>/` to point at).
+//
+// Throws via process.exit on malformed input — `unlighthouse-mcp --site` with
+// no value used to silently land on the bare outputPath and return an empty
+// history, which is much harder to diagnose than a "missing value" error.
+function parseFlags(argv: string[]): { site?: string, root?: string } {
+  const out: { site?: string, root?: string } = {}
+  const needsValue = (name: string, next: string | undefined): string => {
+    if (next == null || next.startsWith('--') || next.startsWith('-')) {
+      process.stderr.write(`[unlighthouse-mcp] missing value for ${name}\n`)
+      process.exit(2)
+    }
+    return next
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--site' || a === '-s') {
+      out.site = needsValue(a, argv[++i])
+    }
+    else if (a.startsWith('--site=')) {
+      const v = a.slice('--site='.length)
+      if (!v) {
+        process.stderr.write(`[unlighthouse-mcp] missing value for --site\n`)
+        process.exit(2)
+      }
+      out.site = v
+    }
+    else if (a === '--root' || a === '-r') {
+      out.root = needsValue(a, argv[++i])
+    }
+    else if (a.startsWith('--root=')) {
+      const v = a.slice('--root='.length)
+      if (!v) {
+        process.stderr.write(`[unlighthouse-mcp] missing value for --root\n`)
+        process.exit(2)
+      }
+      out.root = v
+    }
+  }
+  return out
+}
+
+// Resolve --root to an absolute path under CWD. Prevents `--root ../../../`
+// from silently relocating `.unlighthouse` outside the project. If a user
+// genuinely needs an absolute path elsewhere, they can pass one — we honour
+// absolutes verbatim but refuse relatives that escape CWD.
+function sanitiseRoot(raw: string): string {
+  const abs = isAbsolute(raw) ? raw : resolve(process.cwd(), raw)
+  const cwd = process.cwd()
+  if (!isAbsolute(raw) && !abs.startsWith(`${cwd}/`) && abs !== cwd) {
+    process.stderr.write(`[unlighthouse-mcp] --root resolves outside CWD: ${abs}\n`)
+    process.exit(2)
+  }
+  return abs
+}
+
 export async function runMcp(): Promise<void> {
-  const { config } = await resolveConfig()
+  const flags = parseFlags(process.argv.slice(2))
+  const rootDir = flags.root ? sanitiseRoot(flags.root) : undefined
+  const { config } = await resolveConfig({
+    overrides: flags.site ? { site: flags.site } : undefined,
+    cwd: rootDir,
+  })
 
-  // D-018: host owns the concrete consola; tagged children pass into each adapter.
-  const logger = createConsola().withTag('unlighthouse')
+  // D-018: host owns the concrete consola; tagged children pass into each
+  // adapter. MCP routes consola → stderr only (stdout is the JSON-RPC channel).
+  const logger = createConsola({ defaults: { level: 1 } }).withTag('unlighthouse-mcp')
 
-  const storage = memoryStorage({ logger: logger.withTag('storage/memory') as never })
+  // Resolve the on-disk scan directory. The CLI writes to
+  // `.unlighthouse/<hostname>/<configCacheKey>/` where `configCacheKey` is a
+  // 4-char hash of the *raw* userConfig at scan time. Computing the same hash
+  // from MCP's resolved config doesn't generally match (different layering:
+  // c12 + flags + defaults), so we discover instead — pick the subdir whose
+  // `scans` table has the most rows, breaking ties by mtime. If none exists,
+  // mint a fresh hash dir so future writes don't pollute the site root.
+  let outputPath = config.outputPath as string
+  if (config.site) {
+    const site = normaliseHost(config.site)
+    const siteDir = join(outputPath, site.hostname.replace(':', '꞉'))
+    if (fs.existsSync(siteDir)) {
+      const candidates = fs.readdirSync(siteDir)
+        .map((name) => {
+          const dbPath = join(siteDir, name, 'db.sqlite')
+          if (!fs.existsSync(dbPath))
+            return null
+          // Open readonly to probe the scans table. The `scans` SELECT can
+          // throw if the table doesn't exist (malformed/uninitialised DB);
+          // wrap close() in `finally` so the file descriptor is always
+          // released — better-sqlite3 doesn't auto-close on GC.
+          let count = 0
+          let db: InstanceType<typeof Database> | null = null
+          try {
+            db = new Database(dbPath, { readonly: true })
+            count = (db.prepare('SELECT count(*) AS c FROM scans').get() as { c: number }).c
+          }
+          catch {}
+          finally {
+            db?.close()
+          }
+          return { name, mtime: fs.statSync(join(siteDir, name)).mtimeMs, count }
+        })
+        .filter((e): e is { name: string, mtime: number, count: number } => e !== null)
+        .sort((a, b) => (b.count - a.count) || (b.mtime - a.mtime))
+      // Surface ambiguity: if more than one candidate dir holds scans, the
+      // "most rows wins" heuristic might route to the wrong config variant
+      // (e.g. mobile vs desktop ran under different cacheKeys). Emit a
+      // stderr line so users can diagnose without reading source.
+      const withScans = candidates.filter(c => c.count > 0)
+      if (withScans.length > 1) {
+        process.stderr.write(
+          `[unlighthouse-mcp] ${withScans.length} scan dirs found for ${site.hostname}; picking ${withScans[0].name} `
+          + `(${withScans[0].count} scans). Others: ${withScans.slice(1).map(c => `${c.name}=${c.count}`).join(', ')}\n`,
+        )
+      }
+      if (candidates[0] && candidates[0].count > 0) {
+        outputPath = join(siteDir, candidates[0].name)
+      }
+      else {
+        const cacheKey = objectHash({ ...config, version }).substring(0, 4)
+        outputPath = join(siteDir, cacheKey)
+      }
+    }
+    else {
+      const cacheKey = objectHash({ ...config, version }).substring(0, 4)
+      outputPath = join(siteDir, cacheKey)
+    }
+  }
+  fs.ensureDirSync(outputPath)
+  // Diagnostic to stderr (stdout is the JSON-RPC channel and must stay clean).
+  process.stderr.write(`[unlighthouse-mcp] outputPath=${outputPath}\n`)
+
+  const sqliteDb = new Database(join(outputPath, 'db.sqlite'))
+  // Idempotent migration: `CREATE TABLE IF NOT EXISTS` is safe to re-run.
+  // Bare `ALTER TABLE ADD COLUMN` errors with "duplicate column name" on
+  // second pass — swallow that one; surface everything else as a warning.
+  for (const stmt of INIT_SQL_STATEMENTS) {
+    try { sqliteDb.exec(stmt) }
+    catch (err) {
+      const msg = (err as Error).message
+      if (!/duplicate column name/i.test(msg))
+        logger.warn?.(`Migration stmt skipped: ${msg}`)
+    }
+  }
+  const drizzleDb = drizzle(sqliteDb)
+  const drizzleAdapter = drizzleStorage({
+    driver: drizzleDb,
+    logger: (logger as any).withTag('storage/drizzle'),
+  })
+  const storage = createStorage({
+    rows: { ...drizzleAdapter, db: drizzleAdapter.db },
+    blobs: unstorageBlobs({
+      driver: fsDriver({ base: join(outputPath, 'blobs') }),
+    }),
+  })
+
   const auditor = resolveAuditor({ config, logger })
   const crawler = crawleeCrawler({ logger: logger.withTag('crawler/crawlee') as never })
   const seeds = fuseSeeds([

--- a/packages/unlighthouse/src/cli/mcp.ts
+++ b/packages/unlighthouse/src/cli/mcp.ts
@@ -21,12 +21,11 @@ import { createConsola } from 'consola'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import fs from 'fs-extra'
 import { isAbsolute, join, resolve } from 'node:path'
-import objectHash from 'object-hash'
 import fsDriver from 'unstorage/drivers/fs'
 import { version } from '../../package.json'
 import { resolveAuditor } from '../auditor'
 import { resolveConfig } from '../config/resolve'
-import { normaliseHost } from '../util'
+import { computeConfigCacheKey, normaliseHost } from '../util'
 
 function resolveManualUrls(urls: UnlighthouseConfig['urls']): string[] | (() => string[] | Promise<string[]>) {
   if (typeof urls === 'function') {
@@ -45,8 +44,8 @@ function resolveManualUrls(urls: UnlighthouseConfig['urls']): string[] | (() => 
 // Throws via process.exit on malformed input — `unlighthouse-mcp --site` with
 // no value used to silently land on the bare outputPath and return an empty
 // history, which is much harder to diagnose than a "missing value" error.
-function parseFlags(argv: string[]): { site?: string, root?: string } {
-  const out: { site?: string, root?: string } = {}
+function parseFlags(argv: string[]): { site?: string, root?: string, debug?: boolean } {
+  const out: { site?: string, root?: string, debug?: boolean } = {}
   const needsValue = (name: string, next: string | undefined): string => {
     if (next == null || next.startsWith('--') || next.startsWith('-')) {
       process.stderr.write(`[unlighthouse-mcp] missing value for ${name}\n`)
@@ -78,8 +77,20 @@ function parseFlags(argv: string[]): { site?: string, root?: string } {
       }
       out.root = v
     }
+    else if (a === '--debug' || a === '-d') {
+      out.debug = true
+    }
   }
   return out
+}
+
+// Module-level flag so the discovery helpers (which are pure but emit
+// diagnostics) can stay quiet without threading a logger through every call.
+// Set once during boot from --debug; never reassigned at runtime.
+let debugMode = false
+function diag(msg: string): void {
+  if (debugMode)
+    process.stderr.write(msg)
 }
 
 // Resolve --root to an absolute path under CWD. Prevents `--root ../../../`
@@ -96,8 +107,54 @@ function sanitiseRoot(raw: string): string {
   return abs
 }
 
+// Count `scans` rows in a sqlite DB. Opens readonly, returns 0 on any error
+// (table missing, locked, malformed). Used for both site-level (--site given)
+// and root-level (no --site) discovery scoring.
+function countScans(dbPath: string): number {
+  let db: InstanceType<typeof Database> | null = null
+  try {
+    db = new Database(dbPath, { readonly: true })
+    return (db.prepare('SELECT count(*) AS c FROM scans').get() as { c: number }).c
+  }
+  catch {
+    return 0
+  }
+  finally {
+    db?.close()
+  }
+}
+
+// For a given site directory, rank its <cacheKey> subdirs by scan count
+// (mtime tiebreak), return the path of the winner. If no subdir has scans,
+// mint a fresh cacheKey dir so future writes land somewhere structured.
+function pickScanDir(parent: string, hostname: string, config: unknown, version: string): string {
+  const siteDir = join(parent, hostname)
+  if (!fs.existsSync(siteDir))
+    return join(siteDir, computeConfigCacheKey(config, version))
+  const candidates = fs.readdirSync(siteDir)
+    .map((name) => {
+      const dbPath = join(siteDir, name, 'db.sqlite')
+      if (!fs.existsSync(dbPath))
+        return null
+      return { name, mtime: fs.statSync(join(siteDir, name)).mtimeMs, count: countScans(dbPath) }
+    })
+    .filter((e): e is { name: string, mtime: number, count: number } => e !== null)
+    .sort((a, b) => (b.count - a.count) || (b.mtime - a.mtime))
+  const withScans = candidates.filter(c => c.count > 0)
+  if (withScans.length > 1) {
+    diag(
+      `[unlighthouse-mcp] ${withScans.length} scan dirs found for ${hostname}; picking ${withScans[0].name} `
+      + `(${withScans[0].count} scans). Others: ${withScans.slice(1).map(c => `${c.name}=${c.count}`).join(', ')}\n`,
+    )
+  }
+  if (candidates[0] && candidates[0].count > 0)
+    return join(siteDir, candidates[0].name)
+  return join(siteDir, computeConfigCacheKey(config, version))
+}
+
 export async function runMcp(): Promise<void> {
   const flags = parseFlags(process.argv.slice(2))
+  debugMode = flags.debug === true
   const rootDir = flags.root ? sanitiseRoot(flags.root) : undefined
   const { config } = await resolveConfig({
     overrides: flags.site ? { site: flags.site } : undefined,
@@ -106,70 +163,71 @@ export async function runMcp(): Promise<void> {
 
   // D-018: host owns the concrete consola; tagged children pass into each
   // adapter. MCP routes consola → stderr only (stdout is the JSON-RPC channel).
-  const logger = createConsola({ defaults: { level: 1 } }).withTag('unlighthouse-mcp')
+  // --debug raises consola to verbose so the user sees migration / drizzle /
+  // storage chatter alongside the discover diagnostics.
+  const logger = createConsola({ defaults: { level: debugMode ? 4 : 1 } }).withTag('unlighthouse-mcp')
 
   // Resolve the on-disk scan directory. The CLI writes to
   // `.unlighthouse/<hostname>/<configCacheKey>/` where `configCacheKey` is a
   // 4-char hash of the *raw* userConfig at scan time. Computing the same hash
-  // from MCP's resolved config doesn't generally match (different layering:
-  // c12 + flags + defaults), so we discover instead — pick the subdir whose
-  // `scans` table has the most rows, breaking ties by mtime. If none exists,
-  // mint a fresh hash dir so future writes don't pollute the site root.
+  // from MCP's resolved config doesn't always match (c12 layering / defaults
+  // differ), so we discover instead — pick the subdir whose `scans` table has
+  // the most rows, breaking ties by mtime. If none exists, mint a fresh hash
+  // dir so future writes don't pollute the site root.
+  //
+  // When --site is absent, walk `.unlighthouse/<*>/` to find any hostname with
+  // scans on disk. The agent gets to enumerate sites without the user having
+  // to know the URL in advance.
   let outputPath = config.outputPath as string
   if (config.site) {
     const site = normaliseHost(config.site)
-    const siteDir = join(outputPath, site.hostname.replace(':', '꞉'))
-    if (fs.existsSync(siteDir)) {
-      const candidates = fs.readdirSync(siteDir)
-        .map((name) => {
-          const dbPath = join(siteDir, name, 'db.sqlite')
-          if (!fs.existsSync(dbPath))
-            return null
-          // Open readonly to probe the scans table. The `scans` SELECT can
-          // throw if the table doesn't exist (malformed/uninitialised DB);
-          // wrap close() in `finally` so the file descriptor is always
-          // released — better-sqlite3 doesn't auto-close on GC.
-          let count = 0
-          let db: InstanceType<typeof Database> | null = null
-          try {
-            db = new Database(dbPath, { readonly: true })
-            count = (db.prepare('SELECT count(*) AS c FROM scans').get() as { c: number }).c
+    outputPath = pickScanDir(outputPath, site.hostname.replace(':', '꞉'), config, version)
+  }
+  else {
+    const rootDir = outputPath
+    if (fs.existsSync(rootDir)) {
+      const hostDirs = fs.readdirSync(rootDir)
+        .filter(name => fs.statSync(join(rootDir, name)).isDirectory())
+        .map((hostname) => {
+          // Score each hostname by total scans across all <cacheKey> subdirs.
+          const hostDir = join(rootDir, hostname)
+          let total = 0
+          let mtime = 0
+          for (const sub of fs.readdirSync(hostDir)) {
+            const dbPath = join(hostDir, sub, 'db.sqlite')
+            if (!fs.existsSync(dbPath))
+              continue
+            const c = countScans(dbPath)
+            total += c
+            const m = fs.statSync(join(hostDir, sub)).mtimeMs
+            if (m > mtime)
+              mtime = m
           }
-          catch {}
-          finally {
-            db?.close()
-          }
-          return { name, mtime: fs.statSync(join(siteDir, name)).mtimeMs, count }
+          return { hostname, total, mtime }
         })
-        .filter((e): e is { name: string, mtime: number, count: number } => e !== null)
-        .sort((a, b) => (b.count - a.count) || (b.mtime - a.mtime))
-      // Surface ambiguity: if more than one candidate dir holds scans, the
-      // "most rows wins" heuristic might route to the wrong config variant
-      // (e.g. mobile vs desktop ran under different cacheKeys). Emit a
-      // stderr line so users can diagnose without reading source.
-      const withScans = candidates.filter(c => c.count > 0)
-      if (withScans.length > 1) {
-        process.stderr.write(
-          `[unlighthouse-mcp] ${withScans.length} scan dirs found for ${site.hostname}; picking ${withScans[0].name} `
-          + `(${withScans[0].count} scans). Others: ${withScans.slice(1).map(c => `${c.name}=${c.count}`).join(', ')}\n`,
-        )
+        .filter(h => h.total > 0)
+        .sort((a, b) => (b.total - a.total) || (b.mtime - a.mtime))
+      if (hostDirs.length > 0) {
+        const pick = hostDirs[0]
+        if (hostDirs.length > 1) {
+          diag(
+            `[unlighthouse-mcp] no --site provided; ${hostDirs.length} sites have scans on disk; picking ${pick.hostname} `
+            + `(${pick.total} scans). Others: ${hostDirs.slice(1).map(h => `${h.hostname}=${h.total}`).join(', ')}\n`,
+          )
+        }
+        else {
+          diag(`[unlighthouse-mcp] no --site provided; defaulting to ${pick.hostname} (${pick.total} scans)\n`)
+        }
+        outputPath = pickScanDir(rootDir, pick.hostname, config, version)
       }
-      if (candidates[0] && candidates[0].count > 0) {
-        outputPath = join(siteDir, candidates[0].name)
-      }
-      else {
-        const cacheKey = objectHash({ ...config, version }).substring(0, 4)
-        outputPath = join(siteDir, cacheKey)
-      }
-    }
-    else {
-      const cacheKey = objectHash({ ...config, version }).substring(0, 4)
-      outputPath = join(siteDir, cacheKey)
+      // No scans anywhere → leave outputPath at the bare root and history
+      // will be empty. Better than guessing a hostname.
     }
   }
   fs.ensureDirSync(outputPath)
   // Diagnostic to stderr (stdout is the JSON-RPC channel and must stay clean).
-  process.stderr.write(`[unlighthouse-mcp] outputPath=${outputPath}\n`)
+  // Gated by --debug so production agents don't see internal paths by default.
+  diag(`[unlighthouse-mcp] outputPath=${outputPath}\n`)
 
   const sqliteDb = new Database(join(outputPath, 'db.sqlite'))
   // Idempotent migration: `CREATE TABLE IF NOT EXISTS` is safe to re-run.

--- a/packages/unlighthouse/src/host.ts
+++ b/packages/unlighthouse/src/host.ts
@@ -27,7 +27,6 @@ import { defu } from 'defu'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import fs from 'fs-extra'
 import { createCommonJS, resolvePath } from 'mlly'
-import objectHash from 'object-hash'
 import { joinURL } from 'ufo'
 import fsDriver from 'unstorage/drivers/fs'
 import { version } from '../package.json'
@@ -38,7 +37,7 @@ import { createSitesStore } from './data/sites'
 import { resolveUserConfig } from './resolveConfig'
 import { mountServer } from './server'
 import { createServerHooks } from './server-hooks'
-import { normaliseHost } from './util'
+import { computeConfigCacheKey, normaliseHost } from './util'
 
 /**
  * Behavior knobs supplied by the entry preset (cli, ci, integration).
@@ -126,7 +125,7 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
     )
   }
 
-  rs.configCacheKey = objectHash({ ...userConfig, version }).substring(0, 4)
+  rs.configCacheKey = computeConfigCacheKey(userConfig, version)
 
   const resolvedConfig = await resolveUserConfig(userConfig, logger)
 

--- a/packages/unlighthouse/src/util.ts
+++ b/packages/unlighthouse/src/util.ts
@@ -4,6 +4,7 @@ import { joinURL, withLeadingSlash, withTrailingSlash } from 'ufo'
 
 export { hashPathName, sanitiseUrlForFilePath, trimSlashes }
 export { createAxiosInstance, fetchUrlRaw, ReportArtifacts } from '@unlighthouse/core/util/fetch'
+export { computeConfigCacheKey } from './util/config-key'
 
 /** Ensures slashes on both sides of a string. */
 export const withSlashes = (s: string) => withLeadingSlash(withTrailingSlash(s)) || '/'

--- a/packages/unlighthouse/src/util/config-key.ts
+++ b/packages/unlighthouse/src/util/config-key.ts
@@ -1,0 +1,18 @@
+// Shared helper for the on-disk scan directory hash.
+//
+// The CLI host writes scans under `.unlighthouse/<hostname>/<configCacheKey>/`
+// where `configCacheKey` is a 4-char `object-hash` of the userConfig plus the
+// package version. Lifting the call into one function ensures the algorithm
+// stays consistent — if it ever needs to change (different hash length,
+// different version-mixing strategy), there's a single site to update.
+//
+// Note: the CLI hashes its *raw* userConfig (pre-c12 layering); MCP hashes
+// the resolved config it has on hand. Those don't always agree, so MCP's
+// auto-discover routine in cli/mcp.ts still has to scan the filesystem as a
+// fallback. Unifying the input contract is a separate, larger refactor.
+
+import objectHash from 'object-hash'
+
+export function computeConfigCacheKey(userConfig: unknown, version: string): string {
+  return objectHash({ ...(userConfig as object), version }).substring(0, 4)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.2
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@4.4.3)
       better-sqlite3:
         specifier: catalog:dependencies
         version: 12.10.0
@@ -8922,6 +8925,9 @@ packages:
   third-party-web@0.29.0:
     resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
 
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
+
   three@0.135.0:
     resolution: {integrity: sha512-kuEpuuxRzLv0MDsXai9huCxOSQPZ4vje6y0gn80SRmQvgz6/+rI0NAvCRAw56zYaWKMGMfqKWsxF9Qa2Z9xymQ==}
 
@@ -12141,7 +12147,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.64':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -19040,6 +19046,8 @@ snapshots:
       any-promise: 1.3.0
 
   third-party-web@0.29.0: {}
+
+  third-party-web@0.29.2: {}
 
   three@0.135.0: {}
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,0 +1,157 @@
+// MCP projection + handler routing — in-memory client/server transport pair.
+//
+// What we're guarding against:
+//   1. A command's `mcp.hidden` getting stripped (the noisy/dangerous tool
+//      starts being advertised to agents again — see PR #315).
+//   2. The pack handler regressing on the cache hit/miss/refresh cycle that
+//      PR #314 shipped.
+//   3. The pack tool descriptions losing the agent-friendly explanation —
+//      LLMs derive call sequencing from these strings, so silent edits
+//      break behaviour even when types still match.
+//
+// We don't spawn a child process / stdio binary here; that path is exercised
+// by the bin shim itself. The in-memory transport lets us assert the
+// projection layer in isolation in well under a second.
+
+import type { HandlerCtx } from '@unlighthouse/core/api/handlers'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { commands } from '@unlighthouse/contracts'
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createHandlers } from '@unlighthouse/core/api/handlers'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { createMcpServer } from '@unlighthouse/mcp'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+let client: Client
+let scanId: string
+
+beforeAll(async () => {
+  // Real core/storage stack, mocked auditor — gives us a writable scan and
+  // a working pack pipeline without hitting Chrome or the network.
+  const storage = memoryStorage()
+  const auditor = createMockAuditor()
+  const core = createUnlighthouseCore({
+    config: { site: 'http://localhost' } as never,
+    auditor,
+    seeds: manualSeeds({ urls: ['http://localhost/'] }),
+    crawler: parallelMapCrawler({ concurrency: 1 }),
+    storage,
+  })
+  const ctx: HandlerCtx = {
+    core,
+    auditor,
+    storage,
+    config: { site: 'http://localhost' } as never,
+    version: 'test',
+  }
+
+  // Seed one finished scan so pack.run has data to reconcile against.
+  const handlers = createHandlers()
+  const startResult = await (handlers['scan.start'] as { run: (i: unknown, c: HandlerCtx) => Promise<{ scanId: string }> }).run(
+    { site: 'http://localhost' },
+    ctx,
+  )
+  scanId = startResult.scanId
+  // Wait for the scan to drain — parallel-map crawler with concurrency 1 and
+  // one seed completes synchronously inside core.run; poll just in case.
+  await new Promise(r => setTimeout(r, 50))
+
+  // Wire the MCP server and connect an in-memory client to it.
+  const server = createMcpServer({ handlers, ctx, identity: { name: 'test', version: 'test' } })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  client = new Client({ name: 'test-client', version: 'test' }, { capabilities: {} })
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ])
+})
+
+describe('MCP tool surface', () => {
+  it('does not advertise destructive / orchestration commands', async () => {
+    const { tools } = await client.listTools()
+    const names = new Set(tools.map(t => t.name))
+
+    // Curated hidden-set (PR #315). Listed by MCP tool name (dots → underscores).
+    const mustBeHidden = [
+      'scan_cancel',
+      'scan_pause',
+      'scan_resume',
+      'scan_delete',
+      'scan_current',
+      'scan_rescanAll',
+      'route_rescan',
+      'history_delete',
+      'history_rescan',
+      'sites_create',
+      'sites_delete',
+      'auditors_test',
+      'events_subscribe',
+      'events_tail',
+    ]
+    for (const hidden of mustBeHidden)
+      expect(names.has(hidden), `${hidden} should be hidden from MCP`).toBe(false)
+  })
+
+  it('advertises the pack tools', async () => {
+    const { tools } = await client.listTools()
+    const names = new Set(tools.map(t => t.name))
+    expect(names.has('pack_run')).toBe(true)
+    expect(names.has('pack_list')).toBe(true)
+    expect(names.has('scan_summary')).toBe(true)
+  })
+
+  it('pack tool descriptions spell out the agent calling sequence', async () => {
+    // These descriptions are LLM-facing. If someone shortens them back to the
+    // pre-PR one-liners ("Execute a registered pack against a scan"), agents
+    // lose the workflow hint. Guard with substring assertions on the bits
+    // that carry the workflow signal.
+    const { tools } = await client.listTools()
+    const packRun = tools.find(t => t.name === 'pack_run')
+    expect(packRun?.description).toMatch(/pack\.list/i)
+    expect(packRun?.description).toMatch(/history\.list/i)
+    const packList = tools.find(t => t.name === 'pack_list')
+    expect(packList?.description).toMatch(/overview/i)
+    expect(packList?.description).toMatch(/images/i)
+  })
+
+  it('tool count equals (visible registry commands)', async () => {
+    // Sanity check the projection isn't accidentally listing hidden commands.
+    const visible = Object.values(commands).filter(c => !c.mcp?.hidden).length
+    const { tools } = await client.listTools()
+    expect(tools.length).toBe(visible)
+  })
+})
+
+describe('MCP pack.run caching', () => {
+  it('reports cache miss → hit → refresh-miss', async () => {
+    // First call — fresh reconcile.
+    const r1 = await client.callTool({
+      name: 'pack_run',
+      arguments: { scanId, pack: 'overview' },
+    })
+    const p1 = JSON.parse((r1.content as Array<{ text: string }>)[0].text)
+    expect(p1.cache).toBe('miss')
+
+    // Second call — served from cache, same startedAt as the first.
+    const r2 = await client.callTool({
+      name: 'pack_run',
+      arguments: { scanId, pack: 'overview' },
+    })
+    const p2 = JSON.parse((r2.content as Array<{ text: string }>)[0].text)
+    expect(p2.cache).toBe('hit')
+    expect(p2.startedAt).toBe(p1.startedAt)
+
+    // Force refresh — new reconcile, new startedAt.
+    const r3 = await client.callTool({
+      name: 'pack_run',
+      arguments: { scanId, pack: 'overview', refresh: true },
+    })
+    const p3 = JSON.parse((r3.content as Array<{ text: string }>)[0].text)
+    expect(p3.cache).toBe('miss')
+    expect(p3.startedAt).not.toBe(p1.startedAt)
+  })
+})


### PR DESCRIPTION
## What it does

`unlighthouse-mcp` used to boot with `memoryStorage` — agents connected to it saw an empty world. Now it reads the same SQLite + blob layout the CLI writes (`.unlighthouse/<host>/<key>/`), curates the tool surface for agent use, and ships a regression test so we don't lose this.

## What's in it

**Real storage (commit 1):**
- drizzle + unstorage stack pointed at the resolved outputPath
- Auto-discover picks the `<cacheKey>` subdir with the most scans (mtime tiebreak), since CLI and MCP compute the hash from different config layers
- `--site` and `--root` flag parsing (hardened — see below)

**Curated tool surface (commit 1):**
- `mcp.hidden: true` on 14 commands: scan.cancel/pause/resume/delete/current/rescanAll, route.rescan, history.delete/rescan, sites.create/delete, auditors.test, events.subscribe/tail
- Rationale per command (destructive, UI-flow-only, SSRF, untested streaming)
- pack.run / pack.list / scan.summary descriptions rewritten to spell out the agent calling sequence — LLMs derive workflow from these strings

**Hardened flags + paths (commit 1):**
- `sanitiseRoot()` rejects `--root` values that escape CWD
- `parseFlags` errors out on trailing `--site` / `--root` with no value (instead of silently producing `undefined`)
- `db.close()` in a `finally` block — a malformed scans table no longer leaks a file descriptor

**Shared configCacheKey helper (commit 2):**
- Lifts the `objectHash({...userConfig, version}).substring(0,4)` call into `util/config-key.ts`; CLI and MCP both call it
- Auto-discover stays as a safety net for the input-shape mismatch

**Multi-site auto-discovery + --debug flag (commit 3):**
- When no `--site` is provided, MCP walks `.unlighthouse/<*>/` and defaults to the hostname with the most scans
- `--debug` / `-d` gates the `outputPath=...` and "N scan dirs found" stderr lines, and raises consola to verbose
- Default is silent on stderr (stdout JSON-RPC was already safe)

**Integration test (commit 4):**
- `test/mcp.test.ts` — in-memory client/server transport pair
- Asserts: hidden-command set stays hidden, pack tool descriptions keep their workflow hints, pack.run cache cycle (miss → hit → refresh-miss), total tool count matches the visible-registry count
- Adds `@modelcontextprotocol/sdk` to root devDeps so the test can resolve the client
- 5/5 tests, <400ms

## Smoke

Against the local harlanzw.com scan (16 entries, 3 cacheKey variants on disk):
- `tools/list` → 20 tools, all 14 hidden commands absent
- `history_list` returns 16 real scans (was `[]` before)
- `pack_run(overview)` cycle: `miss` → `hit` (same `startedAt`) → `refresh:true` → `miss` (new `startedAt`)
- `--site harlanzw.com` picks `191b/` (16 scans), logs `Others: 575f=4, 03e7=1`
- No-flag boot picks the same host, falls back gracefully when no scans exist

## Follow-ups (deliberately not in this PR)

- `scan.start` has no rate limit when called from MCP — agent can trigger a 5-minute Lighthouse run. UX call.
- Auto-discover's heuristic could be replaced once the configCacheKey input shapes are unified (CLI hashes raw userConfig, MCP hashes resolved).
- Subprocess (stdio bin) is implicitly tested by the shim but not asserted in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)