### PR TITLE
feat(packs): cwv + seo-basics read from the D-030 reconciled blob

### DIFF
--- a/packages/contracts/src/types/atoms.ts
+++ b/packages/contracts/src/types/atoms.ts
@@ -132,6 +132,12 @@ export type ScanRoute = z.infer<typeof ScanRouteSchema>
 // AuditFinding mirrors Lighthouse's per-audit shape but trims it to the
 // fields that drive pack decisions. `severity` is derived at ingest time
 // from (score, scoreDisplayMode) so packs don't have to reinvent the rule.
+//
+// `title` / `description` / `metricSavings` are pulled through so packs
+// don't fall back to raw LHR just to read a human label or a savings number.
+// `details.items` (element-level data) is intentionally NOT projected — the
+// blob would balloon, and the handful of packs that need it (a11y-quick-wins,
+// images) still fetch the raw LHR for those audits.
 const AuditFindingSchema = z.object({
   // Lighthouse audit id, e.g. 'uses-optimized-images' or 'image-delivery-insight'.
   id: z.string(),
@@ -139,10 +145,26 @@ const AuditFindingSchema = z.object({
   score: z.number().nullable(),
   scoreDisplayMode: z.enum(['numeric', 'binary', 'informative', 'manual', 'notApplicable']),
   displayValue: z.string().nullable(),
+  // Human-facing label from the LHR ("Document has a `<title>` element").
+  title: z.string().nullable(),
+  // Long-form remediation copy from the LHR. Nullable because some
+  // informative audits ship without one.
+  description: z.string().nullable(),
   // Pre-bucketed severity. `pass` = score ≥ 0.9, `warn` = ≥ 0.5, `fail` = < 0.5.
   // Manual / notApplicable / informative are always `pass` (they don't fail
   // a scan; packs filter them out by audit id).
   severity: z.enum(['pass', 'warn', 'fail']),
+  // Lighthouse 12+ per-audit savings estimates. Populated on insight audits
+  // (`*-insight` ids) and a few classic ones; absent fields = "no estimate
+  // from Lighthouse," not "zero savings." Units: ms for LCP/FCP/INP/TBT,
+  // dimensionless for CLS.
+  metricSavings: z.object({
+    LCP: z.number().optional(),
+    FCP: z.number().optional(),
+    INP: z.number().optional(),
+    CLS: z.number().optional(),
+    TBT: z.number().optional(),
+  }).nullable(),
 })
 export type AuditFinding = z.infer<typeof AuditFindingSchema>
 
@@ -164,11 +186,17 @@ const ReconciledReportSchema = z.object({
     tbt: z.number().nullable(),
     si: z.number().nullable(),
   }),
-  // Per-category roll-ups: score + the audit ids that contributed (so packs
-  // can iterate a category without walking the full audits map).
+  // Per-category roll-ups: score + the audit refs that contributed (so packs
+  // can iterate a category without walking the full audits map). `weight`
+  // mirrors Lighthouse's category weighting — load-bearing for severity rules
+  // like seo-basics' `severityFromWeight` (is-crawlable carries weight 3-4,
+  // most others weight 1).
   categories: z.partialRecord(CategorySchema, z.object({
     score: z.number().nullable(),
-    auditRefs: z.array(z.string()),
+    auditRefs: z.array(z.object({
+      id: z.string(),
+      weight: z.number().nonnegative(),
+    })),
   })),
   // Per-audit findings keyed by Lighthouse audit id.
   audits: z.record(z.string(), AuditFindingSchema),

--- a/packages/core/src/auditors/mock.ts
+++ b/packages/core/src/auditors/mock.ts
@@ -40,13 +40,16 @@ export function createMockProvider(): UnlighthouseProvider {
             { id: 'first-contentful-paint', weight: 10 },
             { id: 'total-blocking-time', weight: 30 },
             { id: 'speed-index', weight: 10 },
+            { id: 'render-blocking-insight', weight: 0 },
           ],
         },
         'accessibility': {
           id: 'accessibility',
           title: 'Accessibility',
           score: 0.8,
-          auditRefs: [],
+          auditRefs: [
+            { id: 'image-alt', weight: 10 },
+          ],
         },
         'best-practices': {
           id: 'best-practices',
@@ -58,15 +61,26 @@ export function createMockProvider(): UnlighthouseProvider {
           id: 'seo',
           title: 'SEO',
           score: 1,
-          auditRefs: [],
+          auditRefs: [
+            { id: 'is-crawlable', weight: 4 },
+            { id: 'document-title', weight: 1 },
+          ],
         },
       },
       audits: {
-        'largest-contentful-paint': { id: 'largest-contentful-paint', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 1200, displayValue: '1.2 s' },
-        'cumulative-layout-shift': { id: 'cumulative-layout-shift', score: 1, scoreDisplayMode: 'numeric', numericValue: 0.01, displayValue: '0.01' },
-        'first-contentful-paint': { id: 'first-contentful-paint', score: 0.95, scoreDisplayMode: 'numeric', numericValue: 1000, displayValue: '1.0 s' },
-        'total-blocking-time': { id: 'total-blocking-time', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 100, displayValue: '100 ms' },
-        'speed-index': { id: 'speed-index', score: 0.85, scoreDisplayMode: 'numeric', numericValue: 1500, displayValue: '1.5 s' },
+        'largest-contentful-paint': { id: 'largest-contentful-paint', title: 'Largest Contentful Paint', description: 'LCP marks the time at which the largest text or image is painted.', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 1200, displayValue: '1.2 s' },
+        'cumulative-layout-shift': { id: 'cumulative-layout-shift', title: 'Cumulative Layout Shift', description: 'CLS measures visual stability.', score: 1, scoreDisplayMode: 'numeric', numericValue: 0.01, displayValue: '0.01' },
+        'first-contentful-paint': { id: 'first-contentful-paint', title: 'First Contentful Paint', description: 'FCP marks the first paint.', score: 0.95, scoreDisplayMode: 'numeric', numericValue: 1000, displayValue: '1.0 s' },
+        'total-blocking-time': { id: 'total-blocking-time', title: 'Total Blocking Time', description: 'TBT measures main-thread blocking.', score: 0.9, scoreDisplayMode: 'numeric', numericValue: 100, displayValue: '100 ms' },
+        'speed-index': { id: 'speed-index', title: 'Speed Index', description: 'SI shows how quickly content is visually displayed.', score: 0.85, scoreDisplayMode: 'numeric', numericValue: 1500, displayValue: '1.5 s' },
+        // Insight audit with metricSavings — exercises the enriched
+        // ReconciledReport projection used by the cwv pack's topFixes loop.
+        'render-blocking-insight': { id: 'render-blocking-insight', title: 'Eliminate render-blocking resources', description: 'Resources are blocking the first paint of your page.', score: 0.5, scoreDisplayMode: 'numeric', displayValue: 'Potential savings of 250 ms', metricSavings: { FCP: 250, LCP: 180 } },
+        // Classic SEO audits — give seo-basics + title/description coverage.
+        'is-crawlable': { id: 'is-crawlable', title: 'Page is not blocked from indexing', description: 'Search engines can index pages that aren\'t blocked.', score: 1, scoreDisplayMode: 'binary' },
+        'document-title': { id: 'document-title', title: 'Document has a `<title>` element', description: 'The title gives screen reader users an overview of the page.', score: 0, scoreDisplayMode: 'binary' },
+        // Accessibility audit — exercises a11y pass branch in mock.
+        'image-alt': { id: 'image-alt', title: 'Image elements have `[alt]` attributes', description: 'Informative elements should aim for short, descriptive alt text.', score: null, scoreDisplayMode: 'notApplicable' },
       },
     }
 

