### PR TITLE
feat(core): Lighthouse 13 compatibility — pinned with fixture test

### DIFF
--- a/packages/core/src/packs/seo-basics.ts
+++ b/packages/core/src/packs/seo-basics.ts
@@ -115,6 +115,9 @@ const FIX_HINTS: Record<string, string> = {
   'canonical': 'Add `<link rel="canonical" href="…">` pointing at the preferred URL for this page.',
   'image-alt': 'Add `alt` attributes — search engines use them as a fallback when image content can\'t be parsed.',
   'structured-data': 'Add JSON-LD `schema.org` markup (Article, BreadcrumbList, Organization). Test with Google\'s Rich Results tool.',
+  // Note: `font-size` was removed in Lighthouse 13 (2025-10). Hint kept for
+  // pre-13 LHRs that still surface it; LH 13+ scans iterate the SEO category
+  // and won't include this id, so the hint table just won't be consulted.
   'font-size': 'Use a base font-size of at least 12px; 16px is the modern default. Tiny text hurts mobile rankings.',
   'viewport': 'Add `<meta name="viewport" content="width=device-width, initial-scale=1">` — required for mobile-friendliness.',
   'plugins': 'Remove `<embed>` / `<object>` / `<applet>` references. Flash and Java applets aren\'t crawled.',

--- a/packages/core/src/report/extract.ts
+++ b/packages/core/src/report/extract.ts
@@ -2,7 +2,24 @@ import type { Buffer } from 'node:buffer'
 import type { ExtractedRoute, LighthouseResult } from './types'
 import { gunzipSync, gzipSync } from 'node:zlib'
 
-// Audit ID mapping for LH version changes
+// Per-LH-major-version audit id remap. Lookup is `AUDIT_MAP[version][canonical]`
+// — when the canonical metric audit id has moved or been replaced in a given
+// LH version, list the replacement here. Returns the canonical id unchanged
+// when the version isn't pinned or the canonical id is still current.
+//
+// LH 13 audit removals (release notes 2025-10-10) — none of these touch the
+// canonical perf metrics we map below (LCP / CLS / TBT / FCP / SI / TTFB /
+// INP all kept their ids), but other consumers should be aware:
+//   - removed: font-size, offscreen-images, preload-fonts, uses-rel-preload,
+//     first-meaningful-paint, no-document-write, third-party-facades,
+//     uses-passive-event-listeners
+//   - deferred to insight equivalents: server-response-time still emits but
+//     defers numericValue to Document Latency insight. lcp-breakdown emits
+//     but defers to trace engine.
+//
+// Keeping the map empty for v12/v13 is the right behaviour — the canonical
+// ids resolve directly. This scaffolding is here so a future v14 rename
+// (the next likely break) only needs a row added, not a code change.
 const AUDIT_MAP: Record<string, Record<string, string>> = {
   12: {},
   13: {},

--- a/test/extract-lh13-compat.test.ts
+++ b/test/extract-lh13-compat.test.ts
@@ -1,0 +1,145 @@
+// Lighthouse 13 (2025-10) reshuffled the performance audits — several
+// classic ones got removed in favour of `*-insight` equivalents. Canonical
+// perf metric ids (LCP / CLS / TBT / FCP / SI / TTFB / INP) kept their
+// names, so extract.ts should keep producing the same shape against a v13
+// LHR. These tests pin that contract with a synthetic v13 fixture and
+// guard against future LH bumps silently dropping numeric values.
+
+import { extractRouteData, reconcileToContract } from '@unlighthouse/core/report'
+import { describe, expect, it } from 'vitest'
+
+function lh13Lhr(overrides: Record<string, unknown> = {}) {
+  return {
+    lighthouseVersion: '13.0.0',
+    userAgent: 'lh13-test/1.0',
+    categories: {
+      'performance': {
+        score: 0.92,
+        auditRefs: [
+          { id: 'largest-contentful-paint', weight: 25 },
+          { id: 'cumulative-layout-shift', weight: 25 },
+          { id: 'total-blocking-time', weight: 30 },
+          { id: 'first-contentful-paint', weight: 10 },
+          { id: 'speed-index', weight: 10 },
+          // LH 13 keeps the classic timing audits but defers some to insights.
+          { id: 'server-response-time', weight: 0 },
+          { id: 'render-blocking-insight', weight: 0 },
+          { id: 'document-latency-insight', weight: 0 },
+          { id: 'lcp-breakdown-insight', weight: 0 },
+        ],
+      },
+      'seo': {
+        score: 0.95,
+        // LH 13 removed font-size from the SEO category. seo-basics should
+        // not see it; this fixture exercises that path.
+        auditRefs: [
+          { id: 'is-crawlable', weight: 4 },
+          { id: 'document-title', weight: 1 },
+          { id: 'meta-description', weight: 1 },
+        ],
+      },
+    },
+    audits: {
+      'largest-contentful-paint': { score: 0.85, scoreDisplayMode: 'numeric', numericValue: 1450, displayValue: '1.5 s' },
+      'cumulative-layout-shift': { score: 1, scoreDisplayMode: 'numeric', numericValue: 0.02, displayValue: '0.02' },
+      'total-blocking-time': { score: 0.92, scoreDisplayMode: 'numeric', numericValue: 80, displayValue: '80 ms' },
+      'first-contentful-paint': { score: 0.97, scoreDisplayMode: 'numeric', numericValue: 920, displayValue: '0.9 s' },
+      'speed-index': { score: 0.88, scoreDisplayMode: 'numeric', numericValue: 1400, displayValue: '1.4 s' },
+      // LH 13: still emitted, defers numericValue to Document Latency insight.
+      'server-response-time': { score: 0.95, scoreDisplayMode: 'numeric', numericValue: 180, displayValue: '180 ms' },
+      'interaction-to-next-paint': { score: 1, scoreDisplayMode: 'numeric', numericValue: 90, displayValue: '90 ms' },
+      // Insight audits — LH 13 emphasises these. We don't extract numeric
+      // values from them (pack-side concern), but the shape should round-
+      // trip through reconcileToContract without exploding.
+      'render-blocking-insight': {
+        score: 0.5,
+        scoreDisplayMode: 'numeric',
+        displayValue: 'Potential savings of 250 ms',
+        title: 'Eliminate render-blocking resources',
+        metricSavings: { FCP: 250, LCP: 180 },
+      },
+      'document-latency-insight': {
+        score: 0.85,
+        scoreDisplayMode: 'numeric',
+        title: 'Reduce document latency',
+        metricSavings: { LCP: 150 },
+      },
+      'lcp-breakdown-insight': {
+        score: 0.9,
+        scoreDisplayMode: 'informative',
+        title: 'LCP breakdown',
+      },
+      'is-crawlable': { score: 1, scoreDisplayMode: 'binary', title: 'Page is crawlable' },
+      'document-title': { score: 1, scoreDisplayMode: 'binary', title: 'Document has a `<title>` element' },
+      'meta-description': { score: 0, scoreDisplayMode: 'binary', title: 'Document does not have a meta description' },
+    },
+    ...overrides,
+  } as never
+}
+
+describe('extract.ts against a Lighthouse 13 LHR', () => {
+  it('extractRouteData reads canonical perf metrics unchanged', () => {
+    const out = extractRouteData(lh13Lhr())
+    expect(out.lcp).toBe(1450)
+    expect(out.cls).toBe(20) // round(0.02 * 1000)
+    expect(out.tbt).toBe(80)
+    expect(out.fcp).toBe(920)
+    expect(out.si).toBe(1400)
+    expect(out.ttfb).toBe(180)
+    expect(out.inp).toBe(90)
+    expect(out.scores.performance).toBe(0.92)
+    expect(out.scores.seo).toBe(0.95)
+  })
+
+  it('reconcileToContract round-trips a v13 LHR including insight audits', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: lh13Lhr(),
+    })
+    // Insight audit projected with title + metricSavings.
+    expect(out.audits['render-blocking-insight'].title).toMatch(/render-blocking/)
+    expect(out.audits['render-blocking-insight'].metricSavings).toEqual({ FCP: 250, LCP: 180 })
+    expect(out.audits['render-blocking-insight'].severity).toBe('warn')
+
+    // Informative insight audits derive severity = 'pass' regardless of score.
+    expect(out.audits['lcp-breakdown-insight'].severity).toBe('pass')
+
+    // SEO auditRefs reflect what LH 13 actually ships — no font-size row.
+    expect(out.categories.seo?.auditRefs.map(r => r.id)).toEqual([
+      'is-crawlable',
+      'document-title',
+      'meta-description',
+    ])
+    // is-crawlable weight preserved for seo-basics severity derivation.
+    expect(out.categories.seo?.auditRefs[0]).toEqual({ id: 'is-crawlable', weight: 4 })
+
+    // metricSavings collapses to null on audits that don't carry it.
+    expect(out.audits['largest-contentful-paint'].metricSavings).toBeNull()
+  })
+
+  it('survives a v13 LHR where an insight audit ships without metricSavings', () => {
+    const lhr = lh13Lhr({
+      audits: {
+        ...(lh13Lhr().audits as Record<string, unknown>),
+        // An insight that didn't compute savings on this page — pack guards
+        // expect metricSavings === null, not undefined.
+        'image-delivery-insight': {
+          score: null,
+          scoreDisplayMode: 'notApplicable',
+          title: 'Optimise image delivery',
+        },
+      },
+    })
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr,
+    })
+    expect(out.audits['image-delivery-insight'].metricSavings).toBeNull()
+    // notApplicable always derives severity = 'pass' (never blocks a scan).
+    expect(out.audits['image-delivery-insight'].severity).toBe('pass')
+  })
+})


