### PR TITLE
refactor(contracts): schema/type separation — unlocks published .d.ts emission

### DIFF
--- a/packages/contracts/src/commands/assert.ts
+++ b/packages/contracts/src/commands/assert.ts
@@ -2,7 +2,7 @@
 // See v1.md §"lhci.md integration audit" lines 699 + 704.
 
 import { z } from 'zod'
-import { Assertion, AssertionResult, ScanId } from '../types/atoms'
+import { AssertionResultSchema, AssertionSchema, ScanIdSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── assert.evaluate ─────────────────────────────────────────────────────────
@@ -10,15 +10,15 @@ export const AssertEvaluate = defineCommand({
   name: 'assert.evaluate',
   description: 'Evaluate one or more assertions against a completed scan.',
   input: z.object({
-    scanId: ScanId,
-    assertions: z.array(Assertion).min(1),
+    scanId: ScanIdSchema,
+    assertions: z.array(AssertionSchema).min(1),
     /** Optional baseline scan for `maxRegression` assertions. */
-    baselineScanId: ScanId.optional(),
+    baselineScanId: ScanIdSchema.optional(),
   }),
   output: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     passed: z.boolean(),
-    results: z.array(AssertionResult),
+    results: z.array(AssertionResultSchema),
   }),
   exitCodes: { ASSERTION_FAILED: 1, SCAN_NOT_FOUND: 64 },
 })

--- a/packages/contracts/src/commands/compare.ts
+++ b/packages/contracts/src/commands/compare.ts
@@ -2,20 +2,20 @@
 // See v1.md §"lhci.md integration audit" (lines 695–705).
 
 import { z } from 'zod'
