### PR TITLE
feat(packs): a11y + images read from reconciled blob — bounded details.items projection

### DIFF
--- a/packages/contracts/src/types/atoms.ts
+++ b/packages/contracts/src/types/atoms.ts
@@ -142,9 +142,36 @@ export type ScanRoute = z.infer<typeof ScanRouteSchema>
 //
 // `title` / `description` / `metricSavings` are pulled through so packs
 // don't fall back to raw LHR just to read a human label or a savings number.
-// `details.items` (element-level data) is intentionally NOT projected — the
-// blob would balloon, and the handful of packs that need it (a11y-quick-wins,
-// images) still fetch the raw LHR for those audits.
+//
+// `details.items` is projected per-audit ONLY for an allowlist of audit ids
+// that packs actively need (image-* audits for the `images` pack, a11y
+// element-level audits for `a11y-quick-wins`). Items are capped at 30 per
+// audit and only the small set of fields below is kept. Packs that want
+// the full LHR detail array still call getLhr — this projection keeps the
+// blob bounded while making the common case (drill into one image / one
+// element) hit a sub-MB cached blob instead of re-parsing 200KB of LHR.
+const AuditDetailNodeSchema = z.object({
+  selector: z.string().nullable(),
+  snippet: z.string().nullable(),
+  nodeLabel: z.string().nullable(),
+})
+
+const AuditDetailItemSchema = z.object({
+  // URL-shaped fields (image-* audits + render-blocking-insight).
+  url: z.string().nullable(),
+  // For audits that emit an item type (LHR distinguishes 'node' from
+  // checklist rows on lcp-discovery-insight, for example).
+  type: z.string().nullable(),
+  totalBytes: z.number().nullable(),
+  wastedBytes: z.number().nullable(),
+  // Element-level data for a11y / element audits.
+  node: AuditDetailNodeSchema.nullable(),
+  snippet: z.string().nullable(),
+  // First sub-item's reason field — image-delivery-insight stuffs the
+  // remediation hint there. We keep only the first to bound size.
+  reason: z.string().nullable(),
+})
+
 const AuditFindingSchema = z.object({
   // Lighthouse audit id, e.g. 'uses-optimized-images' or 'image-delivery-insight'.
   id: z.string(),
@@ -172,6 +199,11 @@ const AuditFindingSchema = z.object({
     CLS: z.number().optional(),
     TBT: z.number().optional(),
   }).nullable(),
+  // Capped + whitelisted per-item detail. Only populated for the small set
+  // of audits the built-in packs depend on (see PROJECTED_DETAIL_AUDITS in
+  // core/report/extract.ts). null for every other audit — packs fall through
+  // to getLhr for those.
+  items: z.array(AuditDetailItemSchema).nullable(),
 })
 export type AuditFinding = z.infer<typeof AuditFindingSchema>
 