### PR DESCRIPTION
## Summary

Lighthouse 13 shipped 2025-10-10 and the v13.3.0 minor landed last week. The release reshuffled the performance audits (several classics removed in favour of `*-insight` equivalents) but kept all the canonical perf metric ids — LCP / CLS / TBT / FCP / SI / TTFB / INP. So extract.ts already produces the right shape against v13 LHRs; this PR pins that with a fixture test and documents what changed so the next bump is one-line.

## What changed

- **extract.ts**: `AUDIT_MAP` stays empty for v12/v13 (correct — no renames). Comment now lists v13 removals + insight deferrals so a future v14 row is one edit.
- **seo-basics**: noted that `font-size` was removed in v13. Hint stays in the table as a fallback for pre-13 LHRs that still surface it; v13 SEO category iteration just won't include the id.
- **test/extract-lh13-compat.test.ts**: synthetic v13 LHR fixture. Three cases — canonical metric extraction unchanged, `reconcileToContract` round-trips insight audits + their `metricSavings`, and an insight without `metricSavings` collapses to null instead of leaking undefined to pack guards.

## Test plan
- [x] full suite: 419/419 (3 new cases)
- [x] v13 fixture produces same metric shape as v12
- [x] insight audits with `metricSavings` get projected through
- [x] insight audits without `metricSavings` collapse to null

Defensive — PageSpeed Insights / DevTools v13 is rolling out and a fixture test beats a 2 AM bug report.