### PR TITLE
feat(d029): runtime matrix fan-out — one scan, N devices

### DIFF
--- a/packages/contracts/src/ports/auditor.ts
+++ b/packages/contracts/src/ports/auditor.ts
@@ -1,9 +1,9 @@
 // Concrete Page comes from puppeteer-core in auditors/local; ports stay puppeteer-free.
 // LighthouseReport re-uses the type from contracts/types so adapters and the port agree.
-import type { Category } from '../types/atoms'
+import type { Category, Device } from '../types/atoms'
 import type { LighthouseReport } from '../types/index'
 
-export type { Category, LighthouseReport }
+export type { Category, Device, LighthouseReport }
 
 export interface Page {
   url: () => string
@@ -21,6 +21,15 @@ export interface AuditorCapabilities {
 
 export interface AuditOpts {
   signal?: AbortSignal
+  /**
+   * D-029: device form-factor for this audit. Adapters that run Lighthouse
+   * pass it through as the emulation profile (`mobile` → moto-g4 + 4G,
+   * `desktop` → 1366×768 + wired). Fetch-based aggregators ignore it; the
+   * scan still records which device the URL was queried under.
+   *
+   * Defaults to `'mobile'` when omitted, matching Lighthouse's own default.
+   */
+  device?: Device
   /**
    * Lighthouse config passthrough for adapters that run Lighthouse (local, cdp-connect,
    * remote-lighthouse). Ignored by fetch-based aggregators (psi, crux, dataforseo).

--- a/packages/contracts/src/ports/core.ts
+++ b/packages/contracts/src/ports/core.ts
@@ -71,7 +71,12 @@ export interface CrawlSession {
  */
 export interface UnlighthouseCoreRunOverrides {
   site?: string
-  device?: 'mobile' | 'desktop'
+  /**
+   * D-029: device form-factor for the scan. A single value runs once per URL;
+   * an array runs the matrix — one audit per URL per device, all under one
+   * scan id. Defaults to the host config's device when omitted.
+   */
+  device?: 'mobile' | 'desktop' | Array<'mobile' | 'desktop'>
   /** Lighthouse categories — mapped onto `lighthouseOptions.onlyCategories`. */
   categories?: Array<'performance' | 'accessibility' | 'seo' | 'best-practices'>
   /** Sample count — mapped onto `scanner.samples`. */

--- a/packages/core/src/auditors/mock.ts
+++ b/packages/core/src/auditors/mock.ts
@@ -116,13 +116,56 @@ export function createMockAuditor(_opts: MockAuditorOptions = {}): Auditor {
   const provider = createMockProvider()
   return {
     capabilities: MOCK_CAPABILITIES,
-    async audit(url: string, _page?: Page, _opts?: AuditOpts): Promise<LighthouseReport> {
+    async audit(url: string, _page?: Page, opts?: AuditOpts): Promise<LighthouseReport> {
       const report = await provider(url)
       // core.ts's auditWrapper reads `lhrGzip` + `extracted` off the return
       // value, so re-attach them alongside the raw LHR. Without this the
       // ingest path never writes the LHR / reconciled blobs in test runs.
       const out = { ...(report.raw as object) } as Record<string, unknown>
-      out.lhrGzip = (report as { lhrGzip?: Uint8Array }).lhrGzip
+      // D-029: nudge the synthetic LHR per-device so tests can tell mobile
+      // and desktop rows apart. Desktop gets better perf numbers — mirrors
+      // the real-world pattern (less throttling = higher scores). lhrGzip
+      // is regenerated so the LHR blob reflects the modified shape.
+      const device = opts?.device ?? 'mobile'
+      const isDesktop = device === 'desktop'
+      if (isDesktop) {
+        const audits = (out.audits ?? {}) as Record<string, { score?: number, numericValue?: number }>
+        out.audits = {
+          ...audits,
+          'largest-contentful-paint': { ...(audits['largest-contentful-paint'] ?? {}), score: 1, numericValue: 600 },
+          'first-contentful-paint': { ...(audits['first-contentful-paint'] ?? {}), score: 1, numericValue: 500 },
+        }
+        const categories = (out.categories ?? {}) as Record<string, { score?: number }>
+        out.categories = {
+          ...categories,
+          performance: { ...(categories.performance ?? {}), score: 0.98 },
+        }
+        out.lhrGzip = gzipSync(JSON.stringify(out))
+      }
+      else {
+        out.lhrGzip = (report as { lhrGzip?: Uint8Array }).lhrGzip
+      }
+      // Attach an `extracted` payload so core.ts's ingest doesn't fall back to
+      // all-null metric columns. Desktop variant mirrors the LHR nudge above.
+      const lhr = out as { lighthouseVersion?: string }
+      out.extracted = {
+        url,
+        path: new URL(url).pathname,
+        routeName: null,
+        scorePerformance: isDesktop ? 0.98 : 0.9,
+        scoreAccessibility: 0.8,
+        scoreSeo: 1,
+        scoreBestPractices: 0.95,
+        lcp: isDesktop ? 600 : 1200,
+        cls: 0.01,
+        inp: null,
+        fcp: isDesktop ? 500 : 1000,
+        ttfb: null,
+        tbt: 100,
+        si: 1500,
+        lighthouseVersion: lhr.lighthouseVersion ?? '12.0.0',
+        capturedAt: new Date().toISOString(),
+      }
       return out as unknown as LighthouseReport
     },
   }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -61,10 +61,15 @@ function mergeOverrides(
   const next: UnlighthouseConfig = { ...base }
   if (overrides.site)
     next.site = overrides.site
-  if (overrides.device || overrides.sampleSize != null) {
+  // D-029: device may be Device | Device[]. `scanner.device` carries the
+  // primary device (first element of the matrix) for back-compat with
+  // adapters/UI reading config.scanner.device directly. The full matrix is
+  // surfaced separately to orchestrate() via `resolveDeviceMatrix` below.
+  const primaryDevice = Array.isArray(overrides.device) ? overrides.device[0] : overrides.device
+  if (primaryDevice || overrides.sampleSize != null) {
     next.scanner = {
       ...(base.scanner ?? {}),
-      ...(overrides.device ? { device: overrides.device } : {}),
+      ...(primaryDevice ? { device: primaryDevice } : {}),
       ...(overrides.sampleSize != null ? { samples: overrides.sampleSize } : {}),
     }
   }
@@ -75,6 +80,33 @@ function mergeOverrides(
     }
   }
   return next
+}
+
+// D-029: normalises the override's device field into a deduped, ordered list.
+// Single-device input collapses to a one-element array; missing input falls
+// back to the resolved scanner device, then to 'mobile'. Order is preserved
+// because it determines `Scan.device` (the row's primary device).
+function resolveDeviceMatrix(
+  scannerDevice: 'mobile' | 'desktop' | undefined,
+  overrideDevice: UnlighthouseCoreRunOverrides['device'],
+): ['mobile' | 'desktop', ...Array<'mobile' | 'desktop'>] {
+  const raw: Array<'mobile' | 'desktop'> = Array.isArray(overrideDevice)
+    ? overrideDevice
+    : overrideDevice
+      ? [overrideDevice]
+      : scannerDevice
+        ? [scannerDevice]
+        : ['mobile']
+  // Dedup while preserving order.
+  const seen = new Set<'mobile' | 'desktop'>()
+  const out: Array<'mobile' | 'desktop'> = []
+  for (const d of raw) {
+    if (!seen.has(d)) {
+      seen.add(d)
+      out.push(d)
+    }
+  }
+  return out as ['mobile' | 'desktop', ...Array<'mobile' | 'desktop'>]
 }
 
 function toStructuredError(err: unknown): { code: string, message: string, cause?: unknown } {
@@ -345,13 +377,19 @@ function createSession(deps: SessionDeps): CrawlSession {
   async function orchestrate(): Promise<void> {
     const site = (deps.config.site ?? '') as string
     const scannerDevice = deps.config.scanner?.device
-    const device: 'mobile' | 'desktop'
-      = scannerDevice === 'mobile' || scannerDevice === 'desktop' ? scannerDevice : 'mobile'
+    const validScannerDevice
+      = scannerDevice === 'mobile' || scannerDevice === 'desktop' ? scannerDevice : undefined
+    // D-029: resolve the per-scan device matrix once at orchestrate time.
+    // `primaryDevice` keeps the scans row's `device` column meaningful for
+    // back-compat (UIs that only render a single column still see a sane
+    // value); the full list drives the per-URL fan-out below.
+    const devices = resolveDeviceMatrix(validScannerDevice, overrides?.device)
+    const primaryDevice = devices[0]
 
     await storage.scans.create({
       scanId,
       site: site as never,
-      device,
+      device: primaryDevice,
       status: 'starting',
       startedAt,
       completedAt: null,
@@ -368,11 +406,11 @@ function createSession(deps: SessionDeps): CrawlSession {
 
     let firstUrlSeen = false
 
-    async function auditWrapper(url: string): Promise<void> {
+    async function auditOnDevice(url: string, device: 'mobile' | 'desktop'): Promise<void> {
       const auditStart = Date.now()
       await emit('audit:before', { scanId, url: url as never, auditor: 'auditor' })
       try {
-        const report = await auditor.audit(url, undefined, { signal })
+        const report = await auditor.audit(url, undefined, { signal, device })
         // Auditor returns LH report + attached `extracted` (CWV/scores/etc.)
         // + `lhrGzip` (raw LHR in LHCI-format, gzipped). Route the extracted
         // metrics to the row store; the LHR blob to the blob store under the
@@ -483,6 +521,19 @@ function createSession(deps: SessionDeps): CrawlSession {
           durationMs: Date.now() - auditStart,
           ok: false,
         })
+      }
+    }
+
+    // D-029: per-URL fan-out across the device matrix. Devices run
+    // sequentially per URL so we don't double up on the auditor's
+    // concurrency limit (each adapter typically pins to one browser context);
+    // crawler-level concurrency still parallelises URLs. A single device
+    // matrix is the common case and degrades to one inner call.
+    async function auditWrapper(url: string): Promise<void> {
+      for (const dev of devices) {
+        if (signal.aborted)
+          return
+        await auditOnDevice(url, dev)
       }
     }
 

--- a/test/d029-matrix-fanout.test.ts
+++ b/test/d029-matrix-fanout.test.ts
@@ -1,0 +1,105 @@
+// D-029 runtime fan-out: a single scan exercises every URL on every device
+// in the matrix and writes one ScanRoute row per (url, device).
+//
+// Mock auditor is device-aware (see auditors/mock.ts): desktop returns
+// nudged-up perf scores so the two rows are observably different.
+
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { describe, expect, it } from 'vitest'
+
+describe('D-029 matrix fan-out', () => {
+  it('scans one URL on both devices → two rows, distinct scores per device', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://example.com' } as never,
+      auditor: createMockAuditor(),
+      seeds: manualSeeds({ urls: ['http://example.com/'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const session = core.run({
+      overrides: { device: ['mobile', 'desktop'] },
+    })
+    await session.done
+
+    const rows = await storage.routes.listForScan(session.scanId, { pageSize: 100 })
+    expect(rows.total).toBe(2)
+    expect(rows.items.map(r => r.device).sort()).toEqual(['desktop', 'mobile'])
+
+    const mobile = rows.items.find(r => r.device === 'mobile')!
+    const desktop = rows.items.find(r => r.device === 'desktop')!
+    // Mock auditor's desktop profile bumps perf score to 0.98 vs mobile 0.9.
+    expect(mobile.scorePerformance).toBe(0.9)
+    expect(desktop.scorePerformance).toBe(0.98)
+
+    // Per-device blob keys exist for both rows.
+    expect(mobile.lhrBlobKey).toContain('-mobile.json.gz')
+    expect(desktop.lhrBlobKey).toContain('-desktop.json.gz')
+    expect(await storage.blobs.has(mobile.lhrBlobKey)).toBe(true)
+    expect(await storage.blobs.has(desktop.lhrBlobKey)).toBe(true)
+  })
+
+  it('listForScan with device filter returns only the requested device', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://example.com' } as never,
+      auditor: createMockAuditor(),
+      seeds: manualSeeds({ urls: ['http://example.com/a', 'http://example.com/b'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const session = core.run({
+      overrides: { device: ['mobile', 'desktop'] },
+    })
+    await session.done
+
+    const all = await storage.routes.listForScan(session.scanId)
+    expect(all.total).toBe(4) // 2 URLs × 2 devices
+
+    const mobileOnly = await storage.routes.listForScan(session.scanId, { device: 'mobile' })
+    expect(mobileOnly.total).toBe(2)
+    expect(mobileOnly.items.every(r => r.device === 'mobile')).toBe(true)
+  })
+
+  it('Scan.device holds the first device in the matrix (primary device)', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://example.com' } as never,
+      auditor: createMockAuditor(),
+      seeds: manualSeeds({ urls: ['http://example.com/'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const session = core.run({
+      // desktop-first matrix → scan.device = 'desktop'.
+      overrides: { device: ['desktop', 'mobile'] },
+    })
+    await session.done
+
+    const scan = await storage.scans.get(session.scanId)
+    expect(scan?.device).toBe('desktop')
+  })
+
+  it('single-device input still produces one row per URL (back-compat)', async () => {
+    const storage = memoryStorage()
+    const core = createUnlighthouseCore({
+      config: { site: 'http://example.com' } as never,
+      auditor: createMockAuditor(),
+      seeds: manualSeeds({ urls: ['http://example.com/'] }),
+      crawler: parallelMapCrawler({ concurrency: 1 }),
+      storage,
+    })
+    const session = core.run({
+      overrides: { device: 'mobile' },
+    })
+    await session.done
+
+    const rows = await storage.routes.listForScan(session.scanId)
+    expect(rows.total).toBe(1)
+    expect(rows.items[0].device).toBe('mobile')
+  })
+})


### PR DESCRIPTION
## Summary

D-029 step 2: a single scan now audits every URL across the device matrix and writes one ScanRoute row per (url, device). Closes the LHCI #138 use case end-to-end — agents and CLIs can finally pass `--device mobile,desktop` and get both profiles in one run.

Schema for this (PR #320) is already on v1; this PR wires the runtime.

## What changed

**Contracts**: `AuditOpts.device` lets the auditor pick its emulation profile per call. `UnlighthouseCoreRunOverrides.device` accepts `Device | Device[]` so the wire matches what `scan.start` was already advertising.

**core.ts orchestrate**: resolves the per-scan device list once (`resolveDeviceMatrix`), then loops devices per URL inside `auditWrapper`. Each audit threads `device` through `AuditOpts`. `Scan.device` holds the first device in the matrix for back-compat with single-column UIs; row-level truth lives in `scan_routes`.

**Mock auditor**: branches on `opts.device`. Desktop returns nudged-up perf numbers (LCP 600ms vs 1200ms, score 0.98 vs 0.9) and re-gzips the LHR. Also attaches `extracted` so ingest writes real metric columns instead of falling back to all-null.

## Test plan
- [x] full suite: 405/405 passing (4 new D-029 cases)
- [x] one URL × matrix → 2 rows, distinct per-device scores
- [x] two URLs × matrix → 4 rows; listForScan device filter narrows
- [x] Scan.device carries the first device in the matrix
- [x] single-device input still produces exactly one row per URL

## What's NOT in this PR

- `route.get` / `route.rescan` / `pack.run` / `scan.results` command inputs accepting an explicit `device` filter (the wire still defaults to the scan's primary device).
- `compare.run` / `assert.evaluate` URL-uniqueness assumptions — those handlers still build `Map<url, route>` and would collapse the matrix to one row each.

Both are clear follow-ups; this PR is the load-bearing piece.