--- a/packages/core/src/packs/a11y-quick-wins.ts
+++ b/packages/core/src/packs/a11y-quick-wins.ts
@@ -150,58 +150,137 @@ interface RawFinding {
 
 // ── Reconciler ──────────────────────────────────────────────────────────────
 
+// D-029 + reconciled-details: per-route view as it lands from either substrate
+// (reconciled blob first, LHR fallback). Element-level data was projected
+// into the reconciled blob in this PR — earlier scans without that
+// projection still work via getLhr.
+interface RouteView {
+  // (auditId → { weight, title, description, items })
+  audits: Map<string, {
+    weight: number
+    title: string
+    description: string | null
+    items: Array<{ selector: string | null, snippet: string | null, nodeLabel: string | null }>
+    failed: boolean
+  }>
+}
+
+async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteView | null> {
+  // Prefer reconciled. Returns null on miss so we drop through to the LHR
+  // path — keeps older scans working without re-ingesting them.
+  if (ctx.getReconciled) {
+    const reconciled = await ctx.getReconciled(url, 'mobile').catch(() => null) as
+      | { categories?: { accessibility?: { auditRefs?: Array<{ id: string, weight: number }> } }
+        , audits?: Record<string, {
+          score: number | null
+          title: string | null
+          description: string | null
+          items: Array<{ node?: { selector: string | null, snippet: string | null, nodeLabel: string | null } | null }> | null
+        }> }
+      | null
+    if (reconciled?.audits && reconciled.categories?.accessibility?.auditRefs?.length) {
+      const audits = new Map<string, RouteView['audits'] extends Map<string, infer V> ? V : never>()
+      const weights = new Map<string, number>()
+      for (const ref of reconciled.categories.accessibility.auditRefs)
+        weights.set(ref.id, ref.weight)
+      for (const [id, weight] of weights) {
+        const a = reconciled.audits[id]
+        if (!a)
+          continue
+        const failed = a.score != null && a.score < 1
+        const items: RouteView['audits'] extends Map<string, infer V> ? V['items'] : never = []
+        if (failed && a.items) {
+          for (const it of a.items) {
+            const node = it.node
+            if (!node)
+              continue
+            items.push({
+              selector: node.selector,
+              snippet: node.snippet,
+              nodeLabel: node.nodeLabel,
+            })
+          }
+        }
+        audits.set(id, {
+          weight,
+          title: a.title ?? id,
+          description: a.description,
+          items,
+          failed,
+        })
+      }
+      return { audits }
+    }
+  }
+  // LHR fallback.
+  if (ctx.getLhr) {
+    const lhr = await ctx.getLhr(url, 'mobile').catch(() => null) as LhrLike | null
+    if (!lhr?.audits || !lhr.categories?.accessibility?.auditRefs)
+      return null
+    const audits = new Map<string, RouteView['audits'] extends Map<string, infer V> ? V : never>()
+    for (const ref of lhr.categories.accessibility.auditRefs) {
+      const a = lhr.audits[ref.id]
+      if (!a)
+        continue
+      const failed = a.score != null && a.score < 1
+      const items: RouteView['audits'] extends Map<string, infer V> ? V['items'] : never = []
+      if (failed) {
+        for (const it of a.details?.items ?? []) {
+          const node = it.node
+          if (!node)
+            continue
+          items.push({
+            selector: node.selector ?? null,
+            snippet: node.snippet ?? null,
+            nodeLabel: node.nodeLabel ?? null,
+          })
+        }
+      }
+      audits.set(ref.id, {
+        weight: ref.weight,
+        title: a.title ?? ref.id,
+        description: a.description ?? null,
+        items,
+        failed,
+      })
+    }
+    return { audits }
+  }
+  return null
+}
+
 async function reconcile(ctx: PackReconcileCtx): Promise<A11yReport> {
-  if (!ctx.getLhr) {
-    throw new Error('a11y-quick-wins pack requires a getLhr fetcher (PackReconcileCtx.getLhr is undefined).')
+  if (!ctx.getReconciled && !ctx.getLhr) {
+    throw new Error('a11y-quick-wins pack requires getReconciled or getLhr (both PackReconcileCtx fetchers were undefined).')
   }
 
   const findings = new Map<string, RawFinding>()
   let routesAnalysed = 0
-  // Captured once from the first LHR (a11y category metadata).
-  let auditWeights: Map<string, number> | null = null
 
   for (const row of ctx.routes) {
-    const lhr = await ctx.getLhr(row.url, 'mobile').catch(() => null) as LhrLike | null
-    if (!lhr?.audits)
+    const view = await loadRouteView(row.url, ctx)
+    if (!view)
       continue
     routesAnalysed++
 
-    // Build the audit-id → weight map on first LHR. The category shape is
-    // stable across routes within a scan.
-    if (!auditWeights) {
-      auditWeights = new Map()
-      for (const ref of lhr.categories?.accessibility?.auditRefs ?? [])
-        auditWeights.set(ref.id, ref.weight)
-    }
-
-    for (const [auditId, audit] of Object.entries(lhr.audits)) {
-      const weight = auditWeights.get(auditId)
-      if (weight == null)
-        continue // not in the a11y category
-      const score = audit.score
-      if (score == null || score === 1)
-        continue // passing or N/A
-      const items = audit.details?.items ?? []
-      if (!items.length)
+    for (const [auditId, audit] of view.audits) {
+      if (!audit.failed || audit.items.length === 0)
         continue
 
       let finding = findings.get(auditId)
       if (!finding) {
         finding = {
           auditId,
-          title: audit.title ?? auditId,
-          description: audit.description ?? null,
-          weight,
+          title: audit.title,
+          description: audit.description,
+          weight: audit.weight,
           elements: new Map(),
         }
         findings.set(auditId, finding)
       }
 
-      for (const it of items) {
-        const node = it.node
-        if (!node)
-          continue
-        const selector = node.selector ?? '(no selector)'
+      for (const it of audit.items) {
+        const selector = it.selector ?? '(no selector)'
         const existing = finding.elements.get(selector)
         if (existing) {
           existing.routes.add(row.url)
@@ -209,8 +288,8 @@ async function reconcile(ctx: PackReconcileCtx): Promise<A11yReport> {
         else {
           finding.elements.set(selector, {
             selector,
-            snippet: node.snippet ?? null,
-            nodeLabel: node.nodeLabel ?? null,
+            snippet: it.snippet,
+            nodeLabel: it.nodeLabel,
             firstSeenOn: row.url,
             routes: new Set([row.url]),
           })

--- a/packages/core/src/packs/images.ts
+++ b/packages/core/src/packs/images.ts
@@ -266,16 +266,73 @@ function extractMissingAlt(routeUrl: string, lhr: LhrLike, sink: Map<string, Raw
 
 // ── Reconciler ──────────────────────────────────────────────────────────────
 
+// Shim a reconciled report's audits map into the LhrLike shape the existing
+// extractors already iterate. The reconciled projection keeps the same field
+// names (url, totalBytes, wastedBytes, snippet, type, node) on each item,
+// plus pulls the first sub-item's reason — so the extractors that read
+// `it.url` / `it.wastedBytes` / `it.subItems[0].reason` keep working when
+// the source is reconciled instead of raw LHR.
+//
+// Returns null when neither substrate is available (caller skips the row).
+async function loadRouteAuditsAsLhrLike(url: string, ctx: PackReconcileCtx): Promise<LhrLike | null> {
+  if (ctx.getReconciled) {
+    const reconciled = await ctx.getReconciled(url, 'mobile').catch(() => null) as
+      | { audits?: Record<string, {
+        score: number | null
+        metricSavings: { LCP?: number, FCP?: number, INP?: number, CLS?: number, TBT?: number } | null
+        items: Array<{
+          url: string | null
+          type: string | null
+          totalBytes: number | null
+          wastedBytes: number | null
+          node: { selector: string | null, snippet: string | null, nodeLabel: string | null } | null
+          snippet: string | null
+          reason: string | null
+        }> | null
+      }> }
+      | null
+    if (reconciled?.audits) {
+      const audits: NonNullable<LhrLike['audits']> = {}
+      for (const [id, a] of Object.entries(reconciled.audits)) {
+        // Re-pack items into the LHR shape the extractors read: surface the
+        // projected `reason` back under subItems[0].reason where the image-
+        // delivery extractor expects it.
+        const items = (a.items ?? []).map((it) => {
+          const out: Record<string, unknown> = {}
+          if (it.url != null) out.url = it.url
+          if (it.type != null) out.type = it.type
+          if (it.totalBytes != null) out.totalBytes = it.totalBytes
+          if (it.wastedBytes != null) out.wastedBytes = it.wastedBytes
+          if (it.node) out.node = it.node
+          if (it.snippet != null) out.snippet = it.snippet
+          if (it.reason != null) out.subItems = { items: [{ reason: it.reason }] }
+          return out
+        })
+        audits[id] = {
+          score: a.score,
+          metricSavings: a.metricSavings ?? undefined,
+          details: items.length ? { items } : undefined,
+        }
+      }
+      return { audits }
+    }
+  }
+  if (ctx.getLhr) {
+    return (await ctx.getLhr(url, 'mobile').catch(() => null)) as LhrLike | null
+  }
+  return null
+}
+
 async function reconcile(ctx: PackReconcileCtx): Promise<ImagesReport> {
-  if (!ctx.getLhr) {
-    throw new Error('images pack requires a getLhr fetcher (PackReconcileCtx.getLhr is undefined).')
+  if (!ctx.getReconciled && !ctx.getLhr) {
+    throw new Error('images pack requires getReconciled or getLhr (both PackReconcileCtx fetchers were undefined).')
   }
 
   const sink = new Map<string, RawFinding>()
   let routesAnalysed = 0
 
   for (const row of ctx.routes) {
-    const lhr = await ctx.getLhr(row.url, 'mobile').catch(() => null) as LhrLike | null
+    const lhr = await loadRouteAuditsAsLhrLike(row.url, ctx)
     if (!lhr)
       continue
     routesAnalysed++

--- a/packages/core/src/report/extract.ts
+++ b/packages/core/src/report/extract.ts
@@ -159,6 +159,16 @@ export function reconcileRoute(args: {
 //   - score <  0.5 → 'fail'
 //   - score null on a numeric/binary audit → 'fail' (treats "couldn't run" as
 //     pessimistic so packs surface it)
+interface ContractAuditDetailItem {
+  url: string | null
+  type: string | null
+  totalBytes: number | null
+  wastedBytes: number | null
+  node: { selector: string | null, snippet: string | null, nodeLabel: string | null } | null
+  snippet: string | null
+  reason: string | null
+}
+
 interface ContractAuditFinding {
   id: string
   score: number | null
@@ -168,6 +178,74 @@ interface ContractAuditFinding {
   description: string | null
   severity: 'pass' | 'warn' | 'fail'
   metricSavings: { LCP?: number, FCP?: number, INP?: number, CLS?: number, TBT?: number } | null
+  items: ContractAuditDetailItem[] | null
+}
+
+// Audits whose `details.items` we project into the reconciled blob. Adding
+// an id here costs ~30 items × 6 fields per route → typically <2KB even on
+// the worst-offender pages. Off-list audits stay items: null and the packs
+// that need them fall through to getLhr.
+//
+// Membership chosen by what the built-in packs actually read (a11y-quick-
+// wins + images today). Third-party packs can still call getLhr.
+const PROJECTED_DETAIL_AUDITS = new Set<string>([
+  // images pack
+  'image-delivery-insight',
+  'lcp-discovery-insight',
+  'unsized-images',
+  'image-alt',
+  // a11y-quick-wins pack reads element-level data on every failing a11y
+  // audit; we project the common ids the pack covers via FIX_HINTS. Other
+  // a11y audits stay on the LHR path until a real workflow needs them in
+  // the blob.
+  'color-contrast',
+  'label',
+  'button-name',
+  'link-name',
+  'html-has-lang',
+  'meta-viewport',
+  'document-title',
+  'aria-valid-attr-value',
+  'aria-valid-attr',
+  'aria-allowed-attr',
+  'aria-hidden-body',
+  'aria-hidden-focus',
+  'aria-conditional-attr',
+  'aria-prohibited-attr',
+  'tabindex',
+  'duplicate-id-aria',
+  'duplicate-id-active',
+  'frame-title',
+  'valid-lang',
+  'video-caption',
+])
+
+const DETAIL_ITEM_CAP = 30
+
+function projectDetailItem(raw: unknown): ContractAuditDetailItem {
+  const r = (raw ?? {}) as Record<string, unknown>
+  const rawNode = r.node as Record<string, unknown> | undefined
+  const node = rawNode
+    ? {
+        selector: typeof rawNode.selector === 'string' ? rawNode.selector : null,
+        snippet: typeof rawNode.snippet === 'string' ? rawNode.snippet : null,
+        nodeLabel: typeof rawNode.nodeLabel === 'string' ? rawNode.nodeLabel : null,
+      }
+    : null
+  // image-delivery-insight stuffs the remediation hint into subItems[0].reason.
+  // Pulling the first sub-item's reason is enough for the pack; we don't
+  // project the full subItems tree.
+  const subItems = (r.subItems as { items?: Array<{ reason?: unknown }> } | undefined)?.items
+  const reason = typeof subItems?.[0]?.reason === 'string' ? subItems[0].reason : null
+  return {
+    url: typeof r.url === 'string' ? r.url : null,
+    type: typeof r.type === 'string' ? r.type : null,
+    totalBytes: typeof r.totalBytes === 'number' ? r.totalBytes : null,
+    wastedBytes: typeof r.wastedBytes === 'number' ? r.wastedBytes : null,
+    node,
+    snippet: typeof r.snippet === 'string' ? r.snippet : null,
+    reason,
+  }
 }
 
 export function reconcileToContract(args: {
@@ -196,6 +274,8 @@ export function reconcileToContract(args: {
     audits: Record<string, ContractAuditFinding>
     provenance: { lighthouseVersion: string, userAgent: string | null, capturedAt: string }
   } {
+  // The function signature spelled out above mirrors the ReconciledReport
+  // contract atom 1:1 — adding fields here means adding them in atoms.ts too.
   const { scanId, url, device, lhr } = args
   const ext = extractRouteData(lhr)
 
@@ -223,6 +303,7 @@ export function reconcileToContract(args: {
       title?: string
       description?: string
       metricSavings?: { LCP?: number, FCP?: number, INP?: number, CLS?: number, TBT?: number }
+      details?: { items?: unknown[] }
     }
     const mode = (['numeric', 'binary', 'informative', 'manual', 'notApplicable'].includes(aa?.scoreDisplayMode ?? '')
       ? aa.scoreDisplayMode
@@ -240,6 +321,15 @@ export function reconcileToContract(args: {
       if (Object.keys(out).length > 0)
         metricSavings = out
     }
+    // Project details.items only for allowlisted audits and cap the count.
+    // Off-list audits + empty arrays stay items: null so the packs can guard
+    // on truthiness without worrying about empty-array footguns.
+    let items: ContractAuditDetailItem[] | null = null
+    if (PROJECTED_DETAIL_AUDITS.has(id)) {
+      const raw = aa?.details?.items
+      if (Array.isArray(raw) && raw.length > 0)
+        items = raw.slice(0, DETAIL_ITEM_CAP).map(projectDetailItem)
+    }
     audits[id] = {
       id,
       score: aa?.score ?? null,
@@ -249,6 +339,7 @@ export function reconcileToContract(args: {
       description: typeof aa?.description === 'string' ? aa.description : null,
       severity: deriveSeverity(aa?.score ?? null, mode),
       metricSavings,
+      items,
     }
   }
 

--- a/test/reconciled-details-projection.test.ts
+++ b/test/reconciled-details-projection.test.ts
@@ -1,0 +1,282 @@
+// Reconciled blob now projects details.items for an allowlist of audits.
+// These tests pin three things:
+//   1. Off-list audits keep items: null (no accidental balloon).
+//   2. On-list audits project items, capped at DETAIL_ITEM_CAP = 30.
+//   3. The a11y + images packs read from reconciled instead of opening LHR
+//      when both fetchers are available; they fall back to LHR when only
+//      that's present.
+
+import type { PackReconcileCtx, ReconciledReport, ScanRoute } from '@unlighthouse/contracts'
+import { a11yQuickWinsPack } from '@unlighthouse/core/packs/a11y-quick-wins'
+import { imagesPack } from '@unlighthouse/core/packs/images'
+import { reconcileToContract } from '@unlighthouse/core/report'
+import { describe, expect, it, vi } from 'vitest'
+
+// ── ReconciledReport projection ────────────────────────────────────────────
+
+function lhrWithItems() {
+  return {
+    lighthouseVersion: '12.0.0',
+    userAgent: 'test/1.0',
+    categories: {
+      accessibility: { score: 0.8, auditRefs: [{ id: 'image-alt', weight: 10 }] },
+    },
+    audits: {
+      // On-list audit — should get its items projected.
+      'image-alt': {
+        score: 0,
+        scoreDisplayMode: 'binary',
+        title: 'Image elements have `[alt]` attributes',
+        description: 'Informative elements should aim for short, descriptive alt text.',
+        details: {
+          items: Array.from({ length: 50 }, (_, i) => ({
+            node: { selector: `img.broken-${i}`, snippet: `<img src="${i}.jpg">`, nodeLabel: '' },
+            url: `https://cdn.example.com/${i}.jpg`,
+          })),
+        },
+      },
+      // Off-list audit (insight audit not in the allowlist) — items stay null.
+      'render-blocking-insight': {
+        score: 0.5,
+        scoreDisplayMode: 'numeric',
+        title: 'Render-blocking',
+        details: { items: [{ url: 'https://example.com/blocker.js' }] },
+      },
+    },
+  } as never
+}
+
+describe('reconciled report details.items projection', () => {
+  it('projects details for allowlisted audits, capped at 30', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: lhrWithItems(),
+    })
+    expect(out.audits['image-alt'].items).not.toBeNull()
+    expect(out.audits['image-alt'].items).toHaveLength(30)
+    expect(out.audits['image-alt'].items![0].node?.selector).toBe('img.broken-0')
+    expect(out.audits['image-alt'].items![0].url).toBe('https://cdn.example.com/0.jpg')
+  })
+
+  it('off-list audits keep items: null even when LHR carries data', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: lhrWithItems(),
+    })
+    expect(out.audits['render-blocking-insight'].items).toBeNull()
+  })
+
+  it('audits without any details.items keep items: null', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: {
+        ...lhrWithItems(),
+        audits: {
+          ...(lhrWithItems() as { audits: Record<string, unknown> }).audits,
+          'image-alt': {
+            score: 1,
+            scoreDisplayMode: 'binary',
+            title: 'Image elements have alt',
+            // No details → no items.
+          },
+        },
+      } as never,
+    })
+    expect(out.audits['image-alt'].items).toBeNull()
+  })
+
+  it('projects subItems[0].reason as the item-level reason field', () => {
+    const out = reconcileToContract({
+      scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      url: 'http://example.com/',
+      device: 'mobile',
+      lhr: {
+        ...lhrWithItems(),
+        categories: {
+          ...((lhrWithItems() as { categories: Record<string, unknown> }).categories),
+          performance: { score: 0.9, auditRefs: [{ id: 'image-delivery-insight', weight: 0 }] },
+        },
+        audits: {
+          ...((lhrWithItems() as { audits: Record<string, unknown> }).audits),
+          'image-delivery-insight': {
+            score: 0.5,
+            scoreDisplayMode: 'numeric',
+            title: 'Optimise image delivery',
+            details: {
+              items: [{
+                url: 'https://example.com/hero.jpg',
+                wastedBytes: 50000,
+                totalBytes: 200000,
+                subItems: { items: [{ reason: 'Use modern image format (WebP).' }] },
+              }],
+            },
+          },
+        },
+      } as never,
+    })
+    const item = out.audits['image-delivery-insight'].items?.[0]
+    expect(item?.url).toBe('https://example.com/hero.jpg')
+    expect(item?.wastedBytes).toBe(50000)
+    expect(item?.reason).toBe('Use modern image format (WebP).')
+  })
+})
+
+// ── Pack migration: getReconciled preferred over getLhr ────────────────────
+
+function buildRoute(url: string): ScanRoute {
+  return {
+    scanId: 'scan-1' as never,
+    url: url as never,
+    device: 'mobile',
+    path: new URL(url).pathname,
+    routeName: null,
+    status: 'completed',
+    scorePerformance: 0.9,
+    scoreAccessibility: 0.5,
+    scoreSeo: 1,
+    scoreBestPractices: 1,
+    lcp: 1200,
+    cls: 0.01,
+    inp: 100,
+    fcp: 1000,
+    ttfb: 200,
+    tbt: 50,
+    si: 1500,
+    routeMatcherId: null,
+    lhrBlobKey: 'scans/scan-1/lhr/x.json.gz',
+    htmlBlobKey: null,
+    auditedAt: new Date().toISOString(),
+  } as never
+}
+
+function reconciledForA11y(): ReconciledReport {
+  return {
+    scanId: 'scan-1' as never,
+    url: 'http://example.com/' as never,
+    device: 'mobile',
+    metrics: {
+      scorePerformance: 0.9, scoreAccessibility: 0.5, scoreSeo: 1, scoreBestPractices: 1,
+      lcp: 1200, cls: 0.01, inp: 100, fcp: 1000, ttfb: 200, tbt: 50, si: 1500,
+    },
+    categories: {
+      accessibility: { score: 0.5, auditRefs: [{ id: 'color-contrast', weight: 7 }] },
+    },
+    audits: {
+      'color-contrast': {
+        id: 'color-contrast',
+        score: 0,
+        scoreDisplayMode: 'binary',
+        displayValue: null,
+        title: 'Background and foreground colors do not have a sufficient contrast ratio.',
+        description: 'Low-contrast text is hard to read.',
+        severity: 'fail',
+        metricSavings: null,
+        items: [
+          { url: null, type: null, totalBytes: null, wastedBytes: null, node: { selector: 'a.dim', snippet: '<a>click</a>', nodeLabel: 'click' }, snippet: null, reason: null },
+        ],
+      },
+    },
+    provenance: { lighthouseVersion: '12.0.0', userAgent: null, capturedAt: new Date().toISOString() },
+  }
+}
+
+describe('a11y-quick-wins reads from reconciled when available', () => {
+  it('uses getReconciled and skips getLhr', async () => {
+    const getReconciled = vi.fn(async () => reconciledForA11y())
+    const getLhr = vi.fn(async () => null)
+
+    const report = await a11yQuickWinsPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [buildRoute('http://example.com/')],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    expect(getLhr).not.toHaveBeenCalled()
+
+    const cc = report.findings.find(f => f.auditId === 'color-contrast')
+    expect(cc).toBeDefined()
+    expect(cc!.topElements[0].selector).toBe('a.dim')
+    expect(cc!.routeCount).toBe(1)
+  })
+
+  it('falls back to getLhr when reconciled returns null', async () => {
+    const getReconciled = vi.fn(async () => null)
+    const getLhr = vi.fn(async () => ({
+      categories: { accessibility: { auditRefs: [{ id: 'color-contrast', weight: 7 }] } },
+      audits: {
+        'color-contrast': {
+          score: 0,
+          title: 'Contrast',
+          details: { items: [{ node: { selector: 'a.dim', snippet: '<a>x</a>', nodeLabel: 'x' } }] },
+        },
+      },
+    }))
+
+    const report = await a11yQuickWinsPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [buildRoute('http://example.com/')],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    expect(getLhr).toHaveBeenCalledTimes(1)
+    expect(report.findings).toHaveLength(1)
+  })
+})
+
+describe('images pack reads from reconciled when available', () => {
+  it('uses getReconciled and skips getLhr', async () => {
+    const reconciled: ReconciledReport = {
+      scanId: 'scan-1' as never,
+      url: 'http://example.com/' as never,
+      device: 'mobile',
+      metrics: {
+        scorePerformance: 0.9, scoreAccessibility: 1, scoreSeo: 1, scoreBestPractices: 1,
+        lcp: 1200, cls: 0.01, inp: 100, fcp: 1000, ttfb: 200, tbt: 50, si: 1500,
+      },
+      categories: {},
+      audits: {
+        'image-delivery-insight': {
+          id: 'image-delivery-insight',
+          score: 0.5,
+          scoreDisplayMode: 'numeric',
+          displayValue: '50 KB',
+          title: 'Optimise image delivery',
+          description: null,
+          severity: 'warn',
+          metricSavings: { LCP: 150 },
+          items: [
+            { url: 'https://cdn.example.com/hero.jpg', type: null, totalBytes: 200000, wastedBytes: 50000, node: null, snippet: null, reason: 'Convert to WebP' },
+          ],
+        },
+      },
+      provenance: { lighthouseVersion: '12.0.0', userAgent: null, capturedAt: new Date().toISOString() },
+    }
+    const getReconciled = vi.fn(async () => reconciled)
+    const getLhr = vi.fn(async () => null)
+
+    const report = await imagesPack.reconciler({
+      scanId: 'scan-1' as never,
+      routes: [buildRoute('http://example.com/')],
+      getReconciled,
+      getLhr,
+    } as PackReconcileCtx)
+
+    expect(getReconciled).toHaveBeenCalledTimes(1)
+    expect(getLhr).not.toHaveBeenCalled()
+
+    const unopt = report.findings.find(f => f.kind === 'unoptimized')
+    expect(unopt).toBeDefined()
+    expect(unopt!.wastedBytes).toBe(50000)
+    expect(unopt!.reason).toBe('Convert to WebP')
+  })
+})


### PR DESCRIPTION
## Summary

The last two built-in packs that were still opening the raw LHR per route — `a11y-quick-wins` and `images` — now read from the reconciled blob like cwv + seo-basics already do. The blocking dependency was `details.items` (element-level data) which we'd deliberately kept out of the blob to bound size. This PR adds a **bounded** projection: an allowlist of audit ids the built-in packs actually consume, capped at 30 items per audit, with a small field whitelist.

After this, every built-in pack hits the reconciled blob first and only falls through to getLhr for older scans.

## What changed

**Contracts**: AuditFinding.items (capped AuditDetailItem array or null). null on off-list audits, missing details, or empty arrays — pack guards stay simple. Field whitelist covers url / type / totalBytes / wastedBytes / node{selector,snippet,nodeLabel} / snippet / reason (the last hoisted from subItems[0].reason where image-delivery-insight stuffs its hint).

**core/report/extract.ts**: PROJECTED_DETAIL_AUDITS allowlist + DETAIL_ITEM_CAP = 30. Allowlist membership chosen by what a11y-quick-wins + images actually read today. Worst-case overhead per route is under 2KB.

**a11y-quick-wins**: loadRouteView helper reshapes either substrate into the same internal form. Reconciler loop unchanged. Falls back to getLhr when reconciled returns null.

**images**: loadRouteAuditsAsLhrLike shim re-packs reconciled audits into the LhrLike form the existing extractors already iterate. Zero changes to extraction logic. Falls back to getLhr when reconciled is missing.

## Test plan
- [x] full suite: 430/430 (7 new cases)
- [x] on-list audit projects items, capped at 30
- [x] off-list audit keeps items: null even with LHR data
- [x] empty / missing details collapse to null
- [x] subItems[0].reason hoisted to flat item.reason
- [x] a11y + images both use getReconciled, skip getLhr when both wired
- [x] a11y falls back to getLhr when reconciled returns null