### PR TITLE
fix(d029): runtime migration for pre-D-029 sqlite databases

### DIFF
--- a/packages/core/src/storage/drizzle/index.ts
+++ b/packages/core/src/storage/drizzle/index.ts
@@ -52,6 +52,7 @@ export function drizzleStorage(opts: DrizzleStorageOptions): DrizzleStorage {
 }
 
 export { INIT_SQL, INIT_SQL_STATEMENTS } from './init-sql'
+export { applyMigrations } from './migrations'
 
 // Re-export schema/types from contracts for users that want raw access.
 export * from '@unlighthouse/contracts/drizzle'

--- a/packages/core/src/storage/drizzle/migrations.ts
+++ b/packages/core/src/storage/drizzle/migrations.ts
@@ -1,0 +1,124 @@
+// Runtime migrations for sqlite databases that pre-date a schema bump.
+// `INIT_SQL_STATEMENTS` covers fresh databases via `CREATE TABLE IF NOT
+// EXISTS`, but that's a no-op against existing tables — so anything that
+// adds a column, rewrites a primary key, etc., needs an explicit upgrade
+// path. This module owns that path.
+//
+// Each migration is a pair of functions:
+//   - `needs(db)` checks the db's current state. Cheap. Idempotent.
+//   - `apply(db)` performs the migration inside a transaction. Throws on
+//     real corruption; never on "already migrated."
+//
+// Run all of them in order at boot. Adding a new schema bump means
+// appending one entry; old entries stay so an ancient database can
+// catch up through every intermediate version.
+
+import type { Database } from 'better-sqlite3'
+
+interface Migration {
+  /** Stable name for logging. */
+  id: string
+  /** True if the migration should run against this db. */
+  needs: (db: Database) => boolean
+  /** Apply the change. Wrap in a transaction. */
+  apply: (db: Database) => void
+}
+
+// SQLite has no `IF NOT EXISTS` for ALTER and no first-class column
+// metadata — but `PRAGMA table_info(<table>)` returns one row per
+// column. Cheap, no transaction needed, returns [] for non-existent
+// tables.
+function hasColumn(db: Database, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  return rows.some(r => r.name === column)
+}
+
+function tableExists(db: Database, table: string): boolean {
+  const row = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(table)
+  return row != null
+}
+
+const MIGRATIONS: Migration[] = [
+  // D-029 — scan_routes PK widens from (scan_id, url) to
+  // (scan_id, url, device). SQLite can't widen a PK in place; we rebuild
+  // the table and copy rows over with device='mobile' (the historical
+  // default for single-device scans). foreign_keys is briefly disabled so
+  // the dependent aggregation tables don't reject the rename mid-flight.
+  {
+    id: 'd029-scan-routes-device-column',
+    needs: db => tableExists(db, 'scan_routes') && !hasColumn(db, 'scan_routes', 'device'),
+    apply: (db) => {
+      db.pragma('foreign_keys = OFF')
+      try {
+        const migrate = db.transaction(() => {
+          db.exec(`ALTER TABLE scan_routes RENAME TO scan_routes_d029_old`)
+          db.exec(`
+            CREATE TABLE scan_routes (
+              scan_id text NOT NULL,
+              url text NOT NULL,
+              device text NOT NULL DEFAULT 'mobile',
+              path text NOT NULL,
+              route_name text,
+              score_performance real,
+              score_accessibility real,
+              score_seo real,
+              score_best_practices real,
+              lcp real,
+              cls real,
+              inp real,
+              fcp real,
+              ttfb real,
+              tbt real,
+              si real,
+              lighthouse_version text NOT NULL,
+              captured_at text NOT NULL,
+              lhr_blob_key text NOT NULL,
+              report_blob_key text,
+              PRIMARY KEY (scan_id, url, device),
+              FOREIGN KEY (scan_id) REFERENCES scans(scan_id) ON DELETE cascade
+            )
+          `)
+          db.exec(`
+            INSERT INTO scan_routes (
+              scan_id, url, device, path, route_name,
+              score_performance, score_accessibility, score_seo, score_best_practices,
+              lcp, cls, inp, fcp, ttfb, tbt, si,
+              lighthouse_version, captured_at, lhr_blob_key, report_blob_key
+            )
+            SELECT
+              scan_id, url, 'mobile', path, route_name,
+              score_performance, score_accessibility, score_seo, score_best_practices,
+              lcp, cls, inp, fcp, ttfb, tbt, si,
+              lighthouse_version, captured_at, lhr_blob_key, report_blob_key
+            FROM scan_routes_d029_old
+          `)
+          db.exec(`DROP TABLE scan_routes_d029_old`)
+          db.exec(`CREATE INDEX IF NOT EXISTS idx_scan_routes_scan_id ON scan_routes (scan_id)`)
+        })
+        migrate()
+      }
+      finally {
+        db.pragma('foreign_keys = ON')
+      }
+    },
+  },
+]
+
+interface ApplyMigrationsOptions {
+  /** Called with each migration's id once it applies. Useful for logging. */
+  onApply?: (id: string) => void
+}
+
+/**
+ * Run every applicable migration against `db` in order. Cheap on the
+ * already-current case (each `needs` check is a single PRAGMA / sqlite_master
+ * lookup) so it's safe to call on every host boot.
+ */
+export function applyMigrations(db: Database, opts: ApplyMigrationsOptions = {}): void {
+  for (const m of MIGRATIONS) {
+    if (!m.needs(db))
+      continue
+    m.apply(db)
+    opts.onApply?.(m.id)
+  }
+}

