### PR TITLE
feat(d029): command-input device filters for route/scan/pack

### DIFF
--- a/packages/contracts/src/commands/pack.ts
+++ b/packages/contracts/src/commands/pack.ts
@@ -3,16 +3,20 @@
 // pack.run. Output is content-addressable by (scanId, packName, packVersion).
 
 import { z } from 'zod'
-import { ScanId } from '../types/atoms'
+import { Device, ScanId } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── pack.run ────────────────────────────────────────────────────────────────
 export const PackRunCmd = defineCommand({
   name: 'pack.run',
-  description: 'Run a Lighthouse pack (cross-route analysis) against a finished scan. Returns a typed report — e.g. "images" lists routes with unoptimised LCP images, "cwv" returns p75 Core Web Vitals, "seo-basics" returns failing audits grouped by rule. Call pack.list first to discover available packs. Use scanId from history.list. Output is cached so re-running the same (scanId, pack) is free; pass refresh:true to bust.',
+  description: 'Run a Lighthouse pack (cross-route analysis) against a finished scan. Returns a typed report — e.g. "images" lists routes with unoptimised LCP images, "cwv" returns p75 Core Web Vitals, "seo-basics" returns failing audits grouped by rule. Call pack.list first to discover available packs. Use scanId from history.list. For matrix scans, pass `device` to narrow the pack to one form-factor. Output is cached so re-running the same (scanId, pack, device) is free; pass refresh:true to bust.',
   input: z.object({
     scanId: ScanId,
     pack: z.string().min(1),
+    // D-029: pack runs against rows for one device. Omitted = aggregate across
+    // the matrix (every row in scan_routes is handed to the pack). Devices
+    // produce observably different numbers so most packs will want a filter.
+    device: Device.optional(),
     // Skip the cache and re-reconcile. Default false so agent calls hit cache
     // on the second visit; UI exposes this as a "Refresh" button.
     refresh: z.boolean().optional(),

--- a/packages/contracts/src/commands/route.ts
+++ b/packages/contracts/src/commands/route.ts
@@ -1,14 +1,20 @@
 // route.* commands — operations against a single route within a scan.
 
 import { z } from 'zod'
-import { ExtractedMetrics, ScanId, ScanRoute, Url } from '../types/atoms'
+import { Device, ExtractedMetrics, ScanId, ScanRoute, Url } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── route.get ───────────────────────────────────────────────────────────────
 export const RouteGet = defineCommand({
   name: 'route.get',
-  description: 'Get the full route row + LHR blob key for a single URL.',
-  input: z.object({ scanId: ScanId, url: Url }),
+  description: 'Get the full route row + LHR blob key for a single URL. For matrix scans, pass `device` to target a specific form-factor; defaults to the scan\'s primary device.',
+  input: z.object({
+    scanId: ScanId,
+    url: Url,
+    // D-029: matrix scans hold N rows per URL. Caller picks one with `device`;
+    // omitted = use the scan's primary device (back-compat).
+    device: Device.optional(),
+  }),
   output: z.object({
     route: ScanRoute,
     /** The raw LHR JSON, fetched from `storage.blobs.get(route.lhrBlobKey)`. */
@@ -21,7 +27,14 @@ export const RouteGet = defineCommand({
 export const RouteRescan = defineCommand({
   name: 'route.rescan',
   description: 'Re-audit a single URL within an existing scan.',
-  input: z.object({ scanId: ScanId, url: Url }),
+  input: z.object({
+    scanId: ScanId,
+    url: Url,
+    // D-029: which device row to re-audit. Defaults to the scan's primary
+    // device. Re-audits one row at a time — fan-out across the matrix would
+    // double-charge an active auditor without the caller asking for it.
+    device: Device.optional(),
+  }),
   output: z.object({
     scanId: ScanId,
     url: Url,

--- a/packages/contracts/src/commands/scan.ts
+++ b/packages/contracts/src/commands/scan.ts
@@ -211,9 +211,11 @@ export const ScanSummaryCmd = defineCommand({
 // Load-bearing example (v1.md lines 840–853).
 export const ScanResults = defineCommand({
   name: 'scan.results',
-  description: 'List route results for a scan with filter + pagination.',
+  description: 'List route results for a scan with filter + pagination. For matrix scans, pass `device` to narrow to mobile or desktop; omit to aggregate across the matrix.',
   input: z.object({
     scanId: ScanId,
+    // D-029: filter to one device. Omitted = every (url, device) row.
+    device: Device.optional(),
     filter: z
       .object({
         minScore: z.partialRecord(Category, z.number()).optional(),

--- a/packages/core/src/api/handlers/pack.ts
+++ b/packages/core/src/api/handlers/pack.ts
@@ -28,6 +28,15 @@ function packRunBlobKey(scanId: string, packName: string, packVersion: string): 
   return `scans/${scanId}/packs/${packName}-${packVersion}.json`
 }
 
+// D-029: pack runs are device-scoped. The packRuns table is still keyed on
+// (scanId, packName, packVersion) — extending the PK was out of scope for
+// this PR — so we encode device into packName when the caller asked for a
+// specific device. Single-device callers (no input.device) keep the bare
+// pack name and hit the existing cache row exactly as before.
+function packKeyFor(packName: string, device?: string): string {
+  return device ? `${packName}@${device}` : packName
+}
+
 export const packRun: Handler<typeof PackRunCmd> = {
   command: {} as typeof PackRunCmd,
   async run(input, ctx) {
@@ -47,16 +56,20 @@ export const packRun: Handler<typeof PackRunCmd> = {
       })
     }
 
-    // Cache lookup — keyed on (scanId, packName, packVersion). When the row
-    // points at a blob (large report), inflate it before returning.
+    const cachePackName = packKeyFor(pack.name, input.device)
+
+    // Cache lookup — keyed on (scanId, packName(+device), packVersion). When
+    // the row points at a blob (large report), inflate it before returning.
     if (!input.refresh) {
-      const cached = await ctx.storage.packRuns.get(input.scanId, pack.name, pack.version)
+      const cached = await ctx.storage.packRuns.get(input.scanId, cachePackName, pack.version)
       if (cached) {
         const report = await loadCachedReport(cached, ctx)
         if (report !== null) {
           return {
             scanId: cached.scanId,
-            packName: cached.packName,
+            // Strip the device suffix from the wire — clients see the bare
+            // pack name they asked for, the cache key is internal.
+            packName: pack.name,
             packVersion: cached.packVersion,
             startedAt: cached.startedAt,
             completedAt: cached.completedAt,
@@ -75,7 +88,13 @@ export const packRun: Handler<typeof PackRunCmd> = {
     // a 1k-route scan at ~200B/row is well under any reasonable cap. If a
     // future pack needs streaming, the storage port already supports it via
     // cursors — bridge it then.
-    const routes = await ctx.storage.routes.listForScan(input.scanId, { page: 1, pageSize: 10_000 })
+    // D-029: when the caller specified a device, narrow the row set so the
+    // pack only sees rows for that form-factor. Omitted = full matrix.
+    const routes = await ctx.storage.routes.listForScan(input.scanId, {
+      page: 1,
+      pageSize: 10_000,
+      device: input.device,
+    })
 
     // Lazy LHR fetcher. Each blob is ~50-200KB gzipped; packs that need raw
     // audit details (images, cwv) call this per URL, packs that only need
@@ -148,24 +167,24 @@ export const packRun: Handler<typeof PackRunCmd> = {
 
     // Persist. Small reports inline, large ones spill to the blob store —
     // the row keeps only the blob key. Blob key is deterministic on
-    // (scanId, packName, packVersion), so spill→spill overwrites in place;
+    // (scanId, cachePackName, packVersion), so spill→spill overwrites in place;
     // only spill→inline can leave an orphan, handled below.
     const serialised = JSON.stringify(parsed.data)
     const spill = serialised.length > INLINE_REPORT_LIMIT_BYTES
     let reportBlobKey: string | null = null
     if (spill) {
-      reportBlobKey = packRunBlobKey(input.scanId, pack.name, pack.version)
+      reportBlobKey = packRunBlobKey(input.scanId, cachePackName, pack.version)
       await ctx.storage.blobs.put(reportBlobKey, new TextEncoder().encode(serialised), { contentType: 'application/json' })
     }
 
     // Look up the previous row (if any) so we can clean up its blob if the
     // new run drops below the spill threshold. Cheap second read — the cache
     // path already missed, so there's at most one row here.
-    const prior = await ctx.storage.packRuns.get(input.scanId, pack.name, pack.version)
+    const prior = await ctx.storage.packRuns.get(input.scanId, cachePackName, pack.version)
 
     await ctx.storage.packRuns.put({
       scanId: input.scanId,
-      packName: pack.name,
+      packName: cachePackName,
       packVersion: pack.version,
       startedAt,
       completedAt,
@@ -181,6 +200,8 @@ export const packRun: Handler<typeof PackRunCmd> = {
     }
 
     return {
+      // Wire `packName` is the bare pack id the caller asked for; cache key
+      // mangling (cachePackName) stays internal.
       scanId: input.scanId,
       packName: pack.name,
       packVersion: pack.version,

--- a/packages/core/src/api/handlers/route.ts
+++ b/packages/core/src/api/handlers/route.ts
@@ -2,6 +2,7 @@
 
 import type { CommandOutput, ExtractedMetrics, RouteGet, RouteRescan } from '@unlighthouse/contracts'
 import type { Handler } from './types'
+import { gunzipSync } from 'node:zlib'
 import { UnlighthouseError } from '@unlighthouse/contracts'
 
 export const routeGet: Handler<typeof RouteGet> = {
@@ -10,17 +11,23 @@ export const routeGet: Handler<typeof RouteGet> = {
     const scan = await ctx.storage.scans.get(input.scanId)
     if (!scan)
       throw new UnlighthouseError({ code: 'SCAN_NOT_FOUND', message: `scanId=${input.scanId}` })
-    // D-029: routes are PK'd on (scanId, url, device). Single-device scans
-    // pull the lone row by using the scan's own device. Multi-device support
-    // on this command is the next PR's job (input grows a `device` field).
-    const route = await ctx.storage.routes.get(input.scanId, input.url, scan.device)
+    // D-029: prefer the caller's explicit device; fall back to the scan's
+    // primary device so single-device callers stay unchanged. Matrix scans
+    // returning ROUTE_NOT_FOUND on a specific device tells the caller the
+    // form-factor wasn't part of the scan — useful signal, don't swallow.
+    const device = input.device ?? scan.device
+    const route = await ctx.storage.routes.get(input.scanId, input.url, device)
     if (!route)
-      throw new UnlighthouseError({ code: 'ROUTE_NOT_FOUND', message: `${input.scanId}/${input.url}` })
+      throw new UnlighthouseError({ code: 'ROUTE_NOT_FOUND', message: `${input.scanId}/${input.url} (device=${device})` })
+    // The LHR blob is gzipped (core.ts ingest writes via gzipSync). Without
+    // gunzipping first, JSON.parse barfs on the magic bytes. Pre-D-029 this
+    // was latent because no test path hit route.get end-to-end after a real
+    // scan; the matrix tests now do.
     let lhr: unknown = null
     if (route.lhrBlobKey) {
       const blob = await ctx.storage.blobs.get(route.lhrBlobKey)
       if (blob)
-        lhr = JSON.parse(new TextDecoder('utf-8').decode(blob))
+        lhr = JSON.parse(gunzipSync(blob as never).toString('utf-8'))
     }
     return { route, lhr } as CommandOutput<typeof RouteGet>
   },
@@ -32,8 +39,11 @@ export const routeRescan: Handler<typeof RouteRescan> = {
     const scan = await ctx.storage.scans.get(input.scanId)
     if (!scan)
       throw new UnlighthouseError({ code: 'SCAN_NOT_FOUND', message: `scanId=${input.scanId}` })
-    // Direct auditor call, bypassing the crawler. Mirrors core.ts:auditWrapper extraction shape.
-    const report = await ctx.auditor.audit(input.url, undefined, {})
+    // D-029: explicit device, then scan's primary. Auditor emulation profile
+    // is threaded through opts.device so the re-audit produces numbers
+    // consistent with the original device's row.
+    const device = input.device ?? scan.device
+    const report = await ctx.auditor.audit(input.url, undefined, { device })
     const extracted = (report as unknown as { extracted?: ExtractedMetrics }).extracted
     const metrics: ExtractedMetrics = extracted ?? {
       url: input.url,
@@ -53,9 +63,7 @@ export const routeRescan: Handler<typeof RouteRescan> = {
       lighthouseVersion: (report as { lighthouseVersion?: string }).lighthouseVersion ?? 'unknown',
       capturedAt: new Date().toISOString(),
     } as ExtractedMetrics
-    // D-029: re-audit lands under the scan's primary device for now. Future
-    // route.rescan input will accept an explicit device.
-    await ctx.storage.routes.upsert(input.scanId, scan.device, metrics)
+    await ctx.storage.routes.upsert(input.scanId, device, metrics)
     return { scanId: input.scanId, url: input.url, metrics } as CommandOutput<typeof RouteRescan>
   },
 }

--- a/packages/core/src/api/handlers/scan.ts
+++ b/packages/core/src/api/handlers/scan.ts
@@ -252,8 +252,15 @@ export const scanResults: Handler<typeof ScanResults> = {
     const scan = await ctx.storage.scans.get(input.scanId)
     if (!scan)
       notFound(input.scanId)
+    // D-029: pass device filter down to listForScan so the SQL `WHERE device
+    // = ?` narrows the row scan instead of pulling every row and filtering
+    // in JS. Omitted = return every row in the matrix.
     // TODO: push filter/sort down to storage when adapters support it.
-    const all = await ctx.storage.routes.listForScan(input.scanId, { page: 1, pageSize: 10_000 })
+    const all = await ctx.storage.routes.listForScan(input.scanId, {
+      page: 1,
+      pageSize: 10_000,
+      device: input.device,
+    })
     const filtered = applyRouteSort(applyRouteFilter(all.items, input.filter), input.sort)
     const start = (input.page - 1) * input.pageSize
     const items = filtered.slice(start, start + input.pageSize)

--- a/test/d029-command-device-filters.test.ts
+++ b/test/d029-command-device-filters.test.ts
@@ -1,0 +1,185 @@
+// D-029: command-input device filters. Routes are PK'd on (scanId, url,
+// device) so commands that look up or list routes need to thread the
+// caller's device choice through to storage.
+
+import type { Storage } from '@unlighthouse/contracts'
+import { packRun } from '@unlighthouse/core/api/handlers/pack'
+import { routeGet, routeRescan } from '@unlighthouse/core/api/handlers/route'
+import { scanResults } from '@unlighthouse/core/api/handlers/scan'
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+async function runMatrixScan(storage: Storage): Promise<string> {
+  const core = createUnlighthouseCore({
+    config: { site: 'http://example.com' } as never,
+    auditor: createMockAuditor(),
+    seeds: manualSeeds({ urls: ['http://example.com/', 'http://example.com/about'] }),
+    crawler: parallelMapCrawler({ concurrency: 1 }),
+    storage,
+  })
+  const session = core.run({ overrides: { device: ['mobile', 'desktop'] } })
+  await session.done
+  return session.scanId
+}
+
+const makeCtx = (storage: Storage) => ({
+  storage,
+  core: { hooks: undefined } as never,
+  auditor: createMockAuditor(),
+} as never)
+
+// ── route.get ──────────────────────────────────────────────────────────────
+
+describe('route.get accepts device input', () => {
+  let storage: Storage
+  let scanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    scanId = await runMatrixScan(storage)
+  })
+
+  it('returns the requested device row', async () => {
+    const desktop = await routeGet.run(
+      { scanId: scanId as never, url: 'http://example.com/' as never, device: 'desktop' },
+      makeCtx(storage),
+    )
+    expect(desktop.route.device).toBe('desktop')
+    expect(desktop.route.scorePerformance).toBe(0.98) // mock desktop bump
+
+    const mobile = await routeGet.run(
+      { scanId: scanId as never, url: 'http://example.com/' as never, device: 'mobile' },
+      makeCtx(storage),
+    )
+    expect(mobile.route.device).toBe('mobile')
+    expect(mobile.route.scorePerformance).toBe(0.9)
+  })
+
+  it('falls back to the scan primary device when input.device is omitted', async () => {
+    const out = await routeGet.run(
+      { scanId: scanId as never, url: 'http://example.com/' as never },
+      makeCtx(storage),
+    )
+    // The matrix above is ['mobile', 'desktop'] so primary = 'mobile'.
+    expect(out.route.device).toBe('mobile')
+  })
+})
+
+// ── scan.results ───────────────────────────────────────────────────────────
+
+describe('scan.results accepts device input', () => {
+  let storage: Storage
+  let scanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    scanId = await runMatrixScan(storage)
+  })
+
+  it('without device returns every (url, device) row', async () => {
+    const out = await scanResults.run(
+      { scanId: scanId as never, page: 1, pageSize: 50 } as never,
+      makeCtx(storage),
+    )
+    // 2 URLs × 2 devices.
+    expect(out.total).toBe(4)
+  })
+
+  it('with device filter returns only matching rows', async () => {
+    const out = await scanResults.run(
+      { scanId: scanId as never, device: 'desktop', page: 1, pageSize: 50 } as never,
+      makeCtx(storage),
+    )
+    expect(out.total).toBe(2)
+    expect(out.items.every(r => r.device === 'desktop')).toBe(true)
+  })
+})
+
+// ── pack.run ───────────────────────────────────────────────────────────────
+
+describe('pack.run accepts device input', () => {
+  let storage: Storage
+  let scanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    scanId = await runMatrixScan(storage)
+  })
+
+  it('device-specific run caches separately from the no-device aggregate run', async () => {
+    const mobile = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'mobile' } as never,
+      makeCtx(storage),
+    )
+    expect(mobile.cache).toBe('miss')
+
+    const desktop = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'desktop' } as never,
+      makeCtx(storage),
+    )
+    // Different device → different cache row → miss, not hit.
+    expect(desktop.cache).toBe('miss')
+
+    // Re-calling mobile hits cache.
+    const mobile2 = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'mobile' } as never,
+      makeCtx(storage),
+    )
+    expect(mobile2.cache).toBe('hit')
+  })
+
+  it('reports scores reflect the device the pack saw', async () => {
+    const mobile = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'mobile', refresh: true } as never,
+      makeCtx(storage),
+    )
+    const desktop = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'desktop', refresh: true } as never,
+      makeCtx(storage),
+    )
+    // overview pack aggregates per-category averages. Mock desktop perf is
+    // 0.98 vs mobile 0.9 — the gap should surface in the pack report too.
+    const mobileReport = mobile.report as { categoryAverages: { performance: number } }
+    const desktopReport = desktop.report as { categoryAverages: { performance: number } }
+    expect(desktopReport.categoryAverages.performance).toBeGreaterThan(
+      mobileReport.categoryAverages.performance,
+    )
+  })
+
+  it('wire packName is the bare pack id even when device cache key is mangled', async () => {
+    const out = await packRun.run(
+      { scanId: scanId as never, pack: 'overview', device: 'mobile' } as never,
+      makeCtx(storage),
+    )
+    // Internal cache key is 'overview@mobile' but the wire stays 'overview'.
+    expect(out.packName).toBe('overview')
+  })
+})
+
+// ── route.rescan ───────────────────────────────────────────────────────────
+
+describe('route.rescan accepts device input', () => {
+  it('re-audits the requested device row and threads device into AuditOpts', async () => {
+    const storage = memoryStorage()
+    const scanId = await runMatrixScan(storage)
+
+    // Re-audit only the desktop row. Verify by reading back — should still
+    // be marked device='desktop' with the desktop-shaped perf numbers.
+    const out = await routeRescan.run(
+      { scanId: scanId as never, url: 'http://example.com/' as never, device: 'desktop' },
+      makeCtx(storage),
+    )
+    expect(out.url).toBe('http://example.com/')
+    expect(out.metrics.scorePerformance).toBe(0.98)
+
+    const reread = await storage.routes.get(scanId as never, 'http://example.com/', 'desktop')
+    expect(reread?.device).toBe('desktop')
+    // Mobile row is untouched.
+    const mobile = await storage.routes.get(scanId as never, 'http://example.com/', 'mobile')
+    expect(mobile?.scorePerformance).toBe(0.9)
+  })
+})


### PR DESCRIPTION
## Summary

The D-029 storage layer (PR #320), runtime fan-out (PR #321), and compare/assert join fix (PR #322) are all on v1. Last gap on the agent-facing surface: the commands that read or list routes still didn't let callers specify a device. Matrix scans worked end-to-end internally, but `route.get`, `scan.results`, and `pack.run` from an MCP client always saw the scan's primary device.

This PR plumbs `device` through the four commands. Defaults preserve single-device behaviour.

## What changed

**Contracts**: `route.get`, `route.rescan`, `scan.results`, `pack.run` grow an optional `device` input.

**route.get / route.rescan**: prefer explicit device, fall back to scan primary. ROUTE_NOT_FOUND on a specific device now signals "form-factor wasn't part of the scan" — useful, don't swallow. route.rescan threads device into auditor opts.

**scan.results**: passes device down to listForScan so SQL `WHERE device = ?` does the narrowing.

**pack.run**: scopes the row set per device. Cache key encodes device into the pack name (`overview@mobile` internally) so mobile + desktop runs don't overwrite each other in the packRuns table. Wire `packName` stays the bare id — cache mangling is internal.

**Bug fix surfaced by testing**: `route.get` was `JSON.parse`-ing the raw blob output, but the LHR is gzipped on write. Pre-D-029 no test hit this path end-to-end. Added the missing `gunzipSync`.

## Test plan
- [x] full suite: 416/416 (8 new cases)
- [x] route.get: device input, default fallback
- [x] scan.results: 4 rows aggregated, 2 rows filtered
- [x] pack.run: mobile + desktop cache separately; scores differ
- [x] route.rescan: one device row touched, the other untouched