### PR TITLE
fix(d029): compare + assert join base→current on (url, device)

### DIFF
--- a/packages/contracts/src/commands/compare.ts
+++ b/packages/contracts/src/commands/compare.ts
@@ -9,6 +9,13 @@ const ThresholdKey = z.union([MetricName, Category])
 
 const RouteDiff = z.object({
   url: Url,
+  /**
+   * D-029: device dimension on the diff. Matrix scans produce one diff per
+   * (url, device) pair so mobile and desktop regressions don't collapse into
+   * each other. Single-device scans always carry 'mobile' (or whatever the
+   * scan's primary device was).
+   */
+  device: Device,
   metric: ThresholdKey,
   base: z.number().nullable(),
   current: z.number().nullable(),

--- a/packages/core/src/api/handlers/assert.ts
+++ b/packages/core/src/api/handlers/assert.ts
@@ -32,7 +32,14 @@ async function loadRoutes(ctx: HandlerCtx, scanId: ScanId): Promise<ScanRoute[]>
   return res.items
 }
 
-function evalAssertion(assertion: Assertion, routes: ScanRoute[], baseByUrl: Map<string, ScanRoute>): AssertionResult {
+// D-029: (url, device) join key. Matrix scans have multiple rows per URL;
+// keying on url alone would collapse them and silently let a desktop
+// regression mask a mobile improvement (or vice versa).
+function rowKey(r: ScanRoute): string {
+  return `${r.url}|${r.device}`
+}
+
+function evalAssertion(assertion: Assertion, routes: ScanRoute[], baseByKey: Map<string, ScanRoute>): AssertionResult {
   if (assertion.type === 'minScore') {
     const col = CATEGORY_COL[assertion.category]
     const vals = routes.map(r => num(r, col)).filter((v): v is number => v != null)
@@ -55,7 +62,7 @@ function evalAssertion(assertion: Assertion, routes: ScanRoute[], baseByUrl: Map
   let worstDelta = 0
   let worstUrl: string | undefined
   for (const current of routes) {
-    const base = baseByUrl.get(current.url)
+    const base = baseByKey.get(rowKey(current))
     if (!base)
       continue
     const cv = num(current, col)
@@ -81,8 +88,8 @@ export const assertEvaluate: Handler<typeof AssertEvaluate> = {
   async run(input, ctx) {
     const routes = await loadRoutes(ctx, input.scanId)
     const baseRoutes = input.baselineScanId ? await loadRoutes(ctx, input.baselineScanId) : []
-    const baseByUrl = new Map(baseRoutes.map(r => [r.url, r]))
-    const results = input.assertions.map(a => evalAssertion(a, routes, baseByUrl))
+    const baseByKey = new Map(baseRoutes.map(r => [rowKey(r), r]))
+    const results = input.assertions.map(a => evalAssertion(a, routes, baseByKey))
     const hooks = ctx.core.hooks as { callHook: (event: string, payload: unknown) => Promise<void> } | undefined
     if (hooks) {
       for (const result of results) {

--- a/packages/core/src/api/handlers/compare.ts
+++ b/packages/core/src/api/handlers/compare.ts
@@ -42,11 +42,21 @@ function valueOf(route: ScanRoute, metric: MetricName | Category): number | null
 
 interface Diff {
   url: string
+  // D-029: matrix scans key diffs on (url, device) so mobile and desktop
+  // regressions don't collapse. Mirrors the RouteDiff contract atom.
+  device: ScanRoute['device']
   metric: MetricName | Category
   base: number | null
   current: number | null
   delta: number
   regressed: boolean
+}
+
+// D-029: row key for cross-scan join. baseByUrl was URL-only before; matrix
+// scans have multiple rows per URL so the URL alone overwrites every prior
+// device's row when building the map. (url, device) restores 1:1 lookup.
+function rowKey(r: ScanRoute): string {
+  return `${r.url}|${r.device}`
 }
 
 async function loadRoutes(ctx: HandlerCtx, scanId: string): Promise<ScanRoute[]> {
@@ -63,7 +73,7 @@ async function runCompare(ctx: HandlerCtx, baseScanId: string, currentScanId: st
     loadRoutes(ctx, baseScanId),
     loadRoutes(ctx, currentScanId),
   ])
-  const baseByUrl = new Map(baseRoutes.map(r => [r.url, r]))
+  const baseByKey = new Map(baseRoutes.map(r => [rowKey(r), r]))
 
   const metrics: (MetricName | Category)[] = [
     'lcp',
@@ -84,7 +94,10 @@ async function runCompare(ctx: HandlerCtx, baseScanId: string, currentScanId: st
   const improvements: Diff[] = []
 
   for (const current of currentRoutes) {
-    const base = baseByUrl.get(current.url)
+    // Match base to current on (url, device). A matrix scan compared against
+    // a single-device base will still find pairs for the overlapping device
+    // and skip the rest — no false regressions from missing base rows.
+    const base = baseByKey.get(rowKey(current))
     if (!base)
       continue
     for (const metric of metrics) {
@@ -98,7 +111,15 @@ async function runCompare(ctx: HandlerCtx, baseScanId: string, currentScanId: st
       const regressed = score ? -delta > threshold : delta > threshold
       const improved = score ? delta > threshold : -delta > threshold
       if (regressed || improved) {
-        const diff: Diff = { url: current.url, metric, base: baseVal, current: currentVal, delta, regressed }
+        const diff: Diff = {
+          url: current.url,
+          device: current.device,
+          metric,
+          base: baseVal,
+          current: currentVal,
+          delta,
+          regressed,
+        }
         ;(regressed ? regressions : improvements).push(diff)
       }
     }
@@ -147,10 +168,10 @@ export const compareMarkdown: Handler<typeof CompareMarkdown> = {
       lines.push('')
       lines.push(`### ${heading}`)
       lines.push('')
-      lines.push('| Route | Metric | Base | Current | Δ |')
-      lines.push('|-------|--------|------|---------|---|')
+      lines.push('| Route | Device | Metric | Base | Current | Δ |')
+      lines.push('|-------|--------|--------|------|---------|---|')
       for (const r of rows)
-        lines.push(`| \`${r.url}\` | ${r.metric} | ${r.base ?? '—'} | ${r.current ?? '—'} | ${r.delta.toFixed(3)} |`)
+        lines.push(`| \`${r.url}\` | ${r.device} | ${r.metric} | ${r.base ?? '—'} | ${r.current ?? '—'} | ${r.delta.toFixed(3)} |`)
     }
     renderTable(report.regressions, 'Regressions')
     renderTable(report.improvements, 'Improvements')

--- a/test/d029-compare-assert-matrix.test.ts
+++ b/test/d029-compare-assert-matrix.test.ts
@@ -1,0 +1,132 @@
+// D-029: compare.run and assert.evaluate must respect (url, device) row
+// identity. Before this fix, both handlers built a Map<url, ScanRoute> as
+// their base→current join, which silently collapsed matrix rows: a mobile
+// regression and a desktop improvement on the same URL would cancel out
+// (whichever row landed in the map last won).
+//
+// These tests exercise the matrix path end-to-end via memoryStorage so
+// the (url, device) key is verified at the row-store layer too.
+
+import type { Storage } from '@unlighthouse/contracts'
+import { compareRun } from '@unlighthouse/core/api/handlers/compare'
+import { assertEvaluate } from '@unlighthouse/core/api/handlers/assert'
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+// ── Fixture: matrix scan + a second matrix scan with patched rows ───────────
+
+async function runMatrixScan(storage: Storage): Promise<string> {
+  const core = createUnlighthouseCore({
+    config: { site: 'http://example.com' } as never,
+    auditor: createMockAuditor(),
+    seeds: manualSeeds({ urls: ['http://example.com/'] }),
+    crawler: parallelMapCrawler({ concurrency: 1 }),
+    storage,
+  })
+  const session = core.run({ overrides: { device: ['mobile', 'desktop'] } })
+  await session.done
+  return session.scanId
+}
+
+// Patch one route's metric. Returns nothing — `routes.upsert` is idempotent
+// so this just rewrites the row in place under its (scanId, url, device) PK.
+async function patchRouteMetric(
+  storage: Storage,
+  scanId: string,
+  url: string,
+  device: 'mobile' | 'desktop',
+  patch: Record<string, number | null>,
+) {
+  const row = await storage.routes.get(scanId as never, url, device)
+  if (!row)
+    throw new Error(`row not found: ${url}@${device}`)
+  await storage.routes.upsert(scanId as never, device, {
+    ...row,
+    ...patch,
+  } as never)
+}
+
+const makeCtx = (storage: Storage) => ({
+  storage,
+  core: { hooks: undefined } as never,
+  auditor: createMockAuditor(),
+} as never)
+
+// ── compare ────────────────────────────────────────────────────────────────
+
+describe('compare.run respects (url, device) identity', () => {
+  let storage: Storage
+  let baseScanId: string
+  let currentScanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    baseScanId = await runMatrixScan(storage)
+    currentScanId = await runMatrixScan(storage)
+    // Regress LCP on mobile only. Desktop stays unchanged → desktop should
+    // NOT show up as a regression after the fix.
+    await patchRouteMetric(storage, currentScanId, 'http://example.com/', 'mobile', { lcp: 4500 })
+  })
+
+  it('mobile regression is reported with device dimension; desktop stays clean', async () => {
+    const out = await compareRun.run(
+      { baseScanId: baseScanId as never, currentScanId: currentScanId as never },
+      makeCtx(storage),
+    )
+
+    const mobileLcp = out.regressions.filter(r => r.metric === 'lcp' && r.device === 'mobile')
+    const desktopLcp = out.regressions.filter(r => r.metric === 'lcp' && r.device === 'desktop')
+
+    expect(mobileLcp).toHaveLength(1)
+    expect(mobileLcp[0].url).toBe('http://example.com/')
+    expect(mobileLcp[0].base).toBe(1200) // mock mobile baseline
+    expect(mobileLcp[0].current).toBe(4500)
+    expect(desktopLcp).toHaveLength(0)
+  })
+
+  it('every diff carries a device — schema is honored', async () => {
+    const out = await compareRun.run(
+      { baseScanId: baseScanId as never, currentScanId: currentScanId as never },
+      makeCtx(storage),
+    )
+    for (const diff of [...out.regressions, ...out.improvements])
+      expect(diff.device).toMatch(/^(mobile|desktop)$/)
+  })
+})
+
+// ── assert: maxRegression ──────────────────────────────────────────────────
+
+describe('assert.evaluate maxRegression respects (url, device) identity', () => {
+  let storage: Storage
+  let baseScanId: string
+  let currentScanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    baseScanId = await runMatrixScan(storage)
+    currentScanId = await runMatrixScan(storage)
+  })
+
+  it('does NOT see a regression when desktop improves and mobile stays flat', async () => {
+    // Pre-fix: baseByUrl[url] would hold whichever device wrote last
+    // (desktop, after the loop). For the mobile row, base would be the
+    // desktop row → a "regression" of ~600ms LCP would surface even though
+    // mobile didn't move at all.
+    const out = await assertEvaluate.run(
+      {
+        scanId: currentScanId as never,
+        baselineScanId: baseScanId as never,
+        assertions: [{ type: 'maxRegression', metric: 'lcp', value: 100 }],
+      } as never,
+      makeCtx(storage),
+    )
+    // Both scans use the same mock — mobile=1200, desktop=600. Per (url,
+    // device) join: 0 regression. Pre-fix bug would have surfaced one.
+    expect(out.passed).toBe(true)
+    expect(out.results[0].actual).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Both `compare.run` and `assert.evaluate` used to build a `Map<url, ScanRoute>` to join base against current. That was correct under the pre-D-029 schema (one row per URL per scan) but silently breaks now that matrix scans write two rows per URL: whichever device wrote last wins the map, so a mobile regression next to a desktop improvement on the same URL would cancel out — and `assert.maxRegression` would surface a false ~600ms LCP regression on every URL because mobile current would compare against desktop base.

Defensive fix — no bug report, but the runtime fan-out (PR #321) only just landed and this would have been the next thing to bite.

## What changed

**`RouteDiff` contract atom** now carries `device`. Single-device scans always populate it (using the scan's primary device), so the field is non-breaking on the wire.

**`compare.run`** keys `baseByKey` on `${url}|${device}`. Diffs carry the device. `compare.markdown` grew a Device column so PR comments make it obvious which form-factor regressed.

**`assert.evaluate` maxRegression** uses the same composite key. `minScore` and `maxNumericValue` aggregate across all rows so they don't need the join.

## Test plan
- [x] full suite: 408/408 passing (3 new D-029 cases)
- [x] compare: mobile-only regression doesn't pull desktop into the diff
- [x] every diff carries a device — schema is honored end-to-end
- [x] assert maxRegression: identical matrix scans pass with `actual: 0` (pre-fix would have failed)