### PR TITLE
chore(release): test:attw + test:publint across the workspace

### DIFF
--- a/packages/audit-pool/package.json
+++ b/packages/audit-pool/package.json
@@ -28,7 +28,9 @@
   "scripts": {
     "build": "obuild",
     "stub": "obuild --stub",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:attw": "attw --pack --profile node16",
+    "test:publint": "publint"
   },
   "peerDependencies": {
     "puppeteer-core": "catalog:dependencies"

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -20,8 +20,11 @@
     "node": ">=22.0.0"
   },
   "scripts": {
+    "build": "obuild",
     "stub": "obuild --stub",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:attw": "attw --pack --profile node16",
+    "test:publint": "publint"
   },
   "dependencies": {
     "@cloudflare/puppeteer": "catalog:",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -40,7 +40,9 @@
   "scripts": {
     "build": "obuild",
     "stub": "obuild --stub",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:attw": "attw --pack --profile node16",
+    "test:publint": "publint"
   },
   "peerDependencies": {
     "drizzle-orm": "catalog:dependencies",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,9 @@
     "build": "obuild",
     "stub": "obuild --stub && node ./scripts/build-worker.mjs",
     "typecheck": "tsc --noEmit",
-    "db:generate": "drizzle-kit generate"
+    "db:generate": "drizzle-kit generate",
+    "test:attw": "attw --pack --profile node16",
+    "test:publint": "publint"
   },
   "peerDependencies": {
     "better-sqlite3": "catalog:dependencies",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,8 +20,11 @@
     "node": ">=22.0.0"
   },
   "scripts": {
+    "build": "obuild",
     "stub": "obuild --stub",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:attw": "attw --pack --profile node16",
+    "test:publint": "publint"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:",

--- a/v1.md
+++ b/v1.md
@@ -1726,6 +1726,34 @@ From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is 
 ### Phase 7 — Release
 - Bump all packages to 1.0.0. Update docs. Deprecate legacy `provider.name` config. Publish.
 
+#### Phase 7 packaging blockers (surfaced by attw + publint dry-run)
+
+These ship-gates need clearing before any 1.0 publish. Each is a small
+change in isolation; bundling them with the version bump keeps the
+release commit clean.
+
+1. **obuild does not emit `.d.mts` files for contracts / audit-pool.**
+   `publint` flags `pkg.types: ./src/*.ts` as published-but-missing.
+   Workaround today: those packages point `types` at source for
+   workspace consumers, but a published consumer would see no types.
+   Fix: either enable obuild's `.d.ts` emit (preferred) or add a tsc
+   `--emitDeclarationOnly` step to the build.
+2. **core's per-export entries fail `node10` resolution.** All
+   `@unlighthouse/core/*` subpaths resolve under `node16` / `bundler`
+   but `node10` (legacy moduleResolution) sees `Resolution failed`.
+   Either dual-publish CJS or document `moduleResolution: 'node16'`
+   as a peer requirement.
+3. **core / cloudflare / mcp / unlighthouse all warn
+   `CJSResolvesToESM`** under `node16-from-CJS`. Expected — these are
+   ESM-only — but the `engines.node >= 22` field doesn't communicate
+   that. Add `"type": "module"` everywhere (already done on contracts,
+   audit-pool, core) and consider a `package.json` "exports" entry
+   that explicitly returns null for `require` so the error message is
+   accurate.
+
+`pnpm test:publint` and `pnpm test:attw` at the repo root run these
+across every workspace package and bail on regressions.
+
 ### Estimated effort
 
 | Phase | Effort (eng days) |


### PR DESCRIPTION
## Summary

The v1.md Phase 6 ship-gate "attw + publint on every package" was half-done — only `packages/unlighthouse` had the scripts. This wires the same hooks across contracts, core, cloudflare, mcp, audit-pool so the existing root-level `pnpm test:attw` / `pnpm test:publint` actually fans out.

The first dry-run surfaced three concrete release blockers that I documented in v1.md rather than fixing in this PR (each is a separate piece of work):

1. **obuild doesn't emit `.d.mts`** for contracts / audit-pool. Today their `types` field points at source — fine for workspace consumers via TS path aliases, broken for npm-published consumers.
2. **core's per-export entries fail `node10` resolution.** Modern resolution works, legacy doesn't.
3. **`CJSResolvesToESM` warnings** across every ESM-only package. Expected, but the `engines.node >= 22` field doesn't communicate that ESM-only intent loudly enough.

Each is a small change in isolation; bundling them with the 1.0 version bump keeps the release commit clean.

## What changed

- packages/{contracts, core, cloudflare, mcp, audit-pool}/package.json grew `test:attw` and `test:publint` scripts (identical to the one already on `unlighthouse`).
- packages/cloudflare and packages/mcp also picked up a `build` script that was missing — they were being built via the root `pnpm build` script but the per-package script was missing.
- v1.md Phase 7 section grew a "packaging blockers" subsection documenting the three items above.

## Test plan
- [x] full test suite: 430/430 passing
- [x] `pnpm test:publint` now runs across 6 packages (3 pass, 3 fail with documented blockers)
- [x] `pnpm test:attw` runs across 6 packages
- [x] no production code changed