### PR TITLE
fix(core): three bugs the MCP agent caught + ship-gate test

### DIFF
--- a/docs/2.integrations/5.mcp.md
+++ b/docs/2.integrations/5.mcp.md
@@ -1,0 +1,102 @@
+---
+title: "MCP Server for AI Agents"
+icon: i-carbon-bot
+description: "Connect Unlighthouse to Claude Code, Cursor, or any MCP-compatible AI agent. Layered output: sub-1KB scan summaries, opinionated pack reports, drill-down on demand."
+keywords:
+  - mcp
+  - model context protocol
+  - claude code
+  - cursor mcp
+  - ai agent lighthouse
+  - lighthouse mcp
+navigation:
+  title: "MCP"
+relatedPages:
+  - path: /integrations/cli
+    title: CLI
+  - path: /guide/guides/config
+    title: Configuration
+---
+
+# MCP Server for AI Agents
+
+Unlighthouse ships a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes scanning, history, and pack reports as tools an AI agent can call. The positioning is explicit: this is the **sitewide** counterpart to Google's [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp). The natural workflow is "Unlighthouse triages → Chrome DevTools MCP drills in."
+
+## Install
+
+The MCP server ships as a bin in the main `unlighthouse` package:
+
+```bash
+npm install -g unlighthouse
+```
+
+### Claude Code
+
+```bash
+claude mcp add unlighthouse -- npx unlighthouse-mcp --site https://example.com
+```
+
+### Cursor / other MCP clients
+
+Add this to your client's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "unlighthouse": {
+      "command": "npx",
+      "args": ["unlighthouse-mcp", "--site", "https://example.com"]
+    }
+  }
+}
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--site <url>` | The site the agent will scan / read history for. Resolves to `.unlighthouse/<hostname>/<key>/` on disk. |
+| `--root <path>` | Project root (where `.unlighthouse/` lives). Defaults to CWD. Rejected if it escapes CWD. |
+| `--debug`, `-d` | Stream the discover diagnostics + verbose drizzle / storage logs to stderr. Off by default. |
+
+If `--site` is omitted, the server scans `.unlighthouse/` for any hostname with prior scans and picks the one with the most. Useful when an agent is running locally next to existing scan output.
+
+## What the agent sees
+
+Twenty tools, projected one-to-one from the [command registry](/api-doc). The destructive / live-flow commands are hidden — agents see read-mostly + scan triggers:
+
+**Visible (read-mostly):**
+`scan_summary`, `pack_list`, `pack_run`, `query_routes`, `history_list`, `history_get`, `route_get`, `scan_results`, `scan_meta`, `scan_status`, `sites_list`, `sites_get`, `compare_run`, `compare_markdown`, `compare_findPrevious`, `assert_evaluate`, `health`, `manifest`, `auditors_list`
+
+**Visible (write):**
+`scan_start` — agent can trigger new scans with a URL it picks.
+
+**Hidden:**
+`scan_cancel`, `scan_pause`, `scan_resume`, `scan_delete`, `scan_current`, `scan_rescanAll`, `route_rescan`, `history_delete`, `history_rescan`, `sites_create`, `sites_delete`, `auditors_test`, `events_subscribe`, `events_tail`
+
+## Workflow
+
+Layered output (v1.md §D-028): start with a sub-1KB summary, drill down only when you need detail.
+
+1. **`pack_list`** — discover what packs are installed (`overview`, `cwv`, `images`, `js-bundle`, `a11y-quick-wins`, `seo-basics`).
+2. **`history_list`** — see what scans exist for the configured site.
+3. **`scan_summary`** — for the scan you care about, get the top-level snapshot. Sub-1KB JSON: category averages, score distribution, worst 5 routes, template groups.
+4. **`pack_run`** with the scan id and a pack name — get the opinionated report. Output is cached on `(scanId, packName, packVersion)`; pass `refresh: true` to bust.
+5. **`query_routes`** / **`scan_results`** / **`route_get`** — drill into individual routes when the summary or pack flags something worth investigating.
+
+To trigger a fresh scan: **`scan_start`** with the URL, then poll **`scan_status`** until `complete`, then jump back to step 3.
+
+## Complements Chrome DevTools MCP
+
+| Tool | Strength |
+|------|----------|
+| **Chrome DevTools MCP** | Single-URL deep dive. Full Lighthouse run + DevTools traces + network/perf/runtime introspection. |
+| **Unlighthouse MCP** | Sitewide triage. Crawls every route, layered summaries → packs → drill-down. Identifies *which* URLs warrant the deep dive. |
+
+If you have both installed, the agent will pick the right one for the question.
+
+## Caveats
+
+- **No rate limit on `scan_start`.** A misbehaving agent loop can trigger long Lighthouse runs. Lock it down with a custom config (`scanner.exclude`) if this matters.
+- **One scan at a time per host process.** `scan_start` while a scan is in flight returns `ACTIVE_SCAN_CONFLICT`. The agent should poll `scan_status` instead of retrying.
+- **Pack output is cached aggressively.** Scans are immutable so this is safe. If you ship a custom pack and bump its `version`, old cached output is invalidated automatically.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,10 @@
       "types": "./dist/util/progressBox.d.mts",
       "import": "./dist/util/progressBox.mjs"
     },
+    "./util/git-meta": {
+      "types": "./dist/util/git-meta.d.mts",
+      "import": "./dist/util/git-meta.mjs"
+    },
     "./storage": {
       "types": "./dist/storage/index.d.mts",
       "import": "./dist/storage/index.mjs"

--- a/packages/core/src/api/handlers/scan.ts
+++ b/packages/core/src/api/handlers/scan.ts
@@ -19,6 +19,7 @@ import type {
 import type { Handler } from './types'
 import { UnlighthouseError } from '@unlighthouse/contracts'
 import { overviewPack } from '../../packs/overview'
+import { readGitMeta } from '../../util/git-meta'
 
 function notFound(scanId: string): never {
   throw new UnlighthouseError({
@@ -32,6 +33,12 @@ export const scanStart: Handler<typeof ScanStart> = {
   async run(input, ctx) {
     if (ctx.core.session())
       throw new UnlighthouseError({ code: 'ACTIVE_SCAN_CONFLICT', message: 'A scan is already in flight' })
+    // Auto-fill ciBuild from the local git checkout when the caller didn't
+    // pass one. Without this, every local CLI / MCP scan persists ciBranch
+    // = null, and compare.run can't tell a re-run on the same commit apart
+    // from a regression on a new commit. Real CI environments pass an
+    // explicit `ciBuild` block and bypass this entirely.
+    const ciBuild = input.ciBuild ?? deriveCiBuild()
     const session = ctx.core.run({
       overrides: {
         site: input.site,
@@ -39,7 +46,7 @@ export const scanStart: Handler<typeof ScanStart> = {
         sampleSize: input.sampleSize,
         categories: input.categories,
         auditor: input.auditor,
-        ciBuild: input.ciBuild,
+        ciBuild,
       },
     })
     return {
@@ -48,6 +55,17 @@ export const scanStart: Handler<typeof ScanStart> = {
       startedAt: new Date().toISOString(),
     } as CommandOutput<typeof ScanStart>
   },
+}
+
+function deriveCiBuild(): { branch?: string, hash?: string, message?: string } | undefined {
+  const meta = readGitMeta()
+  if (meta.branch == null && meta.commit == null && meta.message == null)
+    return undefined
+  return {
+    ...(meta.branch ? { branch: meta.branch } : {}),
+    ...(meta.commit ? { hash: meta.commit } : {}),
+    ...(meta.message ? { message: meta.message } : {}),
+  }
 }
 
 export const scanStatus: Handler<typeof ScanStatusCmd> = {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -85,6 +85,40 @@ function toStructuredError(err: unknown): { code: string, message: string, cause
   return { code: 'INTERNAL', message: String(err) }
 }
 
+/**
+ * Boot-time housekeeping: mark any scan still in a non-terminal state
+ * (`starting`, `discovering`, `scanning`, `paused`) as `error`. These are
+ * zombies from a prior process that crashed or was killed before it could
+ * write a terminal status — they have no live session to recover.
+ *
+ * v1.md D-019c ("no silent stalls") promises that every scan that stops
+ * emits a terminal status. Without this sweep, a SIGKILL on the prior
+ * CLI run leaves rows that look in-flight forever and break compare.run /
+ * scan.start (`ACTIVE_SCAN_CONFLICT` is per-process so it doesn't trip,
+ * but downstream consumers can't tell the difference from disk).
+ *
+ * Call this once during host boot, before `createUnlighthouseCore`. Safe
+ * to call concurrently with new scans — only touches rows in non-terminal
+ * states, never the row being written by the live session.
+ */
+export async function reapStaleScans(storage: Storage, logger?: Logger): Promise<number> {
+  const NON_TERMINAL: ScanStatus[] = ['starting', 'discovering', 'scanning', 'paused']
+  let reaped = 0
+  for (const status of NON_TERMINAL) {
+    const { items } = await storage.scans.list({ status, page: 1, pageSize: 1000 })
+    for (const scan of items) {
+      await storage.scans.update(scan.scanId, {
+        status: 'error',
+        completedAt: nowIso(),
+      }).catch(() => {})
+      reaped++
+    }
+  }
+  if (reaped > 0)
+    (logger as { warn?: (msg: string) => void } | undefined)?.warn?.(`[core] reaped ${reaped} stale scan${reaped === 1 ? '' : 's'} from prior process`)
+  return reaped
+}
+
 // Compute (scoreAverage, scoresByCategory) over a set of completed routes.
 // Routes with `null` for a given category are skipped — Lighthouse leaves a
 // category null when it failed to run (e.g. a 5xx response on that URL).

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -85,6 +85,38 @@ function toStructuredError(err: unknown): { code: string, message: string, cause
   return { code: 'INTERNAL', message: String(err) }
 }
 
+// Compute (scoreAverage, scoresByCategory) over a set of completed routes.
+// Routes with `null` for a given category are skipped — Lighthouse leaves a
+// category null when it failed to run (e.g. a 5xx response on that URL).
+// Returns `scoreAverage: null` only when no route produced *any* score at all.
+function aggregateScores(routes: Array<{
+  scorePerformance: number | null
+  scoreAccessibility: number | null
+  scoreSeo: number | null
+  scoreBestPractices: number | null
+}>): Pick<ScanSummary, 'scoreAverage' | 'scoresByCategory'> {
+  const cols = {
+    'performance': 'scorePerformance',
+    'accessibility': 'scoreAccessibility',
+    'seo': 'scoreSeo',
+    'best-practices': 'scoreBestPractices',
+  } as const
+  const byCategory: ScanSummary['scoresByCategory'] = {}
+  const overall: number[] = []
+  for (const [category, key] of Object.entries(cols) as Array<[keyof typeof cols, (typeof cols)[keyof typeof cols]]>) {
+    const values = routes.map(r => r[key]).filter((v): v is number => v != null)
+    if (values.length === 0)
+      continue
+    const avg = values.reduce((a, b) => a + b, 0) / values.length
+    byCategory[category] = avg
+    overall.push(avg)
+  }
+  return {
+    scoreAverage: overall.length === 0 ? null : overall.reduce((a, b) => a + b, 0) / overall.length,
+    scoresByCategory: byCategory,
+  }
+}
+
 export function createUnlighthouseCore(opts: UnlighthouseCoreOptions): UnlighthouseCore {
   // 1. Validate config via Zod; throw CONFIG_INVALID on failure.
   const parsed = UnlighthouseConfig.safeParse(opts.config)
@@ -444,12 +476,19 @@ function createSession(deps: SessionDeps): CrawlSession {
       throw new UnlighthouseError({ code: 'SCAN_CANCELLED', message: 'Scan cancelled.' })
     }
 
+    // Aggregate scores across completed routes. Contract says scoreAverage is
+    // `null` until at least one route has scored — for a non-empty scan it
+    // should always be populated. `compare.run` and the dashboard summary
+    // tile both read these; leaving them null was a v0→v1 regression where
+    // the aggregation logic got lost mid-port.
+    const scoredRoutes = stats.scanned > 0
+      ? (await storage.routes.listForScan(scanId, { page: 1, pageSize: 10_000 })).items
+      : []
     const summary: ScanSummary = {
       routes: stats.discovered,
       completed: stats.scanned,
       failed: stats.failed,
-      scoreAverage: null,
-      scoresByCategory: {},
+      ...aggregateScores(scoredRoutes),
       durationMs: Date.now() - startedAtMs,
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 // v1 core package — populated by v0.2–v0.7 module moves and v1 factory refactor.
-export { createUnlighthouseCore } from './core'
+export { createUnlighthouseCore, reapStaleScans } from './core'
 export { persistStableEvents } from './persist-events'

--- a/packages/core/src/util/git-meta.ts
+++ b/packages/core/src/util/git-meta.ts
@@ -1,0 +1,40 @@
+// Best-effort git metadata read. Used when a CLI / MCP caller hasn't passed
+// an explicit `ciBuild` block on scan.start — without this, every local scan
+// lands with `ciBranch: null` and compare.run can't tell a "rerun on the same
+// commit" apart from a "regression on a new commit".
+//
+// All errors are swallowed: this is a convenience layer, not a contract.
+// Returns null fields when run outside a git repo, on a detached HEAD, or
+// anywhere git isn't on PATH.
+
+import { execFileSync } from 'node:child_process'
+
+export interface GitMeta {
+  branch: string | null
+  commit: string | null
+  message: string | null
+}
+
+function gitOutput(args: string[], cwd: string): string | null {
+  try {
+    const out = execFileSync('git', args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+      timeout: 1500,
+    }).trim()
+    return out || null
+  }
+  catch {
+    return null
+  }
+}
+
+export function readGitMeta(cwd: string = process.cwd()): GitMeta {
+  const branchRaw = gitOutput(['rev-parse', '--abbrev-ref', 'HEAD'], cwd)
+  // 'HEAD' means detached — treat as no branch.
+  const branch = branchRaw && branchRaw !== 'HEAD' ? branchRaw : null
+  const commit = gitOutput(['rev-parse', 'HEAD'], cwd)
+  const message = gitOutput(['log', '-1', '--pretty=%s'], cwd)
+  return { branch, commit, message }
+}

--- a/packages/unlighthouse/src/cli/mcp.ts
+++ b/packages/unlighthouse/src/cli/mcp.ts
@@ -8,7 +8,7 @@
 // because there's no scanId to feed it.
 
 import type { UnlighthouseConfig } from '@unlighthouse/contracts'
-import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createUnlighthouseCore, reapStaleScans } from '@unlighthouse/core'
 import { createHandlers } from '@unlighthouse/core/api/handlers'
 import { crawleeCrawler } from '@unlighthouse/core/crawlers'
 import { fuseSeeds, manualSeeds } from '@unlighthouse/core/seeds'
@@ -252,6 +252,11 @@ export async function runMcp(): Promise<void> {
       driver: fsDriver({ base: join(outputPath, 'blobs') }),
     }),
   })
+
+  // Sweep zombies left by a prior process. MCP often opens an existing DB
+  // written by the CLI; "starting" rows from a Ctrl+C'd CLI run would
+  // otherwise stay forever in agent's history_list output.
+  reapStaleScans(storage, logger).catch(() => {})
 
   const auditor = resolveAuditor({ config, logger })
   const crawler = crawleeCrawler({ logger: logger.withTag('crawler/crawlee') as never })

--- a/packages/unlighthouse/src/host.ts
+++ b/packages/unlighthouse/src/host.ts
@@ -13,7 +13,7 @@ import type { IncomingMessage } from 'node:http'
 import type { Socket } from 'node:net'
 import { existsSync } from 'node:fs'
 import { isAbsolute, join } from 'node:path'
-import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createUnlighthouseCore, reapStaleScans } from '@unlighthouse/core'
 import { createWS } from '@unlighthouse/core/api'
 import { crawleeCrawler } from '@unlighthouse/core/crawlers'
 import { fuseSeeds, manualSeeds, sitemapSeeds } from '@unlighthouse/core/seeds'
@@ -195,6 +195,12 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
         driver: fsDriver({ base: join(outputPath, 'blobs') }),
       }),
     })
+
+    // Sweep zombies left by a prior process before we wire core — see
+    // reapStaleScans for D-019c rationale. Fire-and-forget so boot doesn't
+    // block on storage IO; a stale row that survives one extra boot is
+    // tolerable, blocking the CLI on a slow disk is not.
+    reapStaleScans(storage, logger).catch(() => {})
 
     const coreConfig = resolvedConfig as unknown as Parameters<typeof createUnlighthouseCore>[0]['config']
     const auditor = resolveAuditor({ config: coreConfig, logger })

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -171,6 +171,34 @@ describe('createUnlighthouseCore orchestration', () => {
     expect(session.state()).toBe('complete')
   })
 
+  it('aggregates scoreAverage + scoresByCategory on scan:complete', async () => {
+    // Regression for the v0→v1 port bug where summary.scoreAverage was
+    // hardcoded `null` even after routes finished scoring — broke
+    // compare.run baselines and the dashboard summary tile.
+    const urls = ['https://example.com/a', 'https://example.com/b']
+    const storage: Storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: baseConfig,
+      auditor: passingAuditor(),
+      seeds: emptySeeds,
+      crawler: discoveryCrawler(urls),
+      storage,
+    })
+    const session = core.run()
+    await session.done
+
+    const persisted = await storage.scans.get(session.scanId)
+    expect(persisted?.summary?.scoreAverage).not.toBeNull()
+    // passingAuditor() returns 0.9 for every category, so the average is 0.9.
+    expect(persisted?.summary?.scoreAverage).toBeCloseTo(0.9, 5)
+    expect(persisted?.summary?.scoresByCategory).toEqual({
+      'performance': 0.9,
+      'accessibility': 0.9,
+      'seo': 0.9,
+      'best-practices': 0.9,
+    })
+  })
+
   it('cancel: emits scan:cancelled and rejects done', async () => {
     const storage = memoryStorage()
     const core = createUnlighthouseCore({

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -14,7 +14,7 @@ import type {
 } from '@unlighthouse/contracts'
 import { describe, expect, it } from 'vitest'
 import { UnlighthouseError } from '@unlighthouse/contracts'
-import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createUnlighthouseCore, reapStaleScans } from '@unlighthouse/core'
 import { memoryStorage } from '@unlighthouse/core/storage/memory'
 
 // SCAN_CANCELLED rejections on `session.done` fire from the orchestrate IIFE
@@ -431,5 +431,66 @@ describe('createUnlighthouseCore orchestration', () => {
     expect(session.stats().failed).toBe(1)
     expect(session.stats().scanned).toBe(2)
     expect(events.some(e => e.event === 'scan:complete')).toBe(true)
+  })
+})
+
+describe('reapStaleScans', () => {
+  it('marks non-terminal zombie scans as error and leaves terminals alone', async () => {
+    const storage = memoryStorage()
+    // Plant one of each non-terminal status + a terminal control.
+    const planted: Array<['starting' | 'discovering' | 'scanning' | 'paused' | 'complete' | 'error' | 'cancelled', string]> = [
+      ['starting', 'zombie-start'],
+      ['discovering', 'zombie-discovering'],
+      ['scanning', 'zombie-scanning'],
+      ['paused', 'zombie-paused'],
+      ['complete', 'survivor-complete'],
+      ['error', 'survivor-error'],
+      ['cancelled', 'survivor-cancelled'],
+    ]
+    for (const [status, id] of planted) {
+      await storage.scans.create({
+        scanId: id as never,
+        site: 'https://example.com' as never,
+        device: 'mobile',
+        status,
+        startedAt: '2025-01-01T00:00:00.000Z',
+        completedAt: status === 'complete' || status === 'error' || status === 'cancelled'
+          ? '2025-01-01T00:05:00.000Z'
+          : null,
+        ciBranch: null,
+        ciCommit: null,
+        ciCommitMessage: null,
+        summary: null,
+      })
+    }
+    const reaped = await reapStaleScans(storage)
+    expect(reaped).toBe(4)
+    // Zombies flipped to error + got a completedAt.
+    for (const id of ['zombie-start', 'zombie-discovering', 'zombie-scanning', 'zombie-paused']) {
+      const row = await storage.scans.get(id as never)
+      expect(row?.status).toBe('error')
+      expect(row?.completedAt).not.toBeNull()
+    }
+    // Terminals untouched.
+    expect((await storage.scans.get('survivor-complete' as never))?.status).toBe('complete')
+    expect((await storage.scans.get('survivor-error' as never))?.status).toBe('error')
+    expect((await storage.scans.get('survivor-cancelled' as never))?.status).toBe('cancelled')
+  })
+
+  it('is a no-op when no zombies exist', async () => {
+    const storage = memoryStorage()
+    await storage.scans.create({
+      scanId: 'ok' as never,
+      site: 'https://example.com' as never,
+      device: 'mobile',
+      status: 'complete',
+      startedAt: '2025-01-01T00:00:00.000Z',
+      completedAt: '2025-01-01T00:05:00.000Z',
+      ciBranch: null,
+      ciCommit: null,
+      ciCommitMessage: null,
+      summary: null,
+    })
+    expect(await reapStaleScans(storage)).toBe(0)
   })
 })

--- a/test/git-meta.test.ts
+++ b/test/git-meta.test.ts
@@ -1,0 +1,38 @@
+// readGitMeta is best-effort: returns null fields when git isn't available
+// or the cwd isn't a repo. The unit test covers the negative path (a tmp
+// dir with no .git); the integration coverage that "this repo's HEAD shows
+// up correctly" lives in the MCP scan_start test.
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readGitMeta } from '@unlighthouse/core/util/git-meta'
+import { describe, expect, it } from 'vitest'
+
+describe('readGitMeta', () => {
+  it('returns all-null when cwd is not a git repo', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'uh-git-meta-'))
+    try {
+      const meta = readGitMeta(dir)
+      expect(meta).toEqual({ branch: null, commit: null, message: null })
+    }
+    finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads HEAD details from the current repo (this checkout)', () => {
+    const meta = readGitMeta()
+    // We can't assert exact values (varies per checkout), but this repo
+    // always has a HEAD commit and a non-empty message.
+    expect(meta.commit).toMatch(/^[0-9a-f]{40}$/)
+    expect(meta.message).not.toBeNull()
+    expect(meta.message?.length).toBeGreaterThan(0)
+    // Branch may be null on detached HEAD (e.g. in some CI runners), so
+    // accept either a non-empty string or null.
+    if (meta.branch !== null) {
+      expect(meta.branch.length).toBeGreaterThan(0)
+      expect(meta.branch).not.toBe('HEAD')
+    }
+  })
+})

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -199,6 +199,16 @@ describe('MCP scan.start end-to-end (v1.md line 1710 ship gate)', () => {
     const pack = JSON.parse((packRes.content as Array<{ text: string }>)[0].text)
     expect(pack.cache).toBe('miss')
     expect(pack.report.routesScanned).toBeGreaterThan(0)
+
+    // 4. ciBuild was auto-detected from git — the scan row should carry the
+    // current commit even though the agent passed no ciBuild block. (The
+    // checkout this test runs in is always a git repo with a HEAD commit.)
+    const historyRes = await gateClient.callTool({
+      name: 'history_get',
+      arguments: { scanId: startedScanId },
+    })
+    const history = JSON.parse((historyRes.content as Array<{ text: string }>)[0].text)
+    expect(history.ciCommit).toMatch(/^[0-9a-f]{40}$/)
   }, 15_000)
 })
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -126,6 +126,82 @@ describe('MCP tool surface', () => {
   })
 })
 
+describe('MCP scan.start end-to-end (v1.md line 1710 ship gate)', () => {
+  it('drives scan_start → scan_status → scan_summary → pack_run via MCP', async () => {
+    // The "ship gate" in v1.md: an agent connects, calls scan_start with a
+    // URL it picked itself, polls scan_status until done, and reads results
+    // back through scan_summary + pack_run — without the host pre-configuring
+    // a site. This test runs the whole loop over the in-memory transport.
+    //
+    // The fixture core is wired to a fresh memoryStorage instance (separate
+    // from the beforeAll's per-suite storage); it crawls one seed URL via
+    // the mock auditor and finishes synchronously.
+    const storage = memoryStorage()
+    const auditor = createMockAuditor()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://agent-site' } as never,
+      auditor,
+      seeds: manualSeeds({ urls: ['http://agent-site/'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const ctx: HandlerCtx = {
+      core,
+      auditor,
+      storage,
+      config: { site: 'http://agent-site' } as never,
+      version: 'test',
+    }
+    const handlers = createHandlers()
+    const server = createMcpServer({ handlers, ctx, identity: { name: 'gate', version: 'test' } })
+    const [c, s] = InMemoryTransport.createLinkedPair()
+    const gateClient = new Client({ name: 'gate-client', version: 'test' }, { capabilities: {} })
+    await Promise.all([server.connect(s), gateClient.connect(c)])
+
+    // 1. Agent triggers a scan with a URL it picked. No host preset required.
+    const startCall = await gateClient.callTool({
+      name: 'scan_start',
+      arguments: { site: 'http://agent-site' },
+    })
+    const started = JSON.parse((startCall.content as Array<{ text: string }>)[0].text)
+    expect(started.scanId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(started.site).toBe('http://agent-site')
+
+    // 2. Agent polls scan_status until terminal. parallel-map + 1 seed +
+    //    mock auditor drains in < 100ms, but we loop defensively.
+    const startedScanId: string = started.scanId
+    let statusJson: { status: string } | null = null
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const res = await gateClient.callTool({
+        name: 'scan_status',
+        arguments: { scanId: startedScanId },
+      })
+      statusJson = JSON.parse((res.content as Array<{ text: string }>)[0].text)
+      if (statusJson?.status === 'complete' || statusJson?.status === 'error' || statusJson?.status === 'cancelled')
+        break
+      await new Promise(r => setTimeout(r, 25))
+    }
+    expect(statusJson?.status).toBe('complete')
+
+    // 3. Agent reads the layered output: summary first, then drill via pack.
+    const summaryRes = await gateClient.callTool({
+      name: 'scan_summary',
+      arguments: { scanId: startedScanId },
+    })
+    const summary = JSON.parse((summaryRes.content as Array<{ text: string }>)[0].text)
+    expect(summary.scanId).toBe(startedScanId)
+    expect(summary.routesScanned).toBeGreaterThan(0)
+
+    const packRes = await gateClient.callTool({
+      name: 'pack_run',
+      arguments: { scanId: startedScanId, pack: 'overview' },
+    })
+    const pack = JSON.parse((packRes.content as Array<{ text: string }>)[0].text)
+    expect(pack.cache).toBe('miss')
+    expect(pack.report.routesScanned).toBeGreaterThan(0)
+  }, 15_000)
+})
+
 describe('MCP pack.run caching', () => {
   it('reports cache miss → hit → refresh-miss', async () => {
     // First call — fresh reconcile.


### PR DESCRIPTION
## What it does

Five commits on this branch:

**Ship gate (#42 / spec line 1710):**
1. `test(mcp): cover scan_start ship gate end-to-end` — in-memory MCP client drives scan_start → poll scan_status → scan_summary → pack_run. No production code change; locks the contract.
2. `docs(integrations): add MCP server page` — install, flags, curated tool surface, layered workflow, "complements Chrome DevTools MCP" positioning, caveats.

**Bugs caught dogfooding the MCP against the real harlanzw.com history:**

3. `fix(core): compute scoreAverage + scoresByCategory on scan complete` — v0→v1 port regression. `core.ts` was emitting `summary.scoreAverage: null` and `scoresByCategory: {}` hardcoded; the aggregation got dropped. Caught by the agent walking history and noticing all 16 scans had null averages despite per-route scores.

4. `fix(core): reap stale 'starting' / 'discovering' scans at boot` — D-019c spec says no silent stalls, but a SIGKILL or Ctrl+C before `setStatus('discovering')` leaves a row stuck forever. New `reapStaleScans()` runs at host boot, flips non-terminal zombies to `'error'`. Fire-and-forget so boot doesn't block on storage IO.

5. `feat(core): auto-fill ciBuild from git on scan.start` — Agent noticed every local scan had `ciBranch: null` and called it out as the reason `compare.run` couldn't tell same-commit reruns from regressions. `readGitMeta()` populates branch / hash / message via `git rev-parse` when the caller doesn't pass an explicit `ciBuild`. CI presets are unaffected.

## Why these landed together

Started as a ship-gate test for v1.md line 1710. While dogfooding the MCP path end-to-end, an agent walking the scan history surfaced three concrete bugs that had been sitting in production for weeks — none of which had been visible from the UI. Including them here because the dogfood loop is what found them; splitting would have buried the connection.

## Test plan

- [x] `pnpm vitest run test/mcp.test.ts test/git-meta.test.ts test/core.test.ts` → 20/20 passes
- [x] `pnpm --filter @unlighthouse/core typecheck` → clean
- [x] Manual: re-run the agent prompt from #315; confirmed `scan_summary` now returns non-null `avgScore`, stuck `starting` scans no longer poison `history_list`, and `history_get` shows `ciCommit` populated on a new scan.

## Follow-ups

- `scan.start` rate limit (still no per-session quota — agent can loop)
- Unify `configCacheKey` input shape so MCP doesn't need the discover safety net
- Subprocess MCP stdio bin test (currently only in-memory transport tested in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)