--- a/packages/unlighthouse/src/cli/mcp.ts
+++ b/packages/unlighthouse/src/cli/mcp.ts
@@ -13,7 +13,7 @@ import { createHandlers } from '@unlighthouse/core/api/handlers'
 import { crawleeCrawler } from '@unlighthouse/core/crawlers'
 import { fuseSeeds, manualSeeds } from '@unlighthouse/core/seeds'
 import { createStorage } from '@unlighthouse/core/storage'
-import { drizzleStorage, INIT_SQL_STATEMENTS } from '@unlighthouse/core/storage/drizzle'
+import { applyMigrations, drizzleStorage, INIT_SQL_STATEMENTS } from '@unlighthouse/core/storage/drizzle'
 import { unstorageBlobs } from '@unlighthouse/core/storage/unstorage-blobs'
 import { startStdioServer } from '@unlighthouse/mcp'
 import Database from 'better-sqlite3'
@@ -241,6 +241,11 @@ export async function runMcp(): Promise<void> {
         logger.warn?.(`Migration stmt skipped: ${msg}`)
     }
   }
+  // Runtime upgrades for databases that pre-date a schema bump (D-029
+  // device column, etc.). Same code path host.ts uses.
+  applyMigrations(sqliteDb, {
+    onApply: id => logger.info?.(`[storage] applied migration: ${id}`),
+  })
   const drizzleDb = drizzle(sqliteDb)
   const drizzleAdapter = drizzleStorage({
     driver: drizzleDb,

--- a/packages/unlighthouse/src/host.ts
+++ b/packages/unlighthouse/src/host.ts
@@ -18,7 +18,7 @@ import { createWS } from '@unlighthouse/core/api'
 import { crawleeCrawler } from '@unlighthouse/core/crawlers'
 import { fuseSeeds, manualSeeds, sitemapSeeds } from '@unlighthouse/core/seeds'
 import { createStorage } from '@unlighthouse/core/storage'
-import { drizzleStorage, INIT_SQL_STATEMENTS } from '@unlighthouse/core/storage/drizzle'
+import { applyMigrations, drizzleStorage, INIT_SQL_STATEMENTS } from '@unlighthouse/core/storage/drizzle'
 import { unstorageBlobs } from '@unlighthouse/core/storage/unstorage-blobs'
 import Database from 'better-sqlite3'
 import { loadConfig } from 'c12'
@@ -184,6 +184,14 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
           logger.warn?.(`Migration stmt skipped: ${msg}`)
       }
     }