-import { Category, Device, MetricName, ScanId, Url } from '../types/atoms'
+import { CategorySchema, DeviceSchema, MetricNameSchema, ScanIdSchema, UrlSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
-const ThresholdKey = z.union([MetricName, Category])
+const ThresholdKey = z.union([MetricNameSchema, CategorySchema])
 
-const RouteDiff = z.object({
-  url: Url,
+const RouteDiffSchema = z.object({
+  url: UrlSchema,
   /**
    * D-029: device dimension on the diff. Matrix scans produce one diff per
    * (url, device) pair so mobile and desktop regressions don't collapse into
    * each other. Single-device scans always carry 'mobile' (or whatever the
    * scan's primary device was).
    */
-  device: Device,
+  device: DeviceSchema,
   metric: ThresholdKey,
   base: z.number().nullable(),
   current: z.number().nullable(),
@@ -23,25 +23,27 @@ const RouteDiff = z.object({
   /** `true` when |delta| exceeds the configured threshold. */
   regressed: z.boolean(),
 })
+export type RouteDiff = z.infer<typeof RouteDiffSchema>
 
-const CompareReport = z.object({
-  baseScanId: ScanId,
-  currentScanId: ScanId,
-  regressions: z.array(RouteDiff),
-  improvements: z.array(RouteDiff),
+const CompareReportSchema = z.object({
+  baseScanId: ScanIdSchema,
+  currentScanId: ScanIdSchema,
+  regressions: z.array(RouteDiffSchema),
+  improvements: z.array(RouteDiffSchema),
   thresholds: z.partialRecord(ThresholdKey, z.number()),
 })
+export type CompareReport = z.infer<typeof CompareReportSchema>
 
 // ── compare.run ─────────────────────────────────────────────────────────────
 export const CompareRun = defineCommand({
   name: 'compare.run',
   description: 'Diff two scans against thresholds and return a structured report.',
   input: z.object({
-    baseScanId: ScanId,
-    currentScanId: ScanId,
+    baseScanId: ScanIdSchema,
+    currentScanId: ScanIdSchema,
     thresholds: z.partialRecord(ThresholdKey, z.number()).optional(),
   }),
-  output: CompareReport,
+  output: CompareReportSchema,
   exitCodes: { SCAN_NOT_FOUND: 64 },
 })
 
@@ -50,8 +52,8 @@ export const CompareMarkdown = defineCommand({
   name: 'compare.markdown',
   description: 'Render a Markdown PR comment from a comparison.',
   input: z.object({
-    baseScanId: ScanId,
-    currentScanId: ScanId,
+    baseScanId: ScanIdSchema,
+    currentScanId: ScanIdSchema,
     thresholds: z.partialRecord(ThresholdKey, z.number()).optional(),
     /** Optional title override. */
     title: z.string().optional(),
@@ -68,14 +70,14 @@ export const CompareFindPrevious = defineCommand({
   name: 'compare.findPrevious',
   description: 'Find the most recent prior scan for a site / device / branch.',
   input: z.object({
-    site: Url,
-    device: Device,
+    site: UrlSchema,
+    device: DeviceSchema,
     branch: z.string().optional(),
-    excludeScanId: ScanId.optional(),
+    excludeScanId: ScanIdSchema.optional(),
   }),
   output: z.object({
-    scanId: ScanId.nullable(),
+    scanId: ScanIdSchema.nullable(),
   }),
 })
 
-export { CompareReport, RouteDiff }
+export { CompareReportSchema, RouteDiffSchema }

--- a/packages/contracts/src/commands/events.ts
+++ b/packages/contracts/src/commands/events.ts
@@ -3,7 +3,7 @@
 
 import { z } from 'zod'
 import { HookEventUnion } from '../hooks'
-import { ScanId } from '../types/atoms'
+import { ScanIdSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── events.subscribe ────────────────────────────────────────────────────────
@@ -14,7 +14,7 @@ export const EventsSubscribe = defineCommand({
     'Subscribe to the typed HookMap event stream. Optionally scope to one scan or filter by event name.',
   streaming: true,
   input: z.object({
-    scanId: ScanId.optional(),
+    scanId: ScanIdSchema.optional(),
     events: z.array(z.string()).optional(),
     /** Replay the last N events from the buffer before live events arrive. */
     replay: z.coerce.number().int().nonnegative().max(10_000).optional(),
@@ -36,7 +36,7 @@ export const EventsTail = defineCommand({
     'Tail the persisted event log for a scan, optionally following live events while the scan is in flight.',
   streaming: true,
   input: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     follow: z.boolean().optional(),
     events: z.array(z.string()).optional(),
   }),

--- a/packages/contracts/src/commands/history.ts
+++ b/packages/contracts/src/commands/history.ts
@@ -1,15 +1,22 @@
 // history.* commands — cross-scan list / delete / rescan operations.
 
 import { z } from 'zod'
-import { Device, Paginated, Scan, ScanId, ScanRoute, Url } from '../types/atoms'
+import {
+  DeviceSchema,
+  PaginatedSchema,
+  ScanIdSchema,
+  ScanRouteSchema,
+  ScanSchema,
+  UrlSchema,
+} from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── history.get ─────────────────────────────────────────────────────────────
 export const HistoryGet = defineCommand({
   name: 'history.get',
   description: 'Get full scan metadata + routes by scanId.',
-  input: z.object({ scanId: ScanId }),
-  output: Scan.extend({ routes: z.array(ScanRoute) }),
+  input: z.object({ scanId: ScanIdSchema }),
+  output: ScanSchema.extend({ routes: z.array(ScanRouteSchema) }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
 })
 
@@ -18,13 +25,13 @@ export const HistoryList = defineCommand({
   name: 'history.list',
   description: 'List past scans, optionally filtered by site / device / branch.',
   input: z.object({
-    site: Url.optional(),
-    device: Device.optional(),
+    site: UrlSchema.optional(),
+    device: DeviceSchema.optional(),
     branch: z.string().optional(),
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(500).default(50),
   }),
-  output: Paginated(Scan),
+  output: PaginatedSchema(ScanSchema),
 })
 
 // ── history.delete ──────────────────────────────────────────────────────────
@@ -32,15 +39,15 @@ export const HistoryDelete = defineCommand({
   name: 'history.delete',
   description: 'Delete one or more past scans by id, or by site + retention.',
   input: z.union([
-    z.object({ scanIds: z.array(ScanId).min(1) }),
+    z.object({ scanIds: z.array(ScanIdSchema).min(1) }),
     z.object({
-      site: Url,
+      site: UrlSchema,
       keep: z.number().int().nonnegative().optional(),
       olderThan: z.iso.datetime().optional(),
     }),
   ]),
   output: z.object({
-    deleted: z.array(ScanId),
+    deleted: z.array(ScanIdSchema),
   }),
   // Bulk destructive op. Agent has no business deleting user history.
   mcp: { hidden: true },
@@ -51,15 +58,15 @@ export const HistoryRescan = defineCommand({
   name: 'history.rescan',
   description: 'Start a new scan that mirrors the configuration of a past scan.',
   input: z.object({
-    scanId: ScanId,
-    overrideSite: Url.optional(),
+    scanId: ScanIdSchema,
+    overrideSite: UrlSchema.optional(),
   }),
   output: z.object({
-    scanId: ScanId,
-    site: Url,
+    scanId: ScanIdSchema,
+    site: UrlSchema,
     startedAt: z.iso.datetime(),
     /** The scan whose config was cloned. */
-    sourceScanId: ScanId,
+    sourceScanId: ScanIdSchema,
   }),
   exitCodes: { SCAN_NOT_FOUND: 64, ACTIVE_SCAN_CONFLICT: 9 },
   // Agent can call scan.start with explicit config if a fresh scan is needed;

--- a/packages/contracts/src/commands/index.ts
+++ b/packages/contracts/src/commands/index.ts
@@ -22,7 +22,8 @@ import {
   ScanStatusCmd,
   ScanSummaryCmd,
 } from './scan'
-import { Site, SitesCreate, SitesDelete, SitesGet, SitesList } from './sites'
+import type { Site } from './sites'
+import { SiteSchema, SitesCreate, SitesDelete, SitesGet, SitesList } from './sites'
 
 export * from './compare'
 
@@ -57,12 +58,14 @@ export {
   ScanStart,
   ScanStatusCmd,
   ScanSummaryCmd,
-  Site,
+  SiteSchema,
   SitesCreate,
   SitesDelete,
   SitesGet,
   SitesList,
 }
+
+export type { Site }
 
 export * from './define'
 

--- a/packages/contracts/src/commands/meta.ts
+++ b/packages/contracts/src/commands/meta.ts
@@ -4,7 +4,7 @@
 // `manifest` output (v1.md line 14).
 
 import { z } from 'zod'
-import { Category, Device, Url } from '../types/atoms'
+import { CategorySchema, DeviceSchema, UrlSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── manifest ────────────────────────────────────────────────────────────────
@@ -90,9 +90,9 @@ export const AuditorsTest = defineCommand({
   description: 'Test an auditor against a single URL and return the raw LH report.',
   input: z.object({
     auditor: z.string(),
-    url: Url,
-    device: Device.optional(),
-    categories: z.array(Category).optional(),
+    url: UrlSchema,
+    device: DeviceSchema.optional(),
+    categories: z.array(CategorySchema).optional(),
   }),
   output: z.object({
     ok: z.boolean(),

--- a/packages/contracts/src/commands/pack.ts
+++ b/packages/contracts/src/commands/pack.ts
@@ -3,7 +3,7 @@
 // pack.run. Output is content-addressable by (scanId, packName, packVersion).
 
 import { z } from 'zod'
-import { Device, ScanId } from '../types/atoms'
+import { DeviceSchema, ScanIdSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── pack.run ────────────────────────────────────────────────────────────────
@@ -11,12 +11,12 @@ export const PackRunCmd = defineCommand({
   name: 'pack.run',
   description: 'Run a Lighthouse pack (cross-route analysis) against a finished scan. Returns a typed report — e.g. "images" lists routes with unoptimised LCP images, "cwv" returns p75 Core Web Vitals, "seo-basics" returns failing audits grouped by rule. Call pack.list first to discover available packs. Use scanId from history.list. For matrix scans, pass `device` to narrow the pack to one form-factor. Output is cached so re-running the same (scanId, pack, device) is free; pass refresh:true to bust.',
   input: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     pack: z.string().min(1),
     // D-029: pack runs against rows for one device. Omitted = aggregate across
     // the matrix (every row in scan_routes is handed to the pack). Devices
     // produce observably different numbers so most packs will want a filter.
-    device: Device.optional(),
+    device: DeviceSchema.optional(),
     // Skip the cache and re-reconcile. Default false so agent calls hit cache
     // on the second visit; UI exposes this as a "Refresh" button.
     refresh: z.boolean().optional(),
@@ -25,7 +25,7 @@ export const PackRunCmd = defineCommand({
   // command registry stays single-signature. Consumers narrow `report` by
   // pulling the pack's `reportSchema` from contracts/packs.
   output: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     packName: z.string(),
     packVersion: z.string(),
     startedAt: z.iso.datetime(),

--- a/packages/contracts/src/commands/query.ts
+++ b/packages/contracts/src/commands/query.ts
@@ -4,13 +4,13 @@
 
 import { z } from 'zod'
 import {
-  Category,
-  Device,
-  MetricName,
-  Paginated,
-  ScanId,
-  ScanRoute,
-  Url,
+  CategorySchema,
+  DeviceSchema,
+  MetricNameSchema,
+  PaginatedSchema,
+  ScanIdSchema,
+  ScanRouteSchema,
+  UrlSchema,
 } from '../types/atoms'
 import { defineCommand } from './define'
 
@@ -20,17 +20,17 @@ export const QueryRoutes = defineCommand({
   description:
     'Cross-scan route query. Optional `scanId` scopes to a single scan; `projection` returns metric-only views.',
   input: z.object({
-    scanId: ScanId.optional(),
-    site: Url.optional(),
-    device: Device.optional(),
+    scanId: ScanIdSchema.optional(),
+    site: UrlSchema.optional(),
+    device: DeviceSchema.optional(),
     branch: z.string().optional(),
     urlPattern: z.string().optional(),
     /** Limit columns returned. Empty / undefined returns the full row. */
-    projection: z.array(MetricName).optional(),
+    projection: z.array(MetricNameSchema).optional(),
     filter: z
       .object({
-        minScore: z.partialRecord(Category, z.number()).optional(),
-        maxMetric: z.partialRecord(MetricName, z.number()).optional(),
+        minScore: z.partialRecord(CategorySchema, z.number()).optional(),
+        maxMetric: z.partialRecord(MetricNameSchema, z.number()).optional(),
       })
       .optional(),
     sort: z
@@ -43,5 +43,5 @@ export const QueryRoutes = defineCommand({
    * When `projection` is set, only the named metric columns are populated;
    *  callers should treat the un-projected fields as `null`.
    */
-  output: Paginated(ScanRoute),
+  output: PaginatedSchema(ScanRouteSchema),
 })

--- a/packages/contracts/src/commands/route.ts
+++ b/packages/contracts/src/commands/route.ts
@@ -1,7 +1,7 @@
 // route.* commands — operations against a single route within a scan.
 
 import { z } from 'zod'
-import { Device, ExtractedMetrics, ScanId, ScanRoute, Url } from '../types/atoms'
+import { DeviceSchema, ExtractedMetricsSchema, ScanIdSchema, ScanRouteSchema, UrlSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
 // ── route.get ───────────────────────────────────────────────────────────────
@@ -9,14 +9,14 @@ export const RouteGet = defineCommand({
   name: 'route.get',
   description: 'Get the full route row + LHR blob key for a single URL. For matrix scans, pass `device` to target a specific form-factor; defaults to the scan\'s primary device.',
   input: z.object({
-    scanId: ScanId,
-    url: Url,
+    scanId: ScanIdSchema,
+    url: UrlSchema,
     // D-029: matrix scans hold N rows per URL. Caller picks one with `device`;
     // omitted = use the scan's primary device (back-compat).
-    device: Device.optional(),
+    device: DeviceSchema.optional(),
   }),
   output: z.object({
-    route: ScanRoute,
+    route: ScanRouteSchema,
     /** The raw LHR JSON, fetched from `storage.blobs.get(route.lhrBlobKey)`. */
     lhr: z.unknown(),
   }),
@@ -28,17 +28,17 @@ export const RouteRescan = defineCommand({
   name: 'route.rescan',
   description: 'Re-audit a single URL within an existing scan.',
   input: z.object({
-    scanId: ScanId,
-    url: Url,
+    scanId: ScanIdSchema,
+    url: UrlSchema,
     // D-029: which device row to re-audit. Defaults to the scan's primary
     // device. Re-audits one row at a time — fan-out across the matrix would
     // double-charge an active auditor without the caller asking for it.
-    device: Device.optional(),
+    device: DeviceSchema.optional(),
   }),
   output: z.object({
-    scanId: ScanId,
-    url: Url,
-    metrics: ExtractedMetrics,
+    scanId: ScanIdSchema,
+    url: UrlSchema,
+    metrics: ExtractedMetricsSchema,
   }),
   exitCodes: { ROUTE_NOT_FOUND: 66, SCAN_NOT_FOUND: 64 },
   // Mutates an existing scan's data and needs a live auditor — UI flow only.

--- a/packages/contracts/src/commands/scan.ts
+++ b/packages/contracts/src/commands/scan.ts
@@ -3,15 +3,15 @@
 
 import { z } from 'zod'
 import {
-  Category,
-  Device,
-  MetricName,
-  Paginated,
-  ScanId,
-  ScanRoute,
-  ScanStatus,
-  ScanSummary,
-  Url,
+  CategorySchema,
+  DeviceSchema,
+  MetricNameSchema,
+  PaginatedSchema,
+  ScanIdSchema,
+  ScanRouteSchema,
+  ScanStatusSchema,
+  ScanSummarySchema,
+  UrlSchema,
 } from '../types/atoms'
 import { defineCommand } from './define'
 
@@ -24,10 +24,10 @@ export const ScanStart = defineCommand({
   name: 'scan.start',
   description: 'Start a new scan against a site. `device` accepts a single device or a list for a multi-device matrix scan.',
   input: z.object({
-    site: Url,
-    device: z.union([Device, z.array(Device).min(1)]).optional(),
+    site: UrlSchema,
+    device: z.union([DeviceSchema, z.array(DeviceSchema).min(1)]).optional(),
     sampleSize: z.number().int().min(1).max(10).optional(),
-    categories: z.array(Category).optional(),
+    categories: z.array(CategorySchema).optional(),
     auditor: z.string().optional(),
     ciBuild: z
       .object({
@@ -38,8 +38,8 @@ export const ScanStart = defineCommand({
       .optional(),
   }),
   output: z.object({
-    scanId: ScanId,
-    site: Url,
+    scanId: ScanIdSchema,
+    site: UrlSchema,
     startedAt: z.iso.datetime(),
   }),
   exitCodes: { ACTIVE_SCAN_CONFLICT: 9, QUOTA_EXCEEDED: 78 },
@@ -49,10 +49,10 @@ export const ScanStart = defineCommand({
 export const ScanStatusCmd = defineCommand({
   name: 'scan.status',
   description: 'Get the current status + stats of a scan.',
-  input: z.object({ scanId: ScanId }),
+  input: z.object({ scanId: ScanIdSchema }),
   output: z.object({
-    scanId: ScanId,
-    status: ScanStatus,
+    scanId: ScanIdSchema,
+    status: ScanStatusSchema,
     discovered: z.number().int().nonnegative(),
     scanned: z.number().int().nonnegative(),
     failed: z.number().int().nonnegative(),
@@ -68,12 +68,12 @@ export const ScanCancel = defineCommand({
   name: 'scan.cancel',
   description: 'Cancel an in-flight scan.',
   input: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     reason: z.string().optional(),
   }),
   output: z.object({
-    scanId: ScanId,
-    status: ScanStatus,
+    scanId: ScanIdSchema,
+    status: ScanStatusSchema,
     cancelledAt: z.iso.datetime(),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
@@ -86,10 +86,10 @@ export const ScanCancel = defineCommand({
 export const ScanPause = defineCommand({
   name: 'scan.pause',
   description: 'Pause an in-flight scan (requires a pausable crawler).',
-  input: z.object({ scanId: ScanId }),
+  input: z.object({ scanId: ScanIdSchema }),
   output: z.object({
-    scanId: ScanId,
-    status: ScanStatus,
+    scanId: ScanIdSchema,
+    status: ScanStatusSchema,
   }),
   exitCodes: { NOT_SUPPORTED: 65, SCAN_NOT_FOUND: 64 },
   mcp: { hidden: true },
@@ -99,10 +99,10 @@ export const ScanPause = defineCommand({
 export const ScanResume = defineCommand({
   name: 'scan.resume',
   description: 'Resume a paused scan.',
-  input: z.object({ scanId: ScanId }),
+  input: z.object({ scanId: ScanIdSchema }),
   output: z.object({
-    scanId: ScanId,
-    status: ScanStatus,
+    scanId: ScanIdSchema,
+    status: ScanStatusSchema,
   }),
   exitCodes: { NOT_SUPPORTED: 65, SCAN_NOT_FOUND: 64 },
   mcp: { hidden: true },
@@ -112,9 +112,9 @@ export const ScanResume = defineCommand({
 export const ScanDelete = defineCommand({
   name: 'scan.delete',
   description: 'Delete a scan and all of its artifacts.',
-  input: z.object({ scanId: ScanId }),
+  input: z.object({ scanId: ScanIdSchema }),
   output: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     deleted: z.literal(true),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
@@ -126,14 +126,14 @@ export const ScanDelete = defineCommand({
 export const ScanMetaCmd = defineCommand({
   name: 'scan.meta',
   description: 'Get the current scan\'s at-a-glance metadata.',
-  input: z.object({ scanId: ScanId.optional() }),
+  input: z.object({ scanId: ScanIdSchema.optional() }),
   output: z.object({
-    scanId: ScanId,
-    site: Url,
-    device: Device,
+    scanId: ScanIdSchema,
+    site: UrlSchema,
+    device: DeviceSchema,
     throttle: z.boolean(),
     startedAt: z.iso.datetime(),
-    summary: ScanSummary.nullable(),
+    summary: ScanSummarySchema.nullable(),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64 },
 })
@@ -143,7 +143,7 @@ export const ScanCurrent = defineCommand({
   name: 'scan.current',
   description: 'Return the current in-flight scanId, or null.',
   input: z.object({}),
-  output: z.object({ scanId: ScanId.nullable() }),
+  output: z.object({ scanId: ScanIdSchema.nullable() }),
   // "Current" is a UI/CLI session concept — there's no notion of a per-request
   // "current scan" in MCP. Agents pass scanIds explicitly via history.list.
   mcp: { hidden: true },
@@ -153,9 +153,9 @@ export const ScanCurrent = defineCommand({
 export const ScanRescanAll = defineCommand({
   name: 'scan.rescanAll',
   description: 'Full-site rescan within an existing scan (drops all routes + re-queues).',
-  input: z.object({ scanId: ScanId }),
+  input: z.object({ scanId: ScanIdSchema }),
   output: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     queued: z.number().int().nonnegative(),
   }),
   exitCodes: { SCAN_NOT_FOUND: 64, ACTIVE_SCAN_CONFLICT: 9 },
@@ -172,17 +172,17 @@ export const ScanSummaryCmd = defineCommand({
   name: 'scan.summary',
   description: 'Agent entry point: a terse, template-grouped overview of a finished scan in sub-1KB JSON. Returns category averages (perf/a11y/seo/best-practices), passing/needs-work/poor distribution, the worst 5 routes by score, and template groups. Use this first to decide where to drill in — then call pack.run with a specific pack (e.g. "images", "cwv") for actionable findings, or query.routes / scan.results for raw per-route data.',
   input: z.object({
-    scanId: ScanId,
-    device: Device.optional(),
+    scanId: ScanIdSchema,
+    device: DeviceSchema.optional(),
   }),
   output: z.object({
-    scanId: ScanId,
-    site: Url,
-    device: Device,
+    scanId: ScanIdSchema,
+    site: UrlSchema,
+    device: DeviceSchema,
     routesScanned: z.number().int().nonnegative(),
     // Site-wide scoring snapshot. `categories` keys are Lighthouse category ids.
     avgScore: z.number().nullable(),
-    categoryAverages: z.partialRecord(Category, z.number().nullable()),
+    categoryAverages: z.partialRecord(CategorySchema, z.number().nullable()),
     // Bucketed by Lighthouse thresholds: passing ≥ 90, needs-work ≥ 50, poor < 50.
     distribution: z.object({
       passing: z.number().int().nonnegative(),
@@ -192,9 +192,9 @@ export const ScanSummaryCmd = defineCommand({
     // Top-N routes by lowest avg score. URL kept short; the table is for
     // orientation, not consumption — drill into query.routes for detail.
     worstRoutes: z.array(z.object({
-      url: Url,
+      url: UrlSchema,
       score: z.number().nullable(),
-      category: Category.nullable(),
+      category: CategorySchema.nullable(),
     })),
     // Template grouping (from seeds/route-definitions matcher). Routes that
     // matched no template land under `routeName: null` which collapses to "/".
@@ -213,13 +213,13 @@ export const ScanResults = defineCommand({
   name: 'scan.results',
   description: 'List route results for a scan with filter + pagination. For matrix scans, pass `device` to narrow to mobile or desktop; omit to aggregate across the matrix.',
   input: z.object({
-    scanId: ScanId,
+    scanId: ScanIdSchema,
     // D-029: filter to one device. Omitted = every (url, device) row.
-    device: Device.optional(),
+    device: DeviceSchema.optional(),
     filter: z
       .object({
-        minScore: z.partialRecord(Category, z.number()).optional(),
-        maxMetric: z.partialRecord(MetricName, z.number()).optional(),
+        minScore: z.partialRecord(CategorySchema, z.number()).optional(),
+        maxMetric: z.partialRecord(MetricNameSchema, z.number()).optional(),
         urlPattern: z.string().optional(),
       })
       .optional(),
@@ -229,6 +229,6 @@ export const ScanResults = defineCommand({
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(500).default(50),
   }),
-  output: Paginated(ScanRoute),
+  output: PaginatedSchema(ScanRouteSchema),
   exitCodes: { SCAN_NOT_FOUND: 64 },
 })

--- a/packages/contracts/src/commands/sites.ts
+++ b/packages/contracts/src/commands/sites.ts
@@ -3,31 +3,31 @@
 // joined against them by URL.
 
 import { z } from 'zod'
-import { Device, Url } from '../types/atoms'
+import { DeviceSchema, UrlSchema } from '../types/atoms'
 import { defineCommand } from './define'
 
-export const Site = z.object({
+export const SiteSchema = z.object({
   id: z.string(),
   name: z.string(),
-  url: Url,
+  url: UrlSchema,
   group: z.string().nullable(),
-  device: Device,
+  device: DeviceSchema,
   createdAt: z.iso.datetime(),
 })
-export type Site = z.infer<typeof Site>
+export type Site = z.infer<typeof SiteSchema>
 
 export const SitesList = defineCommand({
   name: 'sites.list',
   description: 'List the persisted sites managed by this host.',
   input: z.object({}),
-  output: z.object({ sites: z.array(Site) }),
+  output: z.object({ sites: z.array(SiteSchema) }),
 })
 
 export const SitesGet = defineCommand({
   name: 'sites.get',
   description: 'Get a single site by id.',
   input: z.object({ id: z.string() }),
-  output: z.object({ site: Site.nullable() }),
+  output: z.object({ site: SiteSchema.nullable() }),
 })
 
 export const SitesCreate = defineCommand({
@@ -35,11 +35,11 @@ export const SitesCreate = defineCommand({
   description: 'Create (or upsert by id) a site.',
   input: z.object({
     name: z.string().optional(),
-    url: Url,
+    url: UrlSchema,
     group: z.string().nullable().optional(),
-    device: Device.optional(),
+    device: DeviceSchema.optional(),
   }),
-  output: z.object({ site: Site }),
+  output: z.object({ site: SiteSchema }),
   // Persistent registry mutation. Adding ghost sites across restarts is a
   // hostile-agent vector; site setup belongs in the UI / CLI.
   mcp: { hidden: true },

--- a/packages/contracts/src/config/index.ts
+++ b/packages/contracts/src/config/index.ts
@@ -4,12 +4,12 @@
 //    the post-merge config; defaults live in a literal `defaultConfig` const."
 
 import { z } from 'zod'
-import { Assertion, Category, Device, Url } from '../types/atoms'
+import { AssertionSchema, CategorySchema, DeviceSchema, UrlSchema } from '../types/atoms'
 
 // Lighthouse audit categories budget — number 1..100 OR per-category map.
 const Budget = z.union([
   z.number().int().min(1).max(100),
-  z.partialRecord(Category, z.number().int().min(1).max(100)),
+  z.partialRecord(CategorySchema, z.number().int().min(1).max(100)),
 ])
 
 const ReporterConfig = z.object({
@@ -66,7 +66,7 @@ const CiConfig = z.object({
     ])
     .optional(),
   reporterConfig: ReporterConfig.optional(),
-  assertions: z.array(Assertion).optional(),
+  assertions: z.array(AssertionSchema).optional(),
   build: CiBuild.optional(),
   comparison: ComparisonConfig.optional(),
 })
@@ -92,7 +92,7 @@ const ScannerConfig = z.object({
   dynamicSampling: z.union([z.number().int().positive(), z.literal(false)]).optional(),
   sitemap: z.union([z.boolean(), z.array(z.string())]).optional(),
   robotsTxt: z.boolean().optional(),
-  device: z.union([Device, z.literal(false)]).optional(),
+  device: z.union([DeviceSchema, z.literal(false)]).optional(),
 })
 
 const ClientConfig = z.object({
@@ -147,7 +147,7 @@ const AuditorConfig = z.union([
  * Throws `UnlighthouseError({ code: 'CONFIG_INVALID' })` on validation failure.
  */
 const UnlighthouseConfigSchema = z.object({
-  site: z.union([Url, z.string()]).optional(),
+  site: z.union([UrlSchema, z.string()]).optional(),
   googleApiKey: z.string().optional(),
   root: z.string().optional(),
   cache: z.boolean().optional(),
@@ -181,7 +181,7 @@ const UnlighthouseConfigSchema = z.object({
 })
 
 export type UnlighthouseConfig = z.infer<typeof UnlighthouseConfigSchema>
-export { UnlighthouseConfigSchema as UnlighthouseConfig }
+export { UnlighthouseConfigSchema }
 
 /**
  * Host-agnostic defaults — D-011: defu merges, schema validates.

--- a/packages/contracts/src/drizzle/parity.ts
+++ b/packages/contracts/src/drizzle/parity.ts
@@ -47,10 +47,12 @@ type _AssertScanShape = Expect<Equal<Normalize<ScanRowPublic>, Normalize<Scan>>>
 
 type _AssertScanRouteShape = Expect<Equal<Normalize<ScanRouteRow>, Normalize<ScanRoute>>>
 
-// Inputs to put-batch are ExtractedMetrics; the row adds scanId + blob keys.
+// Inputs to put-batch are ExtractedMetrics; the row adds scanId + device +
+// blob keys. D-029 added device to the row identity; it's not on
+// ExtractedMetrics (callers pass it as a separate arg to putBatch/upsert).
 type _AssertExtractedMetricsShape = Expect<
   Equal<
-    Normalize<Omit<ScanRouteRow, 'scanId' | 'lhrBlobKey' | 'reportBlobKey'>>,
+    Normalize<Omit<ScanRouteRow, 'scanId' | 'device' | 'lhrBlobKey' | 'reportBlobKey'>>,
     Normalize<ExtractedMetrics>
   >
 >

--- a/packages/contracts/src/hooks/index.ts
+++ b/packages/contracts/src/hooks/index.ts
@@ -4,43 +4,43 @@
 
 import { z } from 'zod'
 import {
-  AssertionResult,
-  ExtractedMetrics,
-  ScanId,
-  ScanSummary,
-  StructuredError,
-  Url,
+  AssertionResultSchema,
+  ExtractedMetricsSchema,
+  ScanIdSchema,
+  ScanSummarySchema,
+  StructuredErrorSchema,
+  UrlSchema,
 } from '../types/atoms'
 
 // ────────────────────────────────────────────────────────────────────────────
 // scan:* — orchestration lifecycle. Emitted by core.run(), not by adapters.
 // ────────────────────────────────────────────────────────────────────────────
 
-const ScanCreatedPayloadSchema = z.object({
-  scanId: ScanId,
-  site: Url,
+export const ScanCreatedPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  site: UrlSchema,
   startedAt: z.iso.datetime(),
 })
 export type ScanCreatedPayload = z.infer<typeof ScanCreatedPayloadSchema>
 
-const ScanStartedPayloadSchema = z.object({
-  scanId: ScanId,
+export const ScanStartedPayloadSchema = z.object({
+  scanId: ScanIdSchema,
 })
 export type ScanStartedPayload = z.infer<typeof ScanStartedPayloadSchema>
 
-const ScanDiscoveringPayloadSchema = z.object({
-  scanId: ScanId,
+export const ScanDiscoveringPayloadSchema = z.object({
+  scanId: ScanIdSchema,
 })
 export type ScanDiscoveringPayload = z.infer<typeof ScanDiscoveringPayloadSchema>
 
-const ScanScanningPayloadSchema = z.object({
-  scanId: ScanId,
+export const ScanScanningPayloadSchema = z.object({
+  scanId: ScanIdSchema,
   discovered: z.number().int().nonnegative(),
 })
 export type ScanScanningPayload = z.infer<typeof ScanScanningPayloadSchema>
 
-const ScanProgressPayloadSchema = z.object({
-  scanId: ScanId,
+export const ScanProgressPayloadSchema = z.object({
+  scanId: ScanIdSchema,
   discovered: z.number().int().nonnegative(),
   scanned: z.number().int().nonnegative(),
   failed: z.number().int().nonnegative(),
@@ -48,41 +48,41 @@ const ScanProgressPayloadSchema = z.object({
 })
 export type ScanProgressPayload = z.infer<typeof ScanProgressPayloadSchema>
 
-const ScanRouteCompletePayloadSchema = z.object({
-  scanId: ScanId,
-  url: Url,
-  metrics: ExtractedMetrics,
+export const ScanRouteCompletePayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  url: UrlSchema,
+  metrics: ExtractedMetricsSchema,
 })
 export type ScanRouteCompletePayload = z.infer<typeof ScanRouteCompletePayloadSchema>
 
-const ScanRouteFailedPayloadSchema = z.object({
-  scanId: ScanId,
-  url: Url,
-  error: StructuredError,
+export const ScanRouteFailedPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  url: UrlSchema,
+  error: StructuredErrorSchema,
 })
 export type ScanRouteFailedPayload = z.infer<typeof ScanRouteFailedPayloadSchema>
 
-const ScanPausedPayloadSchema = z.object({ scanId: ScanId })
+export const ScanPausedPayloadSchema = z.object({ scanId: ScanIdSchema })
 export type ScanPausedPayload = z.infer<typeof ScanPausedPayloadSchema>
 
-const ScanResumedPayloadSchema = z.object({ scanId: ScanId })
+export const ScanResumedPayloadSchema = z.object({ scanId: ScanIdSchema })
 export type ScanResumedPayload = z.infer<typeof ScanResumedPayloadSchema>
 
-const ScanCancelledPayloadSchema = z.object({
-  scanId: ScanId,
+export const ScanCancelledPayloadSchema = z.object({
+  scanId: ScanIdSchema,
   reason: z.string().optional(),
 })
 export type ScanCancelledPayload = z.infer<typeof ScanCancelledPayloadSchema>
 
-const ScanCompletePayloadSchema = z.object({
-  scanId: ScanId,
-  summary: ScanSummary,
+export const ScanCompletePayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  summary: ScanSummarySchema,
 })
 export type ScanCompletePayload = z.infer<typeof ScanCompletePayloadSchema>
 
-const ScanErrorPayloadSchema = z.object({
-  scanId: ScanId,
-  error: StructuredError,
+export const ScanErrorPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  error: StructuredErrorSchema,
 })
 export type ScanErrorPayload = z.infer<typeof ScanErrorPayloadSchema>
 
@@ -90,15 +90,15 @@ export type ScanErrorPayload = z.infer<typeof ScanErrorPayloadSchema>
 // assert:* — assertion evaluation.
 // ────────────────────────────────────────────────────────────────────────────
 
-const AssertPassedPayloadSchema = z.object({
-  scanId: ScanId,
-  result: AssertionResult,
+export const AssertPassedPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  result: AssertionResultSchema,
 })
 export type AssertPassedPayload = z.infer<typeof AssertPassedPayloadSchema>
 
-const AssertFailedPayloadSchema = z.object({
-  scanId: ScanId,
-  result: AssertionResult,
+export const AssertFailedPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  result: AssertionResultSchema,
 })
 export type AssertFailedPayload = z.infer<typeof AssertFailedPayloadSchema>
 
@@ -106,9 +106,9 @@ export type AssertFailedPayload = z.infer<typeof AssertFailedPayloadSchema>
 // compare:* — cross-scan diff lifecycle.
 // ────────────────────────────────────────────────────────────────────────────
 
-const CompareCompletePayloadSchema = z.object({
-  baseScanId: ScanId,
-  currentScanId: ScanId,
+export const CompareCompletePayloadSchema = z.object({
+  baseScanId: ScanIdSchema,
+  currentScanId: ScanIdSchema,
   regressions: z.number().int().nonnegative(),
   improvements: z.number().int().nonnegative(),
 })
@@ -118,13 +118,13 @@ export type CompareCompletePayload = z.infer<typeof CompareCompletePayloadSchema
 // quota:* — rate-limit / quota events.
 // ────────────────────────────────────────────────────────────────────────────
 
-const QuotaExceededPayloadSchema = z.object({
+export const QuotaExceededPayloadSchema = z.object({
   bucket: z.string(),
   resetAt: z.iso.datetime().optional(),
 })
 export type QuotaExceededPayload = z.infer<typeof QuotaExceededPayloadSchema>
 
-const QuotaDepletedPayloadSchema = z.object({
+export const QuotaDepletedPayloadSchema = z.object({
   bucket: z.string(),
   remaining: z.number().int().nonnegative(),
   limit: z.number().int().positive(),
@@ -135,27 +135,27 @@ export type QuotaDepletedPayload = z.infer<typeof QuotaDepletedPayloadSchema>
 // route:* — per-URL crawler/html events emitted by the legacy cluster engine.
 // ────────────────────────────────────────────────────────────────────────────
 
-const RouteQueuedPayloadSchema = z.object({ scanId: ScanId, url: Url })
+export const RouteQueuedPayloadSchema = z.object({ scanId: ScanIdSchema, url: UrlSchema })
 export type RouteQueuedPayload = z.infer<typeof RouteQueuedPayloadSchema>
 
-const RouteHtmlExtractedPayloadSchema = z.object({ scanId: ScanId, url: Url, payload: z.string() })
+export const RouteHtmlExtractedPayloadSchema = z.object({ scanId: ScanIdSchema, url: UrlSchema, payload: z.string() })
 export type RouteHtmlExtractedPayload = z.infer<typeof RouteHtmlExtractedPayloadSchema>
 
 // ────────────────────────────────────────────────────────────────────────────
 // audit:* — per-URL audit lifecycle. Used by quota / retry middleware.
 // ────────────────────────────────────────────────────────────────────────────
 
-const AuditBeforePayloadSchema = z.object({
-  scanId: ScanId,
-  url: Url,
+export const AuditBeforePayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  url: UrlSchema,
   auditor: z.string(),
   quotaBucket: z.string().optional(),
 })
 export type AuditBeforePayload = z.infer<typeof AuditBeforePayloadSchema>
 
-const AuditAfterPayloadSchema = z.object({
-  scanId: ScanId,
-  url: Url,
+export const AuditAfterPayloadSchema = z.object({
+  scanId: ScanIdSchema,
+  url: UrlSchema,
   auditor: z.string(),
   durationMs: z.number().nonnegative(),
   ok: z.boolean(),
@@ -166,7 +166,7 @@ export type AuditAfterPayload = z.infer<typeof AuditAfterPayloadSchema>
 // log — root-level log channel. Mirrors consola levels.
 // ────────────────────────────────────────────────────────────────────────────
 
-const LogPayloadSchema = z.object({
+export const LogPayloadSchema = z.object({
   level: z.enum(['silent', 'fatal', 'error', 'warn', 'log', 'info', 'success', 'debug', 'trace', 'verbose']),
   message: z.string(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -202,31 +202,6 @@ export const HookSchemas = {
   'audit:after': AuditAfterPayloadSchema,
   'log': LogPayloadSchema,
 } as const
-
-export {
-  AssertFailedPayloadSchema as AssertFailedPayload,
-  AssertPassedPayloadSchema as AssertPassedPayload,
-  AuditAfterPayloadSchema as AuditAfterPayload,
-  AuditBeforePayloadSchema as AuditBeforePayload,
-  CompareCompletePayloadSchema as CompareCompletePayload,
-  LogPayloadSchema as LogPayload,
-  QuotaDepletedPayloadSchema as QuotaDepletedPayload,
-  QuotaExceededPayloadSchema as QuotaExceededPayload,
-  RouteHtmlExtractedPayloadSchema as RouteHtmlExtractedPayload,
-  RouteQueuedPayloadSchema as RouteQueuedPayload,
-  ScanCancelledPayloadSchema as ScanCancelledPayload,
-  ScanCompletePayloadSchema as ScanCompletePayload,
-  ScanCreatedPayloadSchema as ScanCreatedPayload,
-  ScanDiscoveringPayloadSchema as ScanDiscoveringPayload,
-  ScanErrorPayloadSchema as ScanErrorPayload,
-  ScanPausedPayloadSchema as ScanPausedPayload,
-  ScanProgressPayloadSchema as ScanProgressPayload,
-  ScanResumedPayloadSchema as ScanResumedPayload,
-  ScanRouteCompletePayloadSchema as ScanRouteCompletePayload,
-  ScanRouteFailedPayloadSchema as ScanRouteFailedPayload,
-  ScanScanningPayloadSchema as ScanScanningPayload,
-  ScanStartedPayloadSchema as ScanStartedPayload,
-}
 
 export type HookName = keyof typeof HookSchemas
 

--- a/packages/contracts/src/packs/index.ts
+++ b/packages/contracts/src/packs/index.ts
@@ -13,12 +13,12 @@
 
 import { z } from 'zod'
 import type { Logger } from '../ports/core'
-import { ScanId } from '../types/atoms'
-import type { Device, ScanRoute } from '../types/atoms'
+import { ScanIdSchema } from '../types/atoms'
+import type { Device, ScanId, ScanRoute } from '../types/atoms'
 
 // ── Wire-format ────────────────────────────────────────────────────────────
 
-const AuditorRequirementSchema = z.object({
+export const AuditorRequirementSchema = z.object({
   kind: z.enum(['lh-category', 'lh-audit', 'custom']),
   id: z.string(),
   required: z.boolean(),
@@ -27,8 +27,8 @@ export type AuditorRequirement = z.infer<typeof AuditorRequirementSchema>
 
 // Cached output of pack.run. Content-addressable by (scanId, name, version).
 // Large reports spill to a blob; small ones stay inline.
-const PackRunSchema = z.object({
-  scanId: ScanId,
+export const PackRunSchema = z.object({
+  scanId: ScanIdSchema,
   packName: z.string(),
   packVersion: z.string(),
   startedAt: z.iso.datetime(),
@@ -70,10 +70,4 @@ export interface Pack<TReport = unknown> {
     icon?: string
     component?: string
   }
-}
-
-// Re-export the Zod schemas under stable names (mirrors atoms.ts pattern).
-export {
-  AuditorRequirementSchema as AuditorRequirement,
-  PackRunSchema as PackRun,
 }

--- a/packages/contracts/src/types/atoms.ts
+++ b/packages/contracts/src/types/atoms.ts
@@ -287,22 +287,28 @@ const AssertionResultSchema = z.object({
 })
 export type AssertionResult = z.infer<typeof AssertionResultSchema>
 
+// Schemas are exported under their own names (`FooSchema`). Types live on
+// the inferred `Foo`. Past iterations re-exported `FooSchema as Foo` which
+// shadowed the type and broke tsc's declaration emitter — TS4025/TS4033
+// because the same identifier was bound to both a value and a type. Keeping
+// them separate matches the Zod community convention and makes published
+// .d.ts files honest.
 export {
-  AssertionSchema as Assertion,
-  AssertionResultSchema as AssertionResult,
-  AuditFindingSchema as AuditFinding,
-  CategorySchema as Category,
-  DeviceSchema as Device,
-  ExtractedMetricsSchema as ExtractedMetrics,
-  MetricNameSchema as MetricName,
-  PaginatedSchema as Paginated,
-  ReconciledReportSchema as ReconciledReport,
-  ScanSchema as Scan,
-  ScanIdSchema as ScanId,
-  ScanRouteSchema as ScanRoute,
-  ScanStatusSchema as ScanStatus,
-  ScanSummarySchema as ScanSummary,
-  SeedSchema as Seed,
-  StructuredErrorSchema as StructuredError,
-  UrlSchema as Url,
+  AssertionResultSchema,
+  AssertionSchema,
+  AuditFindingSchema,
+  CategorySchema,
+  DeviceSchema,
+  ExtractedMetricsSchema,
+  MetricNameSchema,
+  PaginatedSchema,
+  ReconciledReportSchema,
+  ScanIdSchema,
+  ScanRouteSchema,
+  ScanSchema,
+  ScanStatusSchema,
+  ScanSummarySchema,
+  SeedSchema,
+  StructuredErrorSchema,
+  UrlSchema,
 }

--- a/packages/contracts/src/types/index.ts
+++ b/packages/contracts/src/types/index.ts
@@ -770,4 +770,8 @@ export interface UnlighthouseReport {
   insights: UnlighthouseInsights
   artifacts?: any
   raw?: Result
+  // Gzipped LHCI-format LHR. Set by providers that produce a raw Lighthouse
+  // run (local, mock, cdp-connect); core's ingest path persists it to the
+  // blob store under the route's `lhrBlobKey` when present.
+  lhrGzip?: Uint8Array
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -9,6 +9,7 @@ import type {
   ScanStatus,
   ScanSummary,
   Storage,
+  UnlighthouseConfig,
   UnlighthouseCore,
   UnlighthouseCoreOptions,
   UnlighthouseCoreRunOptions,
@@ -16,7 +17,7 @@ import type {
 } from '@unlighthouse/contracts'
 import type { Hookable } from 'hookable'
 import {
-  UnlighthouseConfig,
+  UnlighthouseConfigSchema,
   UnlighthouseError,
 } from '@unlighthouse/contracts'
 import { createHooks } from 'hookable'
@@ -185,7 +186,7 @@ function aggregateScores(routes: Array<{
 
 export function createUnlighthouseCore(opts: UnlighthouseCoreOptions): UnlighthouseCore {
   // 1. Validate config via Zod; throw CONFIG_INVALID on failure.
-  const parsed = UnlighthouseConfig.safeParse(opts.config)
+  const parsed = UnlighthouseConfigSchema.safeParse(opts.config)
   if (!parsed.success) {
     throw new UnlighthouseError({
       code: 'CONFIG_INVALID',

--- a/packages/core/src/packs/a11y-quick-wins.ts
+++ b/packages/core/src/packs/a11y-quick-wins.ts
@@ -154,15 +154,22 @@ interface RawFinding {
 // (reconciled blob first, LHR fallback). Element-level data was projected
 // into the reconciled blob in this PR — earlier scans without that
 // projection still work via getLhr.
+interface RouteViewElement {
+  selector: string | null
+  snippet: string | null
+  nodeLabel: string | null
+}
+
+interface RouteViewAudit {
+  weight: number
+  title: string
+  description: string | null
+  items: RouteViewElement[]
+  failed: boolean
+}
+
 interface RouteView {
-  // (auditId → { weight, title, description, items })
-  audits: Map<string, {
-    weight: number
-    title: string
-    description: string | null
-    items: Array<{ selector: string | null, snippet: string | null, nodeLabel: string | null }>
-    failed: boolean
-  }>
+  audits: Map<string, RouteViewAudit>
 }
 
 async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteView | null> {
@@ -179,7 +186,7 @@ async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteV
         }> }
       | null
     if (reconciled?.audits && reconciled.categories?.accessibility?.auditRefs?.length) {
-      const audits = new Map<string, RouteView['audits'] extends Map<string, infer V> ? V : never>()
+      const audits = new Map<string, RouteViewAudit>()
       const weights = new Map<string, number>()
       for (const ref of reconciled.categories.accessibility.auditRefs)
         weights.set(ref.id, ref.weight)
@@ -188,7 +195,7 @@ async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteV
         if (!a)
           continue
         const failed = a.score != null && a.score < 1
-        const items: RouteView['audits'] extends Map<string, infer V> ? V['items'] : never = []
+        const items: RouteViewElement[] = []
         if (failed && a.items) {
           for (const it of a.items) {
             const node = it.node
@@ -223,7 +230,7 @@ async function loadRouteView(url: string, ctx: PackReconcileCtx): Promise<RouteV
       if (!a)
         continue
       const failed = a.score != null && a.score < 1
-      const items: RouteView['audits'] extends Map<string, infer V> ? V['items'] : never = []
+      const items: RouteViewElement[] = []
       if (failed) {
         for (const it of a.details?.items ?? []) {
           const node = it.node

--- a/packages/unlighthouse/src/config/resolve.ts
+++ b/packages/unlighthouse/src/config/resolve.ts
@@ -6,7 +6,8 @@
 import { Buffer } from 'node:buffer'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { UnlighthouseConfig, UnlighthouseError } from '@unlighthouse/contracts'
+import type { UnlighthouseConfig } from '@unlighthouse/contracts'
+import { UnlighthouseConfigSchema, UnlighthouseError } from '@unlighthouse/contracts'
 import { loadConfig } from 'c12'
 import { defu } from 'defu'
 import { withLeadingSlash, withTrailingSlash } from 'ufo'
@@ -239,7 +240,7 @@ export async function resolveConfig(opts: ResolveConfigOptions = {}): Promise<Re
 
   const merged = applyHostRules(config as UnlighthouseConfig, cwd)
 
-  const parsed = UnlighthouseConfig.safeParse(merged)
+  const parsed = UnlighthouseConfigSchema.safeParse(merged)
   if (!parsed.success) {
     throw new UnlighthouseError({
       code: 'CONFIG_INVALID',

--- a/packages/unlighthouse/src/server-hooks.ts
+++ b/packages/unlighthouse/src/server-hooks.ts
@@ -1,11 +1,20 @@
 // Server-side hook bus wiring. Extracted from `host.ts` so behavior wiring
 // (auto-start on dashboard visit, etc.) can be unit-tested without spinning
 // up the full host (sqlite, fs, drizzle).
+//
+// `ServerHookMap` mirrors the old `ServerHookMap` type from the legacy
+// puppeteer-cluster crawler that lived under @unlighthouse/core/crawlers
+// before it was dropped (commit 5aa8954). Kept local so a future server-side
+// event addition stays in this file's blast radius.
 
 import type { Logger } from '@unlighthouse/contracts'
-import type { LegacyWorkerHooks } from '@unlighthouse/core/crawlers'
 import type { Hookable } from 'hookable'
 import { createHooks } from 'hookable'
+
+export interface ServerHookMap {
+  /** Emitted by the dashboard SPA once it connects to the host. */
+  'visited-client': (clientInfo?: { userAgent?: string }) => void | Promise<void>
+}
 
 export interface ServerHooksDeps {
   /** When true, the first `visited-client` event triggers `start()`. */
@@ -20,8 +29,8 @@ export interface ServerHooksDeps {
  * `visited-client` when `autoStartOnVisit` is enabled — idempotent: a flood of
  * visit events from concurrent SPA loads only triggers `start()` once.
  */
-export function createServerHooks(deps: ServerHooksDeps): Hookable<LegacyWorkerHooks> {
-  const hooks = createHooks<LegacyWorkerHooks>()
+export function createServerHooks(deps: ServerHooksDeps): Hookable<ServerHookMap> {
+  const hooks = createHooks<ServerHookMap>()
 
   if (deps.autoStartOnVisit) {
     let started = false

--- a/packages/unlighthouse/src/server.ts
+++ b/packages/unlighthouse/src/server.ts
@@ -1,4 +1,5 @@
-import type { Logger, ResolvedUserConfig, RuntimeSettings, UnlighthouseHooks } from '@unlighthouse/contracts'
+import type { Logger, ResolvedUserConfig, RuntimeSettings } from '@unlighthouse/contracts'
+import type { ServerHookMap } from './server-hooks'
 import type { WS } from '@unlighthouse/core/api'
 import type { App } from 'h3'
 import type { Hookable } from 'hookable'
@@ -31,7 +32,7 @@ const mimeTypes: Record<string, string> = {
 export interface MountServerDeps {
   resolvedConfig: ResolvedUserConfig
   runtimeSettings: RuntimeSettings
-  hooks: Hookable<UnlighthouseHooks>
+  hooks: Hookable<ServerHookMap>
   ws: WS | null
   logger?: Logger
 }

--- a/packages/unlighthouse/tsconfig.json
+++ b/packages/unlighthouse/tsconfig.json
@@ -7,7 +7,11 @@
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    // Same as packages/mcp — the CLI imports source files via `.ts`
+    // extensions for type-safe alias-free workspace dev. obuild strips
+    // the extension at build time.
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*.ts", "build.config.ts"],
   "exclude": ["dist"]

--- a/test/reconcile-contract.test.ts
+++ b/test/reconcile-contract.test.ts
@@ -6,7 +6,7 @@
 // once via the full ingest path (mock auditor → scan complete → verify the
 // `.contract.json` blob is on disk).
 
-import { ReconciledReport } from '@unlighthouse/contracts'
+import { ReconciledReportSchema } from '@unlighthouse/contracts'
 import { createUnlighthouseCore } from '@unlighthouse/core'
 import { createMockAuditor } from '@unlighthouse/core/auditors/mock'
 import { parallelMapCrawler } from '@unlighthouse/core/crawlers/parallel-map'
@@ -60,7 +60,7 @@ describe('reconcileToContract', () => {
     })
     // Round-trip through the Zod schema — the strongest assertion that the
     // shape matches the contract.
-    expect(() => ReconciledReport.parse(out)).not.toThrow()
+    expect(() => ReconciledReportSchema.parse(out)).not.toThrow()
   })
 
   it('derives severity per audit (the bucketing pack reconcilers depend on)', () => {
@@ -195,7 +195,7 @@ describe('scan ingest persists reconciled contract blob', () => {
 
     const parsed = JSON.parse(new TextDecoder().decode(buf!))
     // Validate it against the contract.
-    expect(() => ReconciledReport.parse(parsed)).not.toThrow()
+    expect(() => ReconciledReportSchema.parse(parsed)).not.toThrow()
     expect(parsed.scanId).toBe(scanId)
     expect(parsed.url).toBe(url)
     expect(parsed.device).toBe('mobile')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "unlighthouse": ["./packages/unlighthouse/src"],
       "@unlighthouse/ui": ["./packages/ui"],
       "@unlighthouse/contracts": ["./packages/contracts/src"],
+      "@unlighthouse/contracts/*": ["./packages/contracts/src/*"],
       "@unlighthouse/core": ["./packages/core/src"],
       "@unlighthouse/core/*": ["./packages/core/src/*"],
       "@unlighthouse/mcp": ["./packages/mcp/src"],


### PR DESCRIPTION
## Summary

Root-cause refactor for the dts emission failures that blocked PR #324's follow-up packaging work. Every Zod schema in contracts was double-exported under the same identifier — once as the value via `FooSchema as Foo`, once as the inferred type. TypeScript tolerates this at the type-checker level but tsc's declaration emitter (and rolldown-plugin-dts) errors with TS4025 / TS4033, so the contracts package shipped zero types when published.

After this PR: `FooSchema` is the value (Zod schema), `Foo` is the type. Plain and standard. The way the Zod community does it.

## What changed

**Contracts** (17 atom schemas, 22 hook payload schemas, plus config / packs / sites / compare):
- `FooSchema` exported by name
- `Foo` type exported separately via `z.infer<typeof FooSchema>`
- Dropped every `FooSchema as Foo` re-export
- types/index.ts: `UnlighthouseReport.lhrGzip` declared (was implicitly used)
- drizzle/parity.ts: omit `device` in the ExtractedMetrics shape check (D-029 follow-up that would've failed once dts emission turned on)

**Consumers** (core, unlighthouse):
- `UnlighthouseConfig.safeParse` → `UnlighthouseConfigSchema.safeParse`
- `ReconciledReport.parse` → `ReconciledReportSchema.parse` in tests
- a11y-quick-wins: lifted inline conditional indexed types into named interfaces (tsc couldn't resolve the conditional inference; a latent bug)
- server-hooks: replaced deleted `LegacyWorkerHooks` (dropped 5aa8954) with a local `ServerHookMap` declaring only the one event server.ts fires
- server.ts: imports the local `ServerHookMap` instead of the missing `UnlighthouseHooks` re-export

**Tsconfig hygiene**:
- root paths gains `@unlighthouse/contracts/*` so subpath workspace dev matches package.json exports
- packages/unlighthouse picks up `allowImportingTsExtensions: true` (already on packages/mcp)

## What this PR is NOT

- Doesn't change the published .d.ts emission path. That's a follow-up — this PR removes the source-code blocker so the next one can be a much smaller config change.

## Test plan
- [x] full test suite: 430/430 passing
- [x] `pnpm typecheck` clean across contracts/core/cloudflare/mcp/unlighthouse (UI typecheck has its own pre-existing issues, unchanged)
- [x] contracts + core builds clean