### PR TITLE
feat(packs): D-030 reconciled report blob — substrate for LHR-stable packs

### DIFF
--- a/packages/contracts/src/types/atoms.ts
+++ b/packages/contracts/src/types/atoms.ts
@@ -124,6 +124,62 @@ const ScanRouteSchema = ExtractedMetricsSchema.extend({
 })
 export type ScanRoute = z.infer<typeof ScanRouteSchema>
 
+// D-030 — Reconciled report. Lean per-route projection of the raw LHR, written
+// at scan ingest. Substrate that packs read from instead of re-parsing LHR
+// JSON on every call; survives Lighthouse version drift because we only
+// project the fields packs actually need.
+//
+// AuditFinding mirrors Lighthouse's per-audit shape but trims it to the
+// fields that drive pack decisions. `severity` is derived at ingest time
+// from (score, scoreDisplayMode) so packs don't have to reinvent the rule.
+const AuditFindingSchema = z.object({
+  // Lighthouse audit id, e.g. 'uses-optimized-images' or 'image-delivery-insight'.
+  id: z.string(),
+  // 0..1 score. `null` for manual / notApplicable audits.
+  score: z.number().nullable(),
+  scoreDisplayMode: z.enum(['numeric', 'binary', 'informative', 'manual', 'notApplicable']),
+  displayValue: z.string().nullable(),
+  // Pre-bucketed severity. `pass` = score ≥ 0.9, `warn` = ≥ 0.5, `fail` = < 0.5.
+  // Manual / notApplicable / informative are always `pass` (they don't fail
+  // a scan; packs filter them out by audit id).
+  severity: z.enum(['pass', 'warn', 'fail']),
+})
+export type AuditFinding = z.infer<typeof AuditFindingSchema>
+
+const ReconciledReportSchema = z.object({
+  scanId: ScanIdSchema,
+  url: UrlSchema,
+  device: DeviceSchema,
+  // Metric atoms minus the identity fields already on the parent row.
+  metrics: z.object({
+    scorePerformance: z.number().min(0).max(1).nullable(),
+    scoreAccessibility: z.number().min(0).max(1).nullable(),
+    scoreSeo: z.number().min(0).max(1).nullable(),
+    scoreBestPractices: z.number().min(0).max(1).nullable(),
+    lcp: z.number().nullable(),
+    cls: z.number().nullable(),
+    inp: z.number().nullable(),
+    fcp: z.number().nullable(),
+    ttfb: z.number().nullable(),
+    tbt: z.number().nullable(),
+    si: z.number().nullable(),
+  }),
+  // Per-category roll-ups: score + the audit ids that contributed (so packs
+  // can iterate a category without walking the full audits map).
+  categories: z.partialRecord(CategorySchema, z.object({
+    score: z.number().nullable(),
+    auditRefs: z.array(z.string()),
+  })),
+  // Per-audit findings keyed by Lighthouse audit id.
+  audits: z.record(z.string(), AuditFindingSchema),
+  provenance: z.object({
+    lighthouseVersion: z.string(),
+    userAgent: z.string().nullable(),
+    capturedAt: z.iso.datetime(),
+  }),
+})
+export type ReconciledReport = z.infer<typeof ReconciledReportSchema>
+
 // A seed URL produced by a SeedSource adapter.
 const SeedSchema = z.object({
   url: UrlSchema,
@@ -167,11 +223,13 @@ export type AssertionResult = z.infer<typeof AssertionResultSchema>
 export {
   AssertionSchema as Assertion,
   AssertionResultSchema as AssertionResult,
+  AuditFindingSchema as AuditFinding,
   CategorySchema as Category,
   DeviceSchema as Device,
   ExtractedMetricsSchema as ExtractedMetrics,
   MetricNameSchema as MetricName,
   PaginatedSchema as Paginated,
+  ReconciledReportSchema as ReconciledReport,
   ScanSchema as Scan,
   ScanIdSchema as ScanId,
   ScanRouteSchema as ScanRoute,

--- a/packages/core/src/api/handlers/pack.ts
+++ b/packages/core/src/api/handlers/pack.ts
@@ -13,6 +13,7 @@
 
 import type { CommandOutput, Device, PackList, PackRun, PackRunCmd } from '@unlighthouse/contracts'
 import type { Handler } from './types'
+import { createHash } from 'node:crypto'
 import { gunzipSync } from 'node:zlib'
 import { UnlighthouseError } from '@unlighthouse/contracts'
 import { builtInPacks, getPack } from '../../packs/index'
@@ -97,10 +98,36 @@ export const packRun: Handler<typeof PackRunCmd> = {
       return lhr
     }
 
+    // D-030 reconciled report fetcher. Mirrors getLhr but pulls the
+    // contract-shape blob written at ingest. Packs that opt in survive
+    // Lighthouse version drift without re-parsing the raw LHR — the
+    // reconciler produced a stable AuditFinding shape they can read against.
+    // Returns `null` when the reconciled blob is missing (older scans, or
+    // ingest-time reconciliation failed) so packs can fall through to getLhr.
+    const reconciledCache = new Map<string, unknown>()
+    const getReconciled = async (url: string, _device: Device): Promise<unknown> => {
+      if (reconciledCache.has(url))
+        return reconciledCache.get(url)
+      const row = routes.items.find(r => r.url === url)
+      if (!row?.lhrBlobKey)
+        return null
+      // Derive the contract-blob key from the same scan / url hash that
+      // produced the LHR key. Mirrors the path written in core.ts ingest.
+      const hash = createHash('sha1').update(url).digest('hex').slice(0, 16)
+      const contractKey = `scans/${input.scanId}/reports/${hash}.contract.json`
+      const buf = await ctx.storage.blobs.get(contractKey)
+      if (!buf)
+        return null
+      const parsed = JSON.parse(new TextDecoder().decode(buf))
+      reconciledCache.set(url, parsed)
+      return parsed
+    }
+
     const report = await pack.reconciler({
       scanId: input.scanId,
       routes: routes.items,
       getLhr,
+      getReconciled,
       logger: undefined,
     })
 

--- a/packages/core/src/auditors/mock.ts
+++ b/packages/core/src/auditors/mock.ts
@@ -1,5 +1,6 @@
 import type { Logger, UnlighthouseOptions, UnlighthouseProvider, UnlighthouseReport } from '@unlighthouse/contracts'
 import type { AuditOpts, Auditor, AuditorCapabilities, LighthouseReport, Page } from '@unlighthouse/contracts/ports'
+import { gzipSync } from 'node:zlib'
 
 export interface MockAuditorOptions {
   /** Tagged logger from `createUnlighthouseCore`; absent = silent. */
@@ -18,38 +19,54 @@ export function createMockProvider(): UnlighthouseProvider {
     // Simulate delay
     await new Promise(resolve => setTimeout(resolve, 500))
 
+    // Mock LHR shaped close enough to a real Lighthouse 12 result that the
+    // downstream extract / reconcileToContract pipeline produces realistic
+    // output during tests. Audits include `score` + `scoreDisplayMode` so
+    // severity bucketing in reconcileToContract exercises every branch.
     const raw = {
       requestedUrl: url,
       finalUrl: url,
       fetchTime: new Date().toISOString(),
+      lighthouseVersion: '12.0.0',
+      userAgent: 'mock-auditor/1.0',
       categories: {
         'performance': {
           id: 'performance',
           title: 'Performance',
           score: 0.9,
+          auditRefs: [
+            { id: 'largest-contentful-paint', weight: 25 },
+            { id: 'cumulative-layout-shift', weight: 25 },
+            { id: 'first-contentful-paint', weight: 10 },
+            { id: 'total-blocking-time', weight: 30 },
+            { id: 'speed-index', weight: 10 },
+          ],
         },
         'accessibility': {
           id: 'accessibility',
           title: 'Accessibility',
           score: 0.8,
+          auditRefs: [],
         },
         'best-practices': {
           id: 'best-practices',
           title: 'Best Practices',
           score: 0.95,
+          auditRefs: [],
         },
         'seo': {
           id: 'seo',
           title: 'SEO',
           score: 1,
+          auditRefs: [],
         },
       },
       audits: {
-        'largest-contentful-paint': { numericValue: 1200 },
-        'cumulative-layout-shift': { numericValue: 0.01 },
-        'first-contentful-paint': { numericValue: 1000 },
-        'total-blocking-time': { numericValue: 100 },
-        'speed-index': { numericValue: 1500 },
+        'largest-contentful-paint': { id: 'largest-contentful-paint', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 1200, displayValue: '1.2 s' },
+        'cumulative-layout-shift': { id: 'cumulative-layout-shift', score: 1, scoreDisplayMode: 'numeric', numericValue: 0.01, displayValue: '0.01' },
+        'first-contentful-paint': { id: 'first-contentful-paint', score: 0.95, scoreDisplayMode: 'numeric', numericValue: 1000, displayValue: '1.0 s' },
+        'total-blocking-time': { id: 'total-blocking-time', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 100, displayValue: '100 ms' },
+        'speed-index': { id: 'speed-index', score: 0.85, scoreDisplayMode: 'numeric', numericValue: 1500, displayValue: '1.5 s' },
       },
     }
 
@@ -72,6 +89,10 @@ export function createMockProvider(): UnlighthouseProvider {
           si: 1500,
         },
       },
+      // Gzipped raw LHR so core's ingest path writes the LHR + reconciled blobs.
+      // Without this, the `if (lhrGzip)` branch never fires and downstream
+      // pack tests can't read per-route audit data.
+      lhrGzip: gzipSync(JSON.stringify(raw)),
       raw: raw as any,
     }
   }
@@ -83,7 +104,12 @@ export function createMockAuditor(_opts: MockAuditorOptions = {}): Auditor {
     capabilities: MOCK_CAPABILITIES,
     async audit(url: string, _page?: Page, _opts?: AuditOpts): Promise<LighthouseReport> {
       const report = await provider(url)
-      return report.raw as unknown as LighthouseReport
+      // core.ts's auditWrapper reads `lhrGzip` + `extracted` off the return
+      // value, so re-attach them alongside the raw LHR. Without this the
+      // ingest path never writes the LHR / reconciled blobs in test runs.
+      const out = { ...(report.raw as object) } as Record<string, unknown>
+      out.lhrGzip = (report as { lhrGzip?: Uint8Array }).lhrGzip
+      return out as unknown as LighthouseReport
     },
   }
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -406,6 +406,11 @@ function createSession(deps: SessionDeps): CrawlSession {
           const hash = (await import('node:crypto')).createHash('sha1').update(url).digest('hex').slice(0, 16)
           const lhrKey = `scans/${scanId}/lhr/${hash}.json.gz`
           const reportKey = `scans/${scanId}/reports/${hash}.json`
+          // D-030 contract-shape reconciled blob, written alongside the v0
+          // UI-shape one above. Packs read this; UI still reads the v0 one.
+          // Two blobs are cheaper than coupling pack stability to dashboard
+          // shape changes.
+          const contractKey = `scans/${scanId}/reports/${hash}.contract.json`
           await storage.blobs.put(lhrKey, lhrGzip).catch(() => {})
 
           // Reconciled per-route report — UI-shaped, decoupled from LHR shape.
@@ -413,17 +418,18 @@ function createSession(deps: SessionDeps): CrawlSession {
           // otherwise gunzips + reconciles here as a fallback.
           const reconciled = (report as unknown as { reconciled?: unknown }).reconciled
           let payload: unknown = reconciled
+          let lhrCache: unknown = null
           if (!payload) {
             try {
               const { reconcileRoute } = await import('./report/extract')
               const { gunzipSync } = await import('node:zlib')
-              const lhr = JSON.parse(gunzipSync(lhrGzip).toString())
+              lhrCache = JSON.parse(gunzipSync(lhrGzip).toString())
               payload = reconcileRoute({
                 url,
                 path: (metrics as { path?: string }).path ?? new URL(url).pathname,
                 routeName: (metrics as { routeName?: string | null }).routeName ?? null,
                 reportBlobKey: reportKey,
-                lhr,
+                lhr: lhrCache as never,
               })
             }
             catch { /* best-effort; UI falls back to LHR blob */ }
@@ -432,6 +438,25 @@ function createSession(deps: SessionDeps): CrawlSession {
             const bytes = new TextEncoder().encode(JSON.stringify(payload))
             await storage.blobs.put(reportKey, bytes).catch(() => {})
           }
+
+          // D-030 contract reconciled report. Same LHR gunzip if we already
+          // did one above; otherwise do it now. Packs that opt into
+          // `getReconciled` read this; everything else still reads the
+          // raw LHR via `lhrBlobKey`.
+          try {
+            const { reconcileToContract } = await import('./report/extract')
+            const { gunzipSync } = await import('node:zlib')
+            const lhr = lhrCache ?? JSON.parse(gunzipSync(lhrGzip).toString())
+            const contract = reconcileToContract({
+              scanId,
+              url,
+              device,
+              lhr: lhr as never,
+            })
+            const bytes = new TextEncoder().encode(JSON.stringify(contract))
+            await storage.blobs.put(contractKey, bytes).catch(() => {})
+          }
+          catch { /* best-effort; packs fall back to getLhr */ }
         }
 
         stats.scanned++

--- a/packages/core/src/report/extract.ts
+++ b/packages/core/src/report/extract.ts
@@ -127,3 +127,128 @@ export function reconcileRoute(args: {
     reportBlobKey,
   }
 }
+
+// D-030 reconciler — produces the `ReconciledReport` atom shape from a raw
+// LHR. Distinct from `reconcileRoute` above (which still serves the UI's
+// per-route view); this one is the substrate packs read from. Kept small and
+// flat so we don't grow it past the LH features Packs actually depend on —
+// `opportunities` / `diagnostics` / `fullPageScreenshot` deliberately omitted,
+// callers that need them fetch the raw LHR.
+//
+// `severity` is derived once at ingest so packs don't reinvent the rule:
+//   - manual / notApplicable / informative → 'pass' (these never fail a scan)
+//   - score >= 0.9 → 'pass'
+//   - score >= 0.5 → 'warn'
+//   - score <  0.5 → 'fail'
+//   - score null on a numeric/binary audit → 'fail' (treats "couldn't run" as
+//     pessimistic so packs surface it)
+export function reconcileToContract(args: {
+  scanId: string
+  url: string
+  device: 'mobile' | 'desktop'
+  lhr: LighthouseResult
+}): {
+    scanId: string
+    url: string
+    device: 'mobile' | 'desktop'
+    metrics: {
+      scorePerformance: number | null
+      scoreAccessibility: number | null
+      scoreSeo: number | null
+      scoreBestPractices: number | null
+      lcp: number | null
+      cls: number | null
+      inp: number | null
+      fcp: number | null
+      ttfb: number | null
+      tbt: number | null
+      si: number | null
+    }
+    categories: Record<string, { score: number | null, auditRefs: string[] }>
+    audits: Record<string, {
+      id: string
+      score: number | null
+      scoreDisplayMode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
+      displayValue: string | null
+      severity: 'pass' | 'warn' | 'fail'
+    }>
+    provenance: { lighthouseVersion: string, userAgent: string | null, capturedAt: string }
+  } {
+  const { scanId, url, device, lhr } = args
+  const ext = extractRouteData(lhr)
+
+  const categories: Record<string, { score: number | null, auditRefs: string[] }> = {}
+  for (const [key, c] of Object.entries(lhr.categories ?? {})) {
+    const cat = c as { score?: number | null, auditRefs?: Array<{ id: string }> }
+    categories[key] = {
+      score: cat?.score ?? null,
+      auditRefs: (cat?.auditRefs ?? []).map(r => r.id),
+    }
+  }
+
+  const audits: Record<string, {
+    id: string
+    score: number | null
+    scoreDisplayMode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
+    displayValue: string | null
+    severity: 'pass' | 'warn' | 'fail'
+  }> = {}
+  for (const [id, a] of Object.entries(lhr.audits ?? {})) {
+    const aa = a as {
+      score?: number | null
+      scoreDisplayMode?: string
+      displayValue?: string
+    }
+    const mode = (['numeric', 'binary', 'informative', 'manual', 'notApplicable'].includes(aa?.scoreDisplayMode ?? '')
+      ? aa.scoreDisplayMode
+      : 'informative') as 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
+    audits[id] = {
+      id,
+      score: aa?.score ?? null,
+      scoreDisplayMode: mode,
+      displayValue: aa?.displayValue ?? null,
+      severity: deriveSeverity(aa?.score ?? null, mode),
+    }
+  }
+
+  return {
+    scanId,
+    url,
+    device,
+    metrics: {
+      scorePerformance: ext.scores.performance,
+      scoreAccessibility: ext.scores.accessibility,
+      scoreSeo: ext.scores.seo,
+      scoreBestPractices: ext.scores.bestPractices,
+      lcp: ext.lcp,
+      cls: ext.cls,
+      inp: ext.inp,
+      fcp: ext.fcp,
+      ttfb: ext.ttfb,
+      tbt: ext.tbt,
+      si: ext.si,
+    },
+    categories,
+    audits,
+    provenance: {
+      lighthouseVersion: lhr.lighthouseVersion,
+      userAgent: (lhr as { userAgent?: string }).userAgent ?? null,
+      capturedAt: new Date().toISOString(),
+    },
+  }
+}
+
+function deriveSeverity(
+  score: number | null,
+  mode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable',
+): 'pass' | 'warn' | 'fail' {
+  if (mode === 'manual' || mode === 'notApplicable' || mode === 'informative')
+    return 'pass'
+  if (score == null)
+    return 'fail'
+  if (score >= 0.9)
+    return 'pass'
+  if (score >= 0.5)
+    return 'warn'
+  return 'fail'
+}

--- a/packages/core/src/report/index.ts
+++ b/packages/core/src/report/index.ts
@@ -29,7 +29,7 @@ import { extractRouteData } from './extract'
 import { processPerformance } from './performance'
 import { processSeo } from './seo'
 
-export { decompressLhr, extractRouteData } from './extract'
+export { decompressLhr, extractRouteData, reconcileToContract } from './extract'
 export * from './types'
 
 type AnyDrizzle = any

--- a/test/reconcile-contract.test.ts
+++ b/test/reconcile-contract.test.ts
@@ -1,0 +1,153 @@
+// D-030 — reconcileToContract projects raw LHR JSON to the ReconciledReport
+// atom. The projection is what lets packs survive Lighthouse version drift:
+// new audit IDs land in `audits[id]`, the severity bucketing stays stable.
+//
+// We test the projection in isolation (synthetic LHR → check fields), and
+// once via the full ingest path (mock auditor → scan complete → verify the
+// `.contract.json` blob is on disk).
+
+import { ReconciledReport } from '@unlighthouse/contracts'
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { reconcileToContract } from '@unlighthouse/core/report'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { createHash } from 'node:crypto'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+// ── Synthetic LHR fixture ──────────────────────────────────────────────────
+
+function syntheticLhr() {
+  return {
+    lighthouseVersion: '12.0.0',
+    userAgent: 'test-agent/1.0',
+    categories: {
+      'performance': {
+        score: 0.85,
+        auditRefs: [
+          { id: 'first-contentful-paint', weight: 10 },
+          { id: 'largest-contentful-paint', weight: 25 },
+          { id: 'speed-index', weight: 10 },
+        ],
+      },
+      'accessibility': {
+        score: 0.92,
+        auditRefs: [{ id: 'image-alt', weight: 10 }],
+      },
+      'best-practices': { score: null, auditRefs: [] },
+      'seo': { score: 1.0, auditRefs: [] },
+    },
+    audits: {
+      'first-contentful-paint': { score: 0.95, scoreDisplayMode: 'numeric', displayValue: '1.2s' },
+      'largest-contentful-paint': { score: 0.4, scoreDisplayMode: 'numeric', displayValue: '4.8s' },
+      'speed-index': { score: 0.7, scoreDisplayMode: 'numeric', displayValue: '3.1s' },
+      'image-alt': { score: 0, scoreDisplayMode: 'binary', displayValue: null },
+      'manual-only': { score: null, scoreDisplayMode: 'manual', displayValue: null },
+      'not-applicable': { score: null, scoreDisplayMode: 'notApplicable', displayValue: null },
+      'informative': { score: null, scoreDisplayMode: 'informative', displayValue: '7 KB' },
+    },
+  } as never
+}
+
+describe('reconcileToContract', () => {
+  it('produces a contract-shape ReconciledReport from a synthetic LHR', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: syntheticLhr(),
+    })
+    // Round-trip through the Zod schema — the strongest assertion that the
+    // shape matches the contract.
+    expect(() => ReconciledReport.parse(out)).not.toThrow()
+  })
+
+  it('derives severity per audit (the bucketing pack reconcilers depend on)', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: syntheticLhr(),
+    })
+    // score >= 0.9 → pass
+    expect(out.audits['first-contentful-paint'].severity).toBe('pass')
+    // 0.5 <= score < 0.9 → warn
+    expect(out.audits['speed-index'].severity).toBe('warn')
+    // score < 0.5 → fail
+    expect(out.audits['largest-contentful-paint'].severity).toBe('fail')
+    // binary score 0 → fail
+    expect(out.audits['image-alt'].severity).toBe('fail')
+    // manual / notApplicable / informative → pass (they never block a scan)
+    expect(out.audits['manual-only'].severity).toBe('pass')
+    expect(out.audits['not-applicable'].severity).toBe('pass')
+    expect(out.audits.informative.severity).toBe('pass')
+  })
+
+  it('captures category roll-ups including auditRefs for pack iteration', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: syntheticLhr(),
+    })
+    expect(out.categories.performance?.score).toBe(0.85)
+    expect(out.categories.performance?.auditRefs).toEqual([
+      'first-contentful-paint',
+      'largest-contentful-paint',
+      'speed-index',
+    ])
+    // Null-score categories survive intact (best-practices has no audits run).
+    expect(out.categories['best-practices']?.score).toBeNull()
+    expect(out.categories['best-practices']?.auditRefs).toEqual([])
+  })
+})
+
+// ── Integration: ingest writes the .contract.json blob ──────────────────────
+
+describe('scan ingest persists reconciled contract blob', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  let scanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    const auditor = createMockAuditor()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://example.com' } as never,
+      auditor,
+      seeds: manualSeeds({ urls: ['http://example.com/'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const session = core.run()
+    await session.done
+    scanId = session.scanId
+  })
+
+  it('writes scans/{id}/reports/{urlHash}.contract.json alongside the LHR blob', async () => {
+    const url = 'http://example.com/'
+    const hash = createHash('sha1').update(url).digest('hex').slice(0, 16)
+    const contractKey = `scans/${scanId}/reports/${hash}.contract.json`
+
+    const buf = await storage.blobs.get(contractKey)
+    expect(buf).not.toBeNull()
+    expect(buf!.byteLength).toBeGreaterThan(0)
+
+    const parsed = JSON.parse(new TextDecoder().decode(buf!))
+    // Validate it against the contract.
+    expect(() => ReconciledReport.parse(parsed)).not.toThrow()
+    expect(parsed.scanId).toBe(scanId)
+    expect(parsed.url).toBe(url)
+    expect(parsed.device).toBe('mobile')
+  })
+
+  it('contract blob is independent of the v0 UI reconciled blob', async () => {
+    // The two reconciled blobs co-exist: scans/.../reports/{hash}.json (UI)
+    // and scans/.../reports/{hash}.contract.json (packs). Sanity-check both
+    // wrote out so a future cleanup doesn't accidentally remove the wrong one.
+    const url = 'http://example.com/'
+    const hash = createHash('sha1').update(url).digest('hex').slice(0, 16)
+    expect(await storage.blobs.has(`scans/${scanId}/reports/${hash}.json`)).toBe(true)
+    expect(await storage.blobs.has(`scans/${scanId}/reports/${hash}.contract.json`)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What it does

D-030. Every completed audit now writes a lean reconciled report blob alongside the raw LHR. It's the substrate packs read from — they survive Lighthouse version drift because we only project the audit fields packs actually depend on (id, score, scoreDisplayMode, displayValue, severity), not the whole LHR shape.

Three commits:

1. **`feat(contracts): add D-030 AuditFinding + ReconciledReport atoms`** — new Zod schemas. AuditFinding is the per-audit projection; ReconciledReport bundles metrics + category roll-ups + audits + provenance. Severity is pre-bucketed at ingest so packs don't reinvent the rule.

2. **`feat(core): reconcile + persist D-030 blob at ingest; getReconciled in pack ctx`** — ingest path writes `scans/{id}/reports/{hash}.contract.json` next to the raw LHR. PackReconcileCtx.getReconciled fetcher gives packs typed access. Packs that need element-level details (a11y-quick-wins, images) still fall through to getLhr.

3. **`test(core): cover D-030 reconciler + ingest`** — five new tests, plus the mock auditor now emits `lhrGzip` so scan-related tests actually exercise the persistence branch they were silently skipping before.

## Why now

Pack output cache (#314) made re-running cheap, but pack reconcilers still parse the raw LHR on every cache miss. When Lighthouse 13 ships and audit IDs / shapes drift, every pack breaks. Reconciled blob writes our own stable shape at ingest, so a pack pinned to the contract isn't moved by LH changes.

This PR ships the substrate. Migrating individual packs to `getReconciled` is incremental — left as follow-ups so each migration can be reviewed in isolation.

## Test plan

- [x] `pnpm vitest run test/reconcile-contract.test.ts` → 5/5
- [x] Full suite: 388/393 pass. The 5 failures are pre-existing (3 in api-parity expecting 31 commands but the registry actually has 34; 1 in e2e-http same count drift; 1 flaky in mcp.test that passes in isolation). None caused by this PR — verified by stashing and re-running.
- [x] `pnpm --filter @unlighthouse/contracts --filter @unlighthouse/core typecheck` → clean

## Follow-ups (deliberately out of scope)

- Migrate one pack to `getReconciled` end-to-end as a worked example
- Decide whether the reconciled blob should carry per-audit `details.items` (would let a11y-quick-wins / images drop their LHR dependency, but doubles blob size)
- Audit-id renames table — when LH 12→13 changes an id, do we map at projection time or at pack-read time

🤖 Generated with [Claude Code](https://claude.com/claude-code)