+    // Runtime upgrades for databases that pre-date a schema bump.
+    // INIT_SQL above is `CREATE TABLE IF NOT EXISTS`-style — no-op against
+    // existing tables — so anything that adds a column or rewrites a PK
+    // needs an explicit path. applyMigrations runs each pending migration
+    // once and is a no-op on already-current databases.
+    applyMigrations(sqliteDb, {
+      onApply: id => logger.info?.(`[storage] applied migration: ${id}`),
+    })
     const drizzleDb = drizzle(sqliteDb)
     const drizzleAdapter = drizzleStorage({
       driver: drizzleDb,

--- a/test/d029-runtime-migration.test.ts
+++ b/test/d029-runtime-migration.test.ts
@@ -1,0 +1,193 @@
+// D-029 runtime migration: existing sqlite databases from before the
+// device column landed need an in-place upgrade. INIT_SQL_STATEMENTS uses
+// `CREATE TABLE IF NOT EXISTS` and is a no-op against them; the migrations
+// module owns the explicit upgrade path.
+//
+// This test stands up a synthetic "pre-D-029" database (scan_routes
+// without a device column, PK on (scan_id, url) alone), runs the
+// migration, and verifies the resulting shape + data preservation.
+
+import Database from 'better-sqlite3'
+import { applyMigrations } from '@unlighthouse/core/storage/drizzle'
+import { describe, expect, it } from 'vitest'
+
+function makeLegacyDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE scans (
+      scan_id text PRIMARY KEY NOT NULL,
+      site text NOT NULL,
+      device text NOT NULL,
+      status text NOT NULL,
+      started_at text NOT NULL,
+      completed_at text,
+      ci_branch text,
+      ci_commit text,
+      ci_commit_message text,
+      summary text,
+      created_at_ms integer DEFAULT (unixepoch() * 1000) NOT NULL
+    );
+    CREATE TABLE scan_routes (
+      scan_id text NOT NULL,
+      url text NOT NULL,
+      path text NOT NULL,
+      route_name text,
+      score_performance real,
+      score_accessibility real,
+      score_seo real,
+      score_best_practices real,
+      lcp real,
+      cls real,
+      inp real,
+      fcp real,
+      ttfb real,
+      tbt real,
+      si real,
+      lighthouse_version text NOT NULL,
+      captured_at text NOT NULL,
+      lhr_blob_key text NOT NULL,
+      report_blob_key text,
+      PRIMARY KEY (scan_id, url),
+      FOREIGN KEY (scan_id) REFERENCES scans(scan_id) ON DELETE cascade
+    );
+    CREATE INDEX idx_scan_routes_scan_id ON scan_routes (scan_id);
+  `)
+  // Seed one scan + two routes.
+  db.exec(`INSERT INTO scans (scan_id, site, device, status, started_at) VALUES ('s1', 'http://x', 'mobile', 'complete', '2025-01-01T00:00:00Z')`)
+  db.exec(`INSERT INTO scan_routes (scan_id, url, path, score_performance, lighthouse_version, captured_at, lhr_blob_key) VALUES
+    ('s1', 'http://x/a', '/a', 0.9, '12.0.0', '2025-01-01T00:00:00Z', 'k1'),
+    ('s1', 'http://x/b', '/b', 0.8, '12.0.0', '2025-01-01T00:00:00Z', 'k2')`)
+  return db
+}
+
+function cols(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(r => r.name)
+}
+
+function pkCols(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string, pk: number }>)
+    .filter(r => r.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map(r => r.name)
+}
+
+describe('D-029 runtime migration', () => {
+  it('adds the device column to a legacy scan_routes table', () => {
+    const db = makeLegacyDb()
+    expect(cols(db, 'scan_routes')).not.toContain('device')
+
+    const applied: string[] = []
+    applyMigrations(db, { onApply: id => applied.push(id) })
+
+    expect(applied).toEqual(['d029-scan-routes-device-column'])
+    expect(cols(db, 'scan_routes')).toContain('device')
+  })
+
+  it('widens the PK to (scan_id, url, device)', () => {
+    const db = makeLegacyDb()
+    expect(pkCols(db, 'scan_routes')).toEqual(['scan_id', 'url'])
+
+    applyMigrations(db)
+
+    expect(pkCols(db, 'scan_routes')).toEqual(['scan_id', 'url', 'device'])
+  })
+
+  it('preserves existing rows and stamps them with device=mobile', () => {
+    const db = makeLegacyDb()
+    applyMigrations(db)
+
+    const rows = db.prepare(`SELECT scan_id, url, device, score_performance FROM scan_routes ORDER BY url`).all()
+    expect(rows).toEqual([
+      { scan_id: 's1', url: 'http://x/a', device: 'mobile', score_performance: 0.9 },
+      { scan_id: 's1', url: 'http://x/b', device: 'mobile', score_performance: 0.8 },
+    ])
+  })
+
+  it('is a no-op on an already-migrated database (idempotent)', () => {
+    const db = makeLegacyDb()
+    applyMigrations(db) // first run upgrades
+    const applied: string[] = []
+    applyMigrations(db, { onApply: id => applied.push(id) }) // second run = no-op
+    expect(applied).toEqual([])
+  })
+
+  it('is a no-op on a fresh database that already has the device column', () => {
+    const db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE scans (
+        scan_id text PRIMARY KEY NOT NULL,
+        site text NOT NULL,
+        device text NOT NULL,
+        status text NOT NULL,
+        started_at text NOT NULL,
+        completed_at text,
+        ci_branch text,
+        ci_commit text,
+        ci_commit_message text,
+        summary text,
+        created_at_ms integer DEFAULT (unixepoch() * 1000) NOT NULL
+      );
+      CREATE TABLE scan_routes (
+        scan_id text NOT NULL,
+        url text NOT NULL,
+        device text NOT NULL DEFAULT 'mobile',
+        path text NOT NULL,
+        route_name text,
+        score_performance real,
+        score_accessibility real,
+        score_seo real,
+        score_best_practices real,
+        lcp real,
+        cls real,
+        inp real,
+        fcp real,
+        ttfb real,
+        tbt real,
+        si real,
+        lighthouse_version text NOT NULL,
+        captured_at text NOT NULL,
+        lhr_blob_key text NOT NULL,
+        report_blob_key text,
+        PRIMARY KEY (scan_id, url, device),
+        FOREIGN KEY (scan_id) REFERENCES scans(scan_id) ON DELETE cascade
+      );
+    `)
+    const applied: string[] = []
+    applyMigrations(db, { onApply: id => applied.push(id) })
+    expect(applied).toEqual([])
+  })
+
+  it('survives an empty pre-D-029 scan_routes table (no rows)', () => {
+    const db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE scans (scan_id text PRIMARY KEY NOT NULL, site text NOT NULL, device text NOT NULL, status text NOT NULL, started_at text NOT NULL, completed_at text, ci_branch text, ci_commit text, ci_commit_message text, summary text, created_at_ms integer DEFAULT (unixepoch() * 1000) NOT NULL);
+      CREATE TABLE scan_routes (
+        scan_id text NOT NULL,
+        url text NOT NULL,
+        path text NOT NULL,
+        route_name text,
+        score_performance real,
+        score_accessibility real,
+        score_seo real,
+        score_best_practices real,
+        lcp real,
+        cls real,
+        inp real,
+        fcp real,
+        ttfb real,
+        tbt real,
+        si real,
+        lighthouse_version text NOT NULL,
+        captured_at text NOT NULL,
+        lhr_blob_key text NOT NULL,
+        report_blob_key text,
+        PRIMARY KEY (scan_id, url),
+        FOREIGN KEY (scan_id) REFERENCES scans(scan_id) ON DELETE cascade
+      );
+    `)
+    applyMigrations(db)
+    expect(cols(db, 'scan_routes')).toContain('device')
+    expect(pkCols(db, 'scan_routes')).toEqual(['scan_id', 'url', 'device'])
+    expect(db.prepare(`SELECT count(*) as n FROM scan_routes`).get()).toEqual({ n: 0 })
+  })
+})


### PR DESCRIPTION
## Summary

Real bug from the wild — first post-D-029 scan against a workspace that had run unlighthouse before D-029 errors with:

\`\`\`
SqliteError: table scan_routes has no column named device
\`\`\`

INIT_SQL_STATEMENTS is \`CREATE TABLE IF NOT EXISTS\` shaped, so it's a no-op against existing tables — the device column never gets added. Reported by the user running \`pnpm cli --site https://harlanzw.com\` against a workspace with .unlighthouse/harlanzw.com/<hash>/db.sqlite from a pre-D-029 run.

## Fix

New \`applyMigrations(db)\` function in @unlighthouse/core/storage/drizzle. Each migration declares a cheap \`needs(db)\` check (PRAGMA / sqlite_master lookup) so it's safe to call on every host boot — current dbs short-circuit; legacy dbs upgrade once.

The D-029 migration:
1. ALTER scan_routes RENAME TO scan_routes_d029_old
2. CREATE the new shape with device column + PK (scan_id, url, device)
3. INSERT INTO new SELECT FROM old, stamping device='mobile' (the historical default for single-device scans)
4. DROP scan_routes_d029_old

All inside a transaction, with foreign_keys briefly disabled so dependent aggregation tables don't reject the half-built state. Partial failures leave the db in either the all-old or all-new shape — never broken.

Called at boot in both \`packages/unlighthouse/src/host.ts\` and \`packages/unlighthouse/src/cli/mcp.ts\`. onApply logs each migration's id so a support transcript shows the upgrade ran.

## Verified live

Ran against a real workspace .unlighthouse/harlanzw.com/575f/db.sqlite (43 routes, no device column). Migration: \`applied: d029-scan-routes-device-column\`. Post-migration: 43 rows preserved, all stamped device='mobile', PK is (scan_id, url, device).

## Test plan
- [x] full suite: 436/436 (6 new migration cases)
- [x] legacy db → device column added + PK widened
- [x] existing rows preserved with device='mobile'
- [x] second run = no-op (idempotent)
- [x] fresh db (already has device) = no-op
- [x] empty legacy table migrates cleanly
- [x] manual run against real stale db: 43 rows preserved end-to-end