### PR TITLE
fix(d029): query.routes device filter on scanId path + projection

### DIFF
--- a/packages/core/src/api/handlers/query.ts
+++ b/packages/core/src/api/handlers/query.ts
@@ -10,10 +10,23 @@ export const queryRoutes: Handler<typeof QueryRoutes> = {
     // TODO: push filter/sort/projection down to storage when adapters support it.
     let pool: ScanRoute[] = []
     if (input.scanId) {
-      const res = await ctx.storage.routes.listForScan(input.scanId, { page: 1, pageSize: 10_000 })
+      // D-029: when scoping to one scan, also honour the device filter.
+      // Pre-fix this branch ignored input.device and returned every (url,
+      // device) row in a matrix scan, so the cross-scan path was device-
+      // aware but the per-scan path silently wasn't.
+      const res = await ctx.storage.routes.listForScan(input.scanId, {
+        page: 1,
+        pageSize: 10_000,
+        device: input.device,
+      })
       pool = res.items
     }
     else {
+      // Cross-scan path: scans.list already narrows on device via the scan
+      // metadata column (scan-level primary device). Routes inside those
+      // scans are then further narrowed below when input.device is set —
+      // matters for matrix scans where the scan's primary is 'mobile' but
+      // the caller asked for 'desktop' explicitly.
       const scans = await ctx.storage.scans.list({
         site: input.site,
         device: input.device,
@@ -21,7 +34,11 @@ export const queryRoutes: Handler<typeof QueryRoutes> = {
         pageSize: 500,
       })
       for (const scan of scans.items) {
-        const res = await ctx.storage.routes.listForScan(scan.scanId, { page: 1, pageSize: 10_000 })
+        const res = await ctx.storage.routes.listForScan(scan.scanId, {
+          page: 1,
+          pageSize: 10_000,
+          device: input.device,
+        })
         pool.push(...res.items)
       }
     }
@@ -36,7 +53,18 @@ export const queryRoutes: Handler<typeof QueryRoutes> = {
     if (input.projection?.length) {
       const keep = new Set<string>(input.projection)
       filtered = filtered.map((r) => {
-        const out: Record<string, unknown> = { url: r.url, path: r.path, scanId: r.scanId, lhrBlobKey: r.lhrBlobKey, capturedAt: r.capturedAt, lighthouseVersion: r.lighthouseVersion, routeName: r.routeName }
+        // D-029: device is part of row identity. Drop it from projection and
+        // matrix rows lose the only thing distinguishing them — keep it.
+        const out: Record<string, unknown> = {
+          url: r.url,
+          path: r.path,
+          scanId: r.scanId,
+          device: r.device,
+          lhrBlobKey: r.lhrBlobKey,
+          capturedAt: r.capturedAt,
+          lighthouseVersion: r.lighthouseVersion,
+          routeName: r.routeName,
+        }
         for (const m of ['lcp', 'cls', 'inp', 'fcp', 'ttfb', 'tbt', 'si']) {
           out[m] = keep.has(m) ? (r as unknown as Record<string, number | null>)[m] : null
         }

--- a/test/d029-query-routes-matrix.test.ts
+++ b/test/d029-query-routes-matrix.test.ts
@@ -1,0 +1,86 @@
+// D-029: query.routes is the cross-scan query surface. Two bugs surfaced
+// after the matrix-scan runtime landed:
+//
+//   1. The scanId-scoped branch ignored input.device and returned every
+//      (url, device) row in a matrix scan even when the caller asked for
+//      just one form-factor.
+//   2. The projection branch dropped the device field. Matrix rows then
+//      lost the only thing distinguishing them on the wire — two rows
+//      with the same URL but different device, indistinguishable.
+
+import type { Storage } from '@unlighthouse/contracts'
+import { createUnlighthouseCore } from '@unlighthouse/core'
+import { queryRoutes } from '@unlighthouse/core/api/handlers/query'
+import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
+import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
+import { manualSeeds } from '@unlighthouse/core/seeds/manual'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+async function runMatrixScan(storage: Storage): Promise<string> {
+  const core = createUnlighthouseCore({
+    config: { site: 'http://example.com' } as never,
+    auditor: createMockAuditor(),
+    seeds: manualSeeds({ urls: ['http://example.com/'] }),
+    crawler: parallelMapCrawler({ concurrency: 1 }),
+    storage,
+  })
+  const session = core.run({ overrides: { device: ['mobile', 'desktop'] } })
+  await session.done
+  return session.scanId
+}
+
+const makeCtx = (storage: Storage) => ({
+  storage,
+  core: { hooks: undefined } as never,
+  auditor: createMockAuditor(),
+} as never)
+
+describe('query.routes honours input.device', () => {
+  let storage: Storage
+  let scanId: string
+
+  beforeAll(async () => {
+    storage = memoryStorage()
+    scanId = await runMatrixScan(storage)
+  })
+
+  it('scanId-scoped: no device → both rows', async () => {
+    const out = await queryRoutes.run(
+      { scanId: scanId as never, page: 1, pageSize: 50 } as never,
+      makeCtx(storage),
+    )
+    expect(out.total).toBe(2)
+    expect(out.items.map(r => r.device).sort()).toEqual(['desktop', 'mobile'])
+  })
+
+  it('scanId-scoped: device filter narrows to one row', async () => {
+    const out = await queryRoutes.run(
+      { scanId: scanId as never, device: 'desktop', page: 1, pageSize: 50 } as never,
+      makeCtx(storage),
+    )
+    expect(out.total).toBe(1)
+    expect(out.items[0].device).toBe('desktop')
+    expect(out.items[0].scorePerformance).toBe(0.98)
+  })
+
+  it('projection preserves the device field so matrix rows stay distinguishable', async () => {
+    const out = await queryRoutes.run(
+      {
+        scanId: scanId as never,
+        projection: ['lcp'],
+        page: 1,
+        pageSize: 50,
+      } as never,
+      makeCtx(storage),
+    )
+    expect(out.items).toHaveLength(2)
+    // Both rows carry device; projection didn't strip it.
+    for (const r of out.items)
+      expect(r.device).toMatch(/^(mobile|desktop)$/)
+    // Same URL but different device — the only thing distinguishing them
+    // is the device field, so dropping it would have collapsed the wire.
+    expect(out.items[0].url).toBe(out.items[1].url)
+    expect(out.items[0].device).not.toBe(out.items[1].device)
+  })
+})


### PR DESCRIPTION
## Summary

Two related D-029 bugs in `query.routes` that the previous PRs missed because their test coverage didn't exercise this path against a matrix scan.

## Bugs

**1. scanId-scoped path ignored `input.device`.** The cross-scan branch passed device down via `scans.list`, but when the caller specified a `scanId` the handler just called `listForScan(scanId)` without forwarding the device filter. Matrix scans returned every (url, device) row even when the caller asked for one form-factor.

**2. Projection dropped the device field.** When `input.projection` was set, the handler built its output object by hand and forgot to copy `device`. Matrix rows then collapsed: two same-url projection objects with the only distinguishing field stripped.

Both surfaced by the matrix-scan runtime (PR #321) but only become observable when a caller actually uses query.routes against a matrix scan — which agents will start doing now that pack.run can be scoped per device.

## Test plan
- [x] full suite: 422/422 (3 new cases)
- [x] scanId + no device → both rows
- [x] scanId + device='desktop' → only desktop row
- [x] projection preserves device field