--- a/packages/core/src/packs/cwv.ts
+++ b/packages/core/src/packs/cwv.ts
@@ -17,7 +17,7 @@
 //   - Cross-route fix grouping: "render-blocking-insight saves 200ms FCP
 //     on 18 routes" is one finding, not 18.
 
-import type { Pack, PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
+import type { Pack, PackReconcileCtx, ReconciledReport, ScanRoute } from '@unlighthouse/contracts'
 import { z } from 'zod'
 
 // ── Thresholds ──────────────────────────────────────────────────────────────
@@ -187,6 +187,44 @@ const SAVINGS_TO_METRIC: Record<string, MetricKey> = {
   INP: 'inp',
 }
 
+// Returns the per-audit metricSavings map for a route, preferring the
+// reconciled blob (LH-version stable) over the raw LHR. Filters to insight
+// audit ids up front so the caller doesn't have to. Returns null when neither
+// substrate is available for the route.
+type SavingsMap = NonNullable<ReconciledReport['audits'][string]['metricSavings']>
+async function readInsightAudits(
+  url: string,
+  ctx: PackReconcileCtx,
+): Promise<Map<string, SavingsMap> | null> {
+  if (ctx.getReconciled) {
+    const reconciled = await ctx.getReconciled(url, 'mobile').catch(() => null) as ReconciledReport | null
+    if (reconciled?.audits) {
+      const out = new Map<string, SavingsMap>()
+      for (const [id, finding] of Object.entries(reconciled.audits)) {
+        if (!id.endsWith('-insight') || !finding.metricSavings)
+          continue
+        out.set(id, finding.metricSavings)
+      }
+      // The reconciled blob is the canonical substrate; if it exists for the
+      // route, do NOT also walk the raw LHR (avoids double-counting).
+      return out
+    }
+  }
+  if (ctx.getLhr) {
+    const lhr = await ctx.getLhr(url, 'mobile').catch(() => null) as LhrLike | null
+    if (!lhr?.audits)
+      return null
+    const out = new Map<string, SavingsMap>()
+    for (const [id, audit] of Object.entries(lhr.audits)) {
+      if (!id.endsWith('-insight') || !audit.metricSavings)
+        continue
+      out.set(id, audit.metricSavings as SavingsMap)
+    }
+    return out
+  }
+  return null
+}
+
 // ── Reconciler ──────────────────────────────────────────────────────────────
 
 async function reconcile(ctx: PackReconcileCtx): Promise<CwvReport> {
@@ -200,22 +238,17 @@ async function reconcile(ctx: PackReconcileCtx): Promise<CwvReport> {
     return m?.verdict === 'good'
   })
 
-  // Collect insight savings across routes. Only walk if a getLhr exists —
-  // a host running cwv without raw LHR access still gets the lab snapshot,
-  // just no fix list.
+  // Collect insight savings across routes. Prefer the reconciled report blob
+  // (LH-version-stable, no raw-LHR parse) and fall back to getLhr only when
+  // the reconciled blob is missing — typically old scans ingested before D-030.
   const topFixes: CwvFix[] = []
-  if (ctx.getLhr) {
+  if (ctx.getReconciled || ctx.getLhr) {
     const accum = new Map<string, InsightAccum>()
     for (const row of routes) {
-      const lhr = await ctx.getLhr(row.url, 'mobile').catch(() => null) as LhrLike | null
-      if (!lhr?.audits)
+      const audits = await readInsightAudits(row.url, ctx)
+      if (!audits)
         continue
-      for (const [id, audit] of Object.entries(lhr.audits)) {
-        if (!id.endsWith('-insight'))
-          continue
-        const savings = audit.metricSavings
-        if (!savings)
-          continue
+      for (const [id, savings] of audits) {
         for (const [savingsKey, metric] of Object.entries(SAVINGS_TO_METRIC)) {
           const impact = savings[savingsKey as keyof typeof savings]
           if (typeof impact !== 'number' || impact <= 0)

--- a/packages/core/src/packs/seo-basics.ts
+++ b/packages/core/src/packs/seo-basics.ts
@@ -11,7 +11,7 @@
 // the headline number for an agent or a human auditing whether their site
 // will actually rank.
 
-import type { Pack, PackReconcileCtx } from '@unlighthouse/contracts'
+import type { Pack, PackReconcileCtx, ReconciledReport } from '@unlighthouse/contracts'
 import { z } from 'zod'
 
 // ── Report shape ────────────────────────────────────────────────────────────
@@ -138,37 +138,77 @@ interface RawFinding {
   }>
 }
 
+// Per-route view of just the SEO bits seo-basics needs. Sourced from the
+// reconciled blob first (LH-version stable), with raw LHR as fallback for
+// older scans + as the only source of `details.items` (the reconciled blob
+// deliberately doesn't carry element-level data — too big).
+interface RouteView {
+  audits: Record<string, { score: number | null, title: string | null, description: string | null }>
+  auditWeights: Map<string, number>
+  // Only populated when the raw LHR is available, used for sampleElements.
+  rawLhr: LhrLike | null
+}
+
+async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteView | null> {
+  const reconciled = ctx.getReconciled
+    ? await ctx.getReconciled(url, 'mobile').catch(() => null) as ReconciledReport | null
+    : null
+  const lhr = ctx.getLhr
+    ? await ctx.getLhr(url, 'mobile').catch(() => null) as LhrLike | null
+    : null
+
+  if (!reconciled && !lhr)
+    return null
+
+  const audits: RouteView['audits'] = {}
+  const auditWeights = new Map<string, number>()
+
+  if (reconciled) {
+    for (const ref of reconciled.categories.seo?.auditRefs ?? [])
+      auditWeights.set(ref.id, ref.weight)
+    for (const [id, a] of Object.entries(reconciled.audits)) {
+      audits[id] = { score: a.score, title: a.title, description: a.description }
+    }
+  }
+  else if (lhr) {
+    for (const ref of lhr.categories?.seo?.auditRefs ?? [])
+      auditWeights.set(ref.id, ref.weight)
+    for (const [id, a] of Object.entries(lhr.audits ?? {})) {
+      audits[id] = {
+        score: a.score ?? null,
+        title: a.title ?? null,
+        description: a.description ?? null,
+      }
+    }
+  }
+
+  return { audits, auditWeights, rawLhr: lhr }
+}
+
 // ── Reconciler ──────────────────────────────────────────────────────────────
 
 async function reconcile(ctx: PackReconcileCtx): Promise<SeoReport> {
-  if (!ctx.getLhr) {
-    throw new Error('seo-basics pack requires a getLhr fetcher (PackReconcileCtx.getLhr is undefined).')
+  if (!ctx.getReconciled && !ctx.getLhr) {
+    throw new Error('seo-basics pack requires getReconciled or getLhr (both PackReconcileCtx fetchers were undefined).')
   }
 
   const findings = new Map<string, RawFinding>()
   const routeChecks: SeoRouteCheck[] = []
   let routesAnalysed = 0
   let indexableRoutes = 0
-  let auditWeights: Map<string, number> | null = null
 
   for (const row of ctx.routes) {
-    const lhr = await ctx.getLhr(row.url, 'mobile').catch(() => null) as LhrLike | null
-    if (!lhr?.audits)
+    const view = await loadRouteView(row.url, ctx)
+    if (!view || view.auditWeights.size === 0)
       continue
     routesAnalysed++
-
-    if (!auditWeights) {
-      auditWeights = new Map()
-      for (const ref of lhr.categories?.seo?.auditRefs ?? [])
-        auditWeights.set(ref.id, ref.weight)
-    }
 
     let passes = 0
     let fails = 0
     let indexable = true
 
-    for (const [auditId, weight] of auditWeights) {
-      const audit = lhr.audits[auditId]
+    for (const [auditId, weight] of view.auditWeights) {
+      const audit = view.audits[auditId]
       if (!audit)
         continue
       const score = audit.score
@@ -189,7 +229,7 @@ async function reconcile(ctx: PackReconcileCtx): Promise<SeoReport> {
         finding = {
           auditId,
           title: audit.title ?? auditId,
-          description: audit.description ?? null,
+          description: audit.description,
           weight,
           routes: new Set(),
           sampleElements: [],
@@ -198,13 +238,15 @@ async function reconcile(ctx: PackReconcileCtx): Promise<SeoReport> {
       }
       finding.routes.add(row.url)
 
-      // Capture up to 3 unique element samples across the whole scan for
-      // audits that report element-level items (link-text, hreflang, …).
-      for (const it of audit.details?.items ?? []) {
+      // Element samples can only come from the raw LHR (reconciled blob
+      // intentionally drops details.items to stay lean). When the LHR is
+      // unavailable, sampleElements just stays empty for that finding —
+      // the cross-route counts still rank correctly.
+      const rawAudit = view.rawLhr?.audits?.[auditId]
+      for (const it of rawAudit?.details?.items ?? []) {
         const node = it.node
         if (!node || finding.sampleElements.length >= 3)
           break
-        // De-dupe by selector — same broken anchor on N routes counts once.
         const sel = node.selector ?? null
         if (finding.sampleElements.some(e => e.selector === sel))
           continue

--- a/packages/core/src/report/extract.ts
+++ b/packages/core/src/report/extract.ts
@@ -142,6 +142,17 @@ export function reconcileRoute(args: {
 //   - score <  0.5 → 'fail'
 //   - score null on a numeric/binary audit → 'fail' (treats "couldn't run" as
 //     pessimistic so packs surface it)
+interface ContractAuditFinding {
+  id: string
+  score: number | null
+  scoreDisplayMode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
+  displayValue: string | null
+  title: string | null
+  description: string | null
+  severity: 'pass' | 'warn' | 'fail'
+  metricSavings: { LCP?: number, FCP?: number, INP?: number, CLS?: number, TBT?: number } | null
+}
+
 export function reconcileToContract(args: {
   scanId: string
   url: string
@@ -164,50 +175,63 @@ export function reconcileToContract(args: {
       tbt: number | null
       si: number | null
     }
-    categories: Record<string, { score: number | null, auditRefs: string[] }>
-    audits: Record<string, {
-      id: string
-      score: number | null
-      scoreDisplayMode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
-      displayValue: string | null
-      severity: 'pass' | 'warn' | 'fail'
-    }>
+    categories: Record<string, { score: number | null, auditRefs: Array<{ id: string, weight: number }> }>
+    audits: Record<string, ContractAuditFinding>
     provenance: { lighthouseVersion: string, userAgent: string | null, capturedAt: string }
   } {
   const { scanId, url, device, lhr } = args
   const ext = extractRouteData(lhr)
 
-  const categories: Record<string, { score: number | null, auditRefs: string[] }> = {}
+  const categories: Record<string, { score: number | null, auditRefs: Array<{ id: string, weight: number }> }> = {}
   for (const [key, c] of Object.entries(lhr.categories ?? {})) {
-    const cat = c as { score?: number | null, auditRefs?: Array<{ id: string }> }
+    const cat = c as { score?: number | null, auditRefs?: Array<{ id: string, weight?: number }> }
     categories[key] = {
       score: cat?.score ?? null,
-      auditRefs: (cat?.auditRefs ?? []).map(r => r.id),
+      auditRefs: (cat?.auditRefs ?? []).map(r => ({
+        id: r.id,
+        // LHR usually carries a weight on every auditRef. Defensive default of
+        // 0 — a non-existent weight shouldn't crash pack severity rules; they
+        // already cap at "minor" when weight rounds down to 0.
+        weight: typeof r.weight === 'number' ? r.weight : 0,
+      })),
     }
   }
 
-  const audits: Record<string, {
-    id: string
-    score: number | null
-    scoreDisplayMode: 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
-    displayValue: string | null
-    severity: 'pass' | 'warn' | 'fail'
-  }> = {}
+  const audits: Record<string, ContractAuditFinding> = {}
   for (const [id, a] of Object.entries(lhr.audits ?? {})) {
     const aa = a as {
       score?: number | null
       scoreDisplayMode?: string
       displayValue?: string
+      title?: string
+      description?: string
+      metricSavings?: { LCP?: number, FCP?: number, INP?: number, CLS?: number, TBT?: number }
     }
     const mode = (['numeric', 'binary', 'informative', 'manual', 'notApplicable'].includes(aa?.scoreDisplayMode ?? '')
       ? aa.scoreDisplayMode
       : 'informative') as 'numeric' | 'binary' | 'informative' | 'manual' | 'notApplicable'
+    // Only project metricSavings when at least one field is present + numeric;
+    // an empty object would round-trip as truthy and confuse pack guards.
+    let metricSavings: ContractAuditFinding['metricSavings'] = null
+    if (aa?.metricSavings && typeof aa.metricSavings === 'object') {
+      const out: NonNullable<ContractAuditFinding['metricSavings']> = {}
+      for (const k of ['LCP', 'FCP', 'INP', 'CLS', 'TBT'] as const) {
+        const v = aa.metricSavings[k]
+        if (typeof v === 'number')
+          out[k] = v
+      }
+      if (Object.keys(out).length > 0)
+        metricSavings = out
+    }
     audits[id] = {
       id,
       score: aa?.score ?? null,
       scoreDisplayMode: mode,
       displayValue: aa?.displayValue ?? null,
+      title: typeof aa?.title === 'string' ? aa.title : null,
+      description: typeof aa?.description === 'string' ? aa.description : null,
       severity: deriveSeverity(aa?.score ?? null, mode),
+      metricSavings,
     }
   }
 

--- a/test/pack-reconciled-migration.test.ts
+++ b/test/pack-reconciled-migration.test.ts
@@ -1,0 +1,215 @@
+// Verifies the cwv + seo-basics packs prefer the reconciled blob over the
+// raw LHR. This is the user-visible contract of the D-030 migration: pack
+// behaviour shouldn't change, but the data path does (fewer LHR fetches,
+// LH-version stable).
+
+import type { PackReconcileCtx, ReconciledReport, ScanRoute } from '@unlighthouse/contracts'
+import { cwvPack } from '@unlighthouse/core/packs/cwv'
+import { seoBasicsPack } from '@unlighthouse/core/packs/seo-basics'
+import { describe, expect, it, vi } from 'vitest'
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+
+function buildRoute(url: string): ScanRoute {
+  return {
+    scanId: 'scan-1' as never,
+    url: url as never,
+    path: new URL(url).pathname,
+    routeName: null,
+    status: 'completed',
+    scorePerformance: 0.9,
+    scoreAccessibility: 0.95,
+    scoreSeo: 0.85,
+    scoreBestPractices: 0.9,
+    lcp: 1200,
+    cls: 0.01,
+    inp: 100,
+    fcp: 1000,
+    ttfb: 200,
+    tbt: 50,
+    si: 1500,
+    routeMatcherId: null,
+    lhrBlobKey: 'scans/scan-1/lhr/x.json',
+    htmlBlobKey: null,
+    auditedAt: new Date().toISOString(),
+  } as never
+}
+
+function reconciledReportWith(audits: ReconciledReport['audits'], seoRefs: Array<{ id: string, weight: number }> = []): ReconciledReport {
+  return {
+    scanId: 'scan-1' as never,
+    url: 'http://example.com/' as never,
+    device: 'mobile',
+    metrics: {
+      scorePerformance: 0.9,
+      scoreAccessibility: 0.95,
+      scoreSeo: 0.85,
+      scoreBestPractices: 0.9,
+      lcp: 1200,
+      cls: 0.01,
+      inp: 100,
+      fcp: 1000,
+      ttfb: 200,
+      tbt: 50,
+      si: 1500,
+    },
+    categories: {
+      seo: { score: 0.85, auditRefs: seoRefs },
+    },
+    audits,
+    provenance: {
+      lighthouseVersion: '12.0.0',
+      userAgent: 'test-agent/1.0',
+      capturedAt: new Date().toISOString(),
+    },
+  }
+}
+
+// ── cwv pack ────────────────────────────────────────────────────────────────
+
+describe('cwv pack prefers reconciled report', () => {
+  it('reads metricSavings from reconciled blob; never calls getLhr when reconciled exists', async () => {
+    const route = buildRoute('http://example.com/')
+    const reconciled = reconciledReportWith({
+      'render-blocking-insight': {
+        id: 'render-blocking-insight',
+        score: 0.5,
+        scoreDisplayMode: 'numeric',
+        displayValue: '250 ms',
+        title: 'Eliminate render-blocking resources',
+        description: 'Resources block the first paint.',
+        severity: 'warn',
+        metricSavings: { FCP: 300, LCP: 200 },
+      },
+    })
+    const getReconciled = vi.fn(async () => reconciled)
+    const getLhr = vi.fn(async () => null)
+
+    const report = await cwvPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [route],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    expect(getLhr).not.toHaveBeenCalled()
+    expect(report.topFixes).toHaveLength(2) // FCP + LCP rows for the same insight
+    const fcpFix = report.topFixes.find(f => f.metric === 'fcp')
+    expect(fcpFix?.maxImpactMs).toBe(300)
+    expect(fcpFix?.insight).toBe('render-blocking-insight')
+  })
+
+  it('falls back to getLhr when reconciled returns null (old scan)', async () => {
+    const route = buildRoute('http://example.com/')
+    const getReconciled = vi.fn(async () => null)
+    const getLhr = vi.fn(async () => ({
+      audits: {
+        'render-blocking-insight': {
+          metricSavings: { FCP: 150 },
+        },
+      },
+    }))
+
+    const report = await cwvPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [route],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    expect(getLhr).toHaveBeenCalledTimes(1)
+    expect(report.topFixes).toHaveLength(1)
+    expect(report.topFixes[0].metric).toBe('fcp')
+    expect(report.topFixes[0].maxImpactMs).toBe(150)
+  })
+})
+
+// ── seo-basics pack ─────────────────────────────────────────────────────────
+
+describe('seo-basics pack prefers reconciled report', () => {
+  it('reads title/weight/score from reconciled blob and only hits LHR for details.items', async () => {
+    const route = buildRoute('http://example.com/about')
+    const reconciled = reconciledReportWith(
+      {
+        'is-crawlable': {
+          id: 'is-crawlable',
+          score: 1,
+          scoreDisplayMode: 'binary',
+          displayValue: null,
+          title: 'Page is not blocked from indexing',
+          description: 'Search engines can crawl this page.',
+          severity: 'pass',
+          metricSavings: null,
+        },
+        'document-title': {
+          id: 'document-title',
+          score: 0,
+          scoreDisplayMode: 'binary',
+          displayValue: null,
+          title: 'Document has a <title> element',
+          description: 'The title gives screen reader users an overview of the page.',
+          severity: 'fail',
+          metricSavings: null,
+        },
+      },
+      [
+        { id: 'is-crawlable', weight: 4 },
+        { id: 'document-title', weight: 1 },
+      ],
+    )
+    const getReconciled = vi.fn(async () => reconciled)
+    const getLhr = vi.fn(async () => ({
+      audits: {
+        'document-title': {
+          details: { items: [{ node: { selector: 'title', snippet: '<title></title>', nodeLabel: '' } }] },
+        },
+      },
+    }))
+
+    const report = await seoBasicsPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [route],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    // LHR is consulted in parallel for sampleElements (intentional — packs
+    // need element-level data the reconciled blob doesn't carry).
+    expect(getLhr).toHaveBeenCalledTimes(1)
+
+    // Indexability: is-crawlable passes (score 1), so route stays indexable.
+    expect(report.indexableRoutes).toBe(1)
+    expect(report.unindexableRoutes).toBe(0)
+
+    // The failing audit landed in findings; severity derived from the
+    // reconciled blob's weight (1 → 'serious').
+    const docTitle = report.findings.find(f => f.auditId === 'document-title')
+    expect(docTitle).toBeDefined()
+    expect(docTitle?.severity).toBe('serious')
+    expect(docTitle?.title).toBe('Document has a <title> element')
+    // Element samples pulled from the raw LHR despite reconciled being primary.
+    expect(docTitle?.sampleElements).toHaveLength(1)
+    expect(docTitle?.sampleElements[0].selector).toBe('title')
+  })
+
+  it('still works with only LHR available (reconciled fetcher absent)', async () => {
+    const route = buildRoute('http://example.com/')
+    const getLhr = vi.fn(async () => ({
+      categories: { seo: { auditRefs: [{ id: 'is-crawlable', weight: 4 }] } },
+      audits: { 'is-crawlable': { score: 1, title: 'Crawlable', description: 'x' } },
+    }))
+
+    const report = await seoBasicsPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [route],
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getLhr).toHaveBeenCalledTimes(1)
+    expect(report.routesAnalysed).toBe(1)
+    expect(report.indexableRoutes).toBe(1)
+  })
+})

--- a/test/reconcile-contract.test.ts
+++ b/test/reconcile-contract.test.ts
@@ -92,14 +92,72 @@ describe('reconcileToContract', () => {
       lhr: syntheticLhr(),
     })
     expect(out.categories.performance?.score).toBe(0.85)
+    // auditRefs carries id + weight so packs like seo-basics can derive
+    // severity from category weighting without re-fetching the raw LHR.
     expect(out.categories.performance?.auditRefs).toEqual([
-      'first-contentful-paint',
-      'largest-contentful-paint',
-      'speed-index',
+      { id: 'first-contentful-paint', weight: 10 },
+      { id: 'largest-contentful-paint', weight: 25 },
+      { id: 'speed-index', weight: 10 },
     ])
     // Null-score categories survive intact (best-practices has no audits run).
     expect(out.categories['best-practices']?.score).toBeNull()
     expect(out.categories['best-practices']?.auditRefs).toEqual([])
+  })
+
+  it('projects audit title + description so packs can render labels without the raw LHR', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: {
+        ...syntheticLhr(),
+        audits: {
+          ...(syntheticLhr() as { audits: Record<string, unknown> }).audits,
+          'with-labels': {
+            score: 0.5,
+            scoreDisplayMode: 'numeric',
+            displayValue: null,
+            title: 'Reduce JavaScript execution time',
+            description: 'Consider reducing the time spent parsing, compiling, and executing JS.',
+          },
+        },
+      } as never,
+    })
+    expect(out.audits['with-labels'].title).toBe('Reduce JavaScript execution time')
+    expect(out.audits['with-labels'].description).toMatch(/parsing/)
+    // Audits without a title fall back to null, not "" (consumers branch on null).
+    expect(out.audits['first-contentful-paint'].title).toBeNull()
+  })
+
+  it('projects metricSavings only when at least one savings field is numeric', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: {
+        ...syntheticLhr(),
+        audits: {
+          ...(syntheticLhr() as { audits: Record<string, unknown> }).audits,
+          'render-blocking-insight': {
+            score: 0.6,
+            scoreDisplayMode: 'numeric',
+            displayValue: '250 ms',
+            metricSavings: { FCP: 250, LCP: 180 },
+          },
+          'empty-savings': {
+            score: 0.9,
+            scoreDisplayMode: 'numeric',
+            displayValue: null,
+            metricSavings: {},
+          },
+        },
+      } as never,
+    })
+    expect(out.audits['render-blocking-insight'].metricSavings).toEqual({ FCP: 250, LCP: 180 })
+    // Empty objects collapse to null so pack guards (`if (m.metricSavings)`) work.
+    expect(out.audits['empty-savings'].metricSavings).toBeNull()
+    // Audits without the field stay null.
+    expect(out.audits['first-contentful-paint'].metricSavings).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

D-030 landed last PR — every scan now writes a reconciled report blob alongside the raw LHR. This PR is the natural follow-up: the first two packs that actually use it.

The reconciled blob got slightly richer along the way (title, description, category weight, metricSavings) so packs don't need to keep falling back to the raw LHR just to read a label or a savings number.

## What changed

**ReconciledReport schema** (`contracts/atoms.ts`):
- `AuditFinding` gained `title`, `description`, `metricSavings`
- `categories[*].auditRefs` is now `{ id, weight }[]` instead of `string[]`

`reconcileToContract` projects the new fields. metricSavings collapses to `null` when no per-metric values are present so pack guards stay clean.

**cwv pack** — `topFixes` now reads `metricSavings` from the reconciled blob. Falls back to raw LHR only when the reconciled fetcher returns null (older scans). When both are available, the LHR is never opened.

**seo-basics pack** — reads `score / title / description / weight` from reconciled. `sampleElements` still come from raw LHR because the reconciled blob deliberately doesn't carry `details.items` (would balloon the payload). Older scans without a reconciled blob keep working via `getLhr`.

## What didn't change

- `overview` — already row-only, no LHR/reconciled read. Skipped.
- `js-bundle`, `a11y-quick-wins`, `images` — depend on `details.items` for every finding. Migrating those would require projecting element-level data into the reconciled blob and that's a separate conversation (blob size tradeoff).

## Test plan
- [x] reconcile-contract: new fields project correctly, empty metricSavings → null
- [x] pack-migration: cwv reads reconciled-first, falls back to LHR; seo-basics splits reconciled (scores) + LHR (elements)
- [x] back-compat: seo-basics still works with only getLhr (old scans)
- [x] core builds clean, contract types match

Pre-existing failures on v1 (api-parity, e2e-http manifest count) are unrelated — verified by stashing.