### PR TITLE
feat(storage): filter + sort push-down — large-scan perf, drizzle + memory + D1

### DIFF
--- a/packages/cloudflare/src/storage/d1-r2.ts
+++ b/packages/cloudflare/src/storage/d1-r2.ts
@@ -366,11 +366,53 @@ function d1ScanRouteRepository(db: D1Database): ScanRouteRepository {
         where.push('device = ?')
         args.push(q.device)
       }
+      // Filter / sort push-down — mirrors the drizzle adapter so the
+      // application-side fallback in api/handlers/scan.ts and query.ts
+      // can stay identical between hosts.
+      if (q?.filter?.minScore) {
+        const map: Record<string, string> = {
+          'performance': 'score_performance',
+          'accessibility': 'score_accessibility',
+          'seo': 'score_seo',
+          'best-practices': 'score_best_practices',
+        }
+        for (const [cat, min] of Object.entries(q.filter.minScore)) {
+          const col = map[cat]
+          if (col && typeof min === 'number') {
+            where.push(`${col} IS NOT NULL AND ${col} >= ?`)
+            args.push(min)
+          }
+        }
+      }
+      if (q?.filter?.maxMetric) {
+        const allowed = new Set(['lcp', 'cls', 'inp', 'fcp', 'ttfb', 'tbt', 'si'])
+        for (const [metric, max] of Object.entries(q.filter.maxMetric)) {
+          if (allowed.has(metric) && typeof max === 'number') {
+            // Null columns match (matches the JS-fallback semantics).
+            where.push(`(${metric} IS NULL OR ${metric} <= ?)`)
+            args.push(max)
+          }
+        }
+      }
+      if (q?.filter?.urlPattern) {
+        where.push('url LIKE ?')
+        args.push(`%${q.filter.urlPattern}%`)
+      }
       const whereSql = where.join(' AND ')
+
+      let orderBy = ''
+      switch (q?.sort) {
+        case 'score-asc': orderBy = 'ORDER BY score_performance ASC'; break
+        case 'score-desc': orderBy = 'ORDER BY score_performance DESC'; break
+        case 'lcp-asc': orderBy = 'ORDER BY lcp ASC'; break
+        case 'lcp-desc': orderBy = 'ORDER BY lcp DESC'; break
+        case 'url-asc': orderBy = 'ORDER BY url ASC'; break
+        case 'capturedAt-desc': orderBy = 'ORDER BY captured_at DESC'; break
+      }
 
       const [itemsRes, countRes] = await db.batch<unknown>([
         db
-          .prepare(`SELECT ${ROUTE_COLS} FROM scan_routes WHERE ${whereSql} LIMIT ? OFFSET ?`)
+          .prepare(`SELECT ${ROUTE_COLS} FROM scan_routes WHERE ${whereSql} ${orderBy} LIMIT ? OFFSET ?`)
           .bind(...args, pageSize, offset),
         db
           .prepare(`SELECT count(*) AS count FROM scan_routes WHERE ${whereSql}`)

--- a/packages/contracts/src/ports/storage.ts
+++ b/packages/contracts/src/ports/storage.ts
@@ -39,6 +39,47 @@ export interface ListQuery {
   [k: string]: unknown
 }
 
+/**
+ * Sort modes pushed to the storage adapter. Storage implementations that
+ * understand them issue a real `ORDER BY` clause; ones that don't fall back
+ * to the application-side sort the API handler does on the page slice.
+ *
+ * The set mirrors the wire format on `scan.results.input.sort` /
+ * `query.routes.input.sort` 1:1 — kept in sync by convention.
+ */
+export type RouteSort
+  = | 'score-asc'
+    | 'score-desc'
+    | 'lcp-asc'
+    | 'lcp-desc'
+    | 'url-asc'
+    | 'capturedAt-desc'
+
+/**
+ * Filters that storage adapters can push down to SQL. The application-side
+ * fallback in api/handlers/scan.ts honours the same shape so behaviour stays
+ * identical whether or not the adapter implements push-down.
+ */
+export interface RouteFilter {
+  /**
+   * Lighthouse category id → minimum score (0..1). A row matches when every
+   * listed category column is ≥ the threshold (null columns excluded).
+   */
+  minScore?: Partial<Record<'performance' | 'accessibility' | 'seo' | 'best-practices', number>>
+  /**
+   * Metric column id → maximum value. A row matches when every listed metric
+   * is ≤ the threshold (null columns ignored — "no data" is not "too high").
+   */
+  maxMetric?: Partial<Record<'lcp' | 'cls' | 'inp' | 'fcp' | 'ttfb' | 'tbt' | 'si', number>>
+  /**
+   * URL substring (case-sensitive). SQL adapters use `url LIKE '%pattern%'`;
+   * the wire field on `scan.results` allows a regex source — push-down
+   * matches the literal substring fast path, falls back to the API handler's
+   * RegExp for anything fancier.
+   */
+  urlPattern?: string
+}
+
 export interface RouteListQuery {
   page?: number
   pageSize?: number
@@ -47,6 +88,16 @@ export interface RouteListQuery {
   // a specific device pass it here; the wire on those commands carries the
   // same optional field.
   device?: Device
+  /**
+   * Storage-side filter push-down (see RouteFilter). Adapters that can't
+   * push-down ignore this and let the API handler filter the page slice
+   * in JS — behaviour is identical, perf differs at 10k+ rows.
+   */
+  filter?: RouteFilter
+  /**
+   * Storage-side sort. Same fallback semantics as `filter`.
+   */
+  sort?: RouteSort
   [k: string]: unknown
 }
 

--- a/packages/core/src/api/handlers/query.ts
+++ b/packages/core/src/api/handlers/query.ts
@@ -4,77 +4,99 @@ import type { CommandOutput, QueryRoutes, ScanRoute } from '@unlighthouse/contra
 import type { Handler } from './types'
 import { applyRouteFilter, applyRouteSort } from './scan'
 
+// Substring-or-literal check — same heuristic scanResults uses. Anything
+// that looks like a plain URL/path goes to SQL `LIKE`; richer regexes
+// stay in JS on the final page.
+function isLiteralSubstring(pattern: string): boolean {
+  return /^[\w./\-:?#]+$/.test(pattern)
+}
+
 export const queryRoutes: Handler<typeof QueryRoutes> = {
   command: {} as typeof QueryRoutes,
   async run(input, ctx) {
-    // TODO: push filter/sort/projection down to storage when adapters support it.
-    let pool: ScanRoute[] = []
+    // Single-scan path: push the filter / sort / pagination straight to
+    // storage. The drizzle adapter emits real SQL — a 10k-route scan
+    // filtered to 50 reads 50 rows from disk, not 10k.
     if (input.scanId) {
-      // D-029: when scoping to one scan, also honour the device filter.
-      // Pre-fix this branch ignored input.device and returned every (url,
-      // device) row in a matrix scan, so the cross-scan path was device-
-      // aware but the per-scan path silently wasn't.
-      const res = await ctx.storage.routes.listForScan(input.scanId, {
+      const filterForStorage = input.filter
+        ? {
+            minScore: input.filter.minScore,
+            maxMetric: input.filter.maxMetric,
+            urlPattern: input.urlPattern && isLiteralSubstring(input.urlPattern)
+              ? input.urlPattern
+              : undefined,
+          }
+        : (input.urlPattern && isLiteralSubstring(input.urlPattern)
+            ? { urlPattern: input.urlPattern }
+            : undefined)
+
+      const page = await ctx.storage.routes.listForScan(input.scanId, {
+        page: input.page,
+        pageSize: input.pageSize,
+        device: input.device,
+        filter: filterForStorage,
+        sort: input.sort,
+      })
+
+      let items = page.items
+      // Fall through to JS for regex urlPatterns the SQL push-down skipped.
+      if (input.urlPattern && (!filterForStorage || filterForStorage.urlPattern == null)) {
+        const re = new RegExp(input.urlPattern)
+        items = items.filter(r => re.test(r.url))
+      }
+      if (input.projection?.length)
+        items = items.map(r => projectRow(r, input.projection!))
+      return {
+        items,
+        total: page.total,
+        page: input.page,
+        pageSize: input.pageSize,
+      } as CommandOutput<typeof QueryRoutes>
+    }
+
+    // Cross-scan path: aggregate rows from every matching scan, then
+    // filter/sort/page in JS. Push-down doesn't help here because the
+    // result is a union across scans — SQL would need a UNION ALL
+    // query the storage port doesn't expose. The per-scan listForScan
+    // calls still get the device + (substring) filter push-down so a
+    // 10-scan × 1000-route span doesn't fetch all 10000 just to filter.
+    let pool: ScanRoute[] = []
+    const scans = await ctx.storage.scans.list({
+      site: input.site,
+      device: input.device,
+      branch: input.branch,
+      pageSize: 500,
+    })
+    const filterForStorage = input.filter
+      ? {
+          minScore: input.filter.minScore,
+          maxMetric: input.filter.maxMetric,
+          urlPattern: input.urlPattern && isLiteralSubstring(input.urlPattern)
+            ? input.urlPattern
+            : undefined,
+        }
+      : (input.urlPattern && isLiteralSubstring(input.urlPattern)
+          ? { urlPattern: input.urlPattern }
+          : undefined)
+    for (const scan of scans.items) {
+      const res = await ctx.storage.routes.listForScan(scan.scanId, {
         page: 1,
         pageSize: 10_000,
         device: input.device,
+        filter: filterForStorage,
       })
-      pool = res.items
-    }
-    else {
-      // Cross-scan path: scans.list already narrows on device via the scan
-      // metadata column (scan-level primary device). Routes inside those
-      // scans are then further narrowed below when input.device is set —
-      // matters for matrix scans where the scan's primary is 'mobile' but
-      // the caller asked for 'desktop' explicitly.
-      const scans = await ctx.storage.scans.list({
-        site: input.site,
-        device: input.device,
-        branch: input.branch,
-        pageSize: 500,
-      })
-      for (const scan of scans.items) {
-        const res = await ctx.storage.routes.listForScan(scan.scanId, {
-          page: 1,
-          pageSize: 10_000,
-          device: input.device,
-        })
-        pool.push(...res.items)
-      }
+      pool.push(...res.items)
     }
 
-    if (input.urlPattern) {
+    if (input.urlPattern && (!filterForStorage || filterForStorage.urlPattern == null)) {
       const re = new RegExp(input.urlPattern)
       pool = pool.filter(r => re.test(r.url))
     }
 
     let filtered = applyRouteSort(applyRouteFilter(pool, input.filter), input.sort)
 
-    if (input.projection?.length) {
-      const keep = new Set<string>(input.projection)
-      filtered = filtered.map((r) => {
-        // D-029: device is part of row identity. Drop it from projection and
-        // matrix rows lose the only thing distinguishing them — keep it.
-        const out: Record<string, unknown> = {
-          url: r.url,
-          path: r.path,
-          scanId: r.scanId,
-          device: r.device,
-          lhrBlobKey: r.lhrBlobKey,
-          capturedAt: r.capturedAt,
-          lighthouseVersion: r.lighthouseVersion,
-          routeName: r.routeName,
-        }
-        for (const m of ['lcp', 'cls', 'inp', 'fcp', 'ttfb', 'tbt', 'si']) {
-          out[m] = keep.has(m) ? (r as unknown as Record<string, number | null>)[m] : null
-        }
-        out.scorePerformance = r.scorePerformance
-        out.scoreAccessibility = r.scoreAccessibility
-        out.scoreSeo = r.scoreSeo
-        out.scoreBestPractices = r.scoreBestPractices
-        return out as unknown as ScanRoute
-      })
-    }
+    if (input.projection?.length)
+      filtered = filtered.map(r => projectRow(r, input.projection!))
 
     const start = (input.page - 1) * input.pageSize
     const items = filtered.slice(start, start + input.pageSize)
@@ -85,4 +107,29 @@ export const queryRoutes: Handler<typeof QueryRoutes> = {
       pageSize: input.pageSize,
     } as CommandOutput<typeof QueryRoutes>
   },
+}
+
+// Projection: limit metric columns to those the caller asked for; identity
+// columns (url, path, device, scanId, blob keys, capturedAt, version) stay
+// regardless because they identify the row. Scores stay too — they're cheap
+// and most projection use cases want them alongside metrics.
+function projectRow(r: ScanRoute, projection: string[]): ScanRoute {
+  const keep = new Set(projection)
+  const out: Record<string, unknown> = {
+    url: r.url,
+    path: r.path,
+    scanId: r.scanId,
+    device: r.device,
+    lhrBlobKey: r.lhrBlobKey,
+    capturedAt: r.capturedAt,
+    lighthouseVersion: r.lighthouseVersion,
+    routeName: r.routeName,
+  }
+  for (const m of ['lcp', 'cls', 'inp', 'fcp', 'ttfb', 'tbt', 'si'])
+    out[m] = keep.has(m) ? (r as unknown as Record<string, number | null>)[m] : null
+  out.scorePerformance = r.scorePerformance
+  out.scoreAccessibility = r.scoreAccessibility
+  out.scoreSeo = r.scoreSeo
+  out.scoreBestPractices = r.scoreBestPractices
+  return out as unknown as ScanRoute
 }

--- a/packages/core/src/api/handlers/scan.ts
+++ b/packages/core/src/api/handlers/scan.ts
@@ -252,21 +252,49 @@ export const scanResults: Handler<typeof ScanResults> = {
     const scan = await ctx.storage.scans.get(input.scanId)
     if (!scan)
       notFound(input.scanId)
-    // D-029: pass device filter down to listForScan so the SQL `WHERE device
-    // = ?` narrows the row scan instead of pulling every row and filtering
-    // in JS. Omitted = return every row in the matrix.
-    // TODO: push filter/sort down to storage when adapters support it.
-    const all = await ctx.storage.routes.listForScan(input.scanId, {
-      page: 1,
-      pageSize: 10_000,
+    // Filter / sort / device / pagination all pushed to storage. The drizzle
+    // adapter turns these into real SQL (WHERE + ORDER BY + LIMIT + OFFSET),
+    // so a 10k-route scan filtered down to 50 returns 50 rows from the db
+    // — not 10k rows over the wire followed by a JS filter.
+    //
+    // The wire field `filter.urlPattern` is documented as a regex source;
+    // storage push-down only handles literal substring (LIKE %pattern%).
+    // We still apply the RegExp on the returned page for non-literal
+    // patterns — see filterRouteRegex below. Same with sorts the adapter
+    // doesn't recognise.
+    const filterForStorage = input.filter
+      ? {
+          minScore: input.filter.minScore,
+          maxMetric: input.filter.maxMetric,
+          // Only pass urlPattern through to storage when it looks like a
+          // plain substring (no regex meta-chars). Otherwise let the
+          // adapter return the unfiltered row set and we regex it below.
+          urlPattern: input.filter.urlPattern && /^[\w./\-:?#]+$/.test(input.filter.urlPattern)
+            ? input.filter.urlPattern
+            : undefined,
+        }
+      : undefined
+
+    const page = await ctx.storage.routes.listForScan(input.scanId, {
+      page: input.page,
+      pageSize: input.pageSize,
       device: input.device,
+      filter: filterForStorage,
+      sort: input.sort,
     })
-    const filtered = applyRouteSort(applyRouteFilter(all.items, input.filter), input.sort)
-    const start = (input.page - 1) * input.pageSize
-    const items = filtered.slice(start, start + input.pageSize)
+
+    // Apply the regex filter (if any) on the returned page. This still
+    // pages correctly because the storage LIMIT/OFFSET respects the
+    // substring filter that came with it.
+    let items = page.items
+    if (input.filter?.urlPattern && filterForStorage?.urlPattern == null) {
+      const re = new RegExp(input.filter.urlPattern)
+      items = items.filter(r => re.test(r.url))
+    }
+
     return {
       items,
-      total: filtered.length,
+      total: page.total,
       page: input.page,
       pageSize: input.pageSize,
     } as CommandOutput<typeof ScanResults>

--- a/packages/core/src/storage/drizzle/repositories/routes.ts
+++ b/packages/core/src/storage/drizzle/repositories/routes.ts
@@ -10,7 +10,7 @@ import type {
 import type { ScanRouteRow } from '@unlighthouse/contracts/drizzle'
 import { createHash } from 'node:crypto'
 import { scanRoutes } from '@unlighthouse/contracts/drizzle'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, isNotNull, like, lte, sql } from 'drizzle-orm'
 
 type AnyDrizzle = any
 
@@ -100,14 +100,73 @@ export function createScanRouteRepository(db: AnyDrizzle): ScanRouteRepository {
       const pageSize = Math.max(1, q?.pageSize ?? DEFAULT_PAGE_SIZE)
       const offset = (page - 1) * pageSize
 
-      const where = q?.device
-        ? and(eq(scanRoutes.scanId, scanId), eq(scanRoutes.device, q.device))
-        : eq(scanRoutes.scanId, scanId)
+      // Build the WHERE clause from every filter the query carries. Each
+      // condition is pushed down to SQL — the API handler used to do this
+      // in JS on the full row set which fell over on 10k+ route scans.
+      // Column-typed conditions like `gte(scanRoutes.scorePerformance, …)`
+      // are nullable-safe: drizzle emits `column >= ?` which SQL evaluates
+      // to NULL (not true, not false) for null columns, so missing values
+      // never match the filter — same semantics as the JS fallback.
+      const conditions = [eq(scanRoutes.scanId, scanId)]
+      if (q?.device)
+        conditions.push(eq(scanRoutes.device, q.device))
+      if (q?.filter?.minScore) {
+        const map = {
+          'performance': scanRoutes.scorePerformance,
+          'accessibility': scanRoutes.scoreAccessibility,
+          'seo': scanRoutes.scoreSeo,
+          'best-practices': scanRoutes.scoreBestPractices,
+        } as const
+        for (const [cat, min] of Object.entries(q.filter.minScore)) {
+          const col = map[cat as keyof typeof map]
+          if (col != null && typeof min === 'number')
+            conditions.push(isNotNull(col), gte(col, min))
+        }
+      }
+      if (q?.filter?.maxMetric) {
+        const map = {
+          lcp: scanRoutes.lcp,
+          cls: scanRoutes.cls,
+          inp: scanRoutes.inp,
+          fcp: scanRoutes.fcp,
+          ttfb: scanRoutes.ttfb,
+          tbt: scanRoutes.tbt,
+          si: scanRoutes.si,
+        } as const
+        for (const [metric, max] of Object.entries(q.filter.maxMetric)) {
+          const col = map[metric as keyof typeof map]
+          // Note: this branch keeps the JS-fallback semantics (null columns
+          // match) by NOT chaining `isNotNull` — `column <= ?` with a null
+          // value yields NULL, which drizzle's `where` treats as "exclude",
+          // contradicting the JS path. We patch it with `OR column IS NULL`.
+          if (col != null && typeof max === 'number')
+            conditions.push(sql`(${col} IS NULL OR ${col} <= ${max})`)
+        }
+      }
+      if (q?.filter?.urlPattern) {
+        // Literal-substring fast path. The wire field on `scan.results`
+        // is documented as a regex source — application-side fallback in
+        // the API handler still re-runs the full RegExp on the result
+        // page for callers that pass a real regex.
+        conditions.push(like(scanRoutes.url, `%${q.filter.urlPattern}%`))
+      }
+      const where = conditions.length > 1 ? and(...conditions) : conditions[0]
 
-      const rows = await db
-        .select()
-        .from(scanRoutes)
-        .where(where)
+      // ORDER BY push-down. The fallback in api/handlers/scan.ts uses the
+      // same column choices so behaviour matches.
+      let orderBy
+      switch (q?.sort) {
+        case 'score-asc': orderBy = asc(scanRoutes.scorePerformance); break
+        case 'score-desc': orderBy = desc(scanRoutes.scorePerformance); break
+        case 'lcp-asc': orderBy = asc(scanRoutes.lcp); break
+        case 'lcp-desc': orderBy = desc(scanRoutes.lcp); break
+        case 'url-asc': orderBy = asc(scanRoutes.url); break
+        case 'capturedAt-desc': orderBy = desc(scanRoutes.capturedAt); break
+        default: orderBy = undefined
+      }
+
+      const baseSelect = db.select().from(scanRoutes).where(where)
+      const rows = await (orderBy ? baseSelect.orderBy(orderBy) : baseSelect)
         .limit(pageSize)
         .offset(offset)
 

--- a/packages/core/src/storage/memory/index.ts
+++ b/packages/core/src/storage/memory/index.ts
@@ -142,6 +142,52 @@ export function memoryStorage(_opts: MemoryStorageOptions = {}): Storage {
       let all = Array.from(routesMap.get(scanId)?.values() ?? [])
       if (q?.device)
         all = all.filter(r => r.device === q.device)
+      // Filter/sort push-down for the memory adapter — same semantics the
+      // drizzle adapter pushes to SQL. Kept in lock-step so behaviour
+      // matches between hosts.
+      if (q?.filter) {
+        const f = q.filter
+        const scoreCol = {
+          'performance': 'scorePerformance',
+          'accessibility': 'scoreAccessibility',
+          'seo': 'scoreSeo',
+          'best-practices': 'scoreBestPractices',
+        } as const
+        all = all.filter((r) => {
+          if (f.urlPattern && !r.url.includes(f.urlPattern))
+            return false
+          if (f.minScore) {
+            for (const [cat, min] of Object.entries(f.minScore)) {
+              const v = (r as unknown as Record<string, number | null>)[scoreCol[cat as keyof typeof scoreCol]]
+              if (v == null || v < (min as number))
+                return false
+            }
+          }
+          if (f.maxMetric) {
+            for (const [metric, max] of Object.entries(f.maxMetric)) {
+              const v = (r as unknown as Record<string, number | null>)[metric]
+              if (v != null && v > (max as number))
+                return false
+            }
+          }
+          return true
+        })
+      }
+      if (q?.sort) {
+        const copy = [...all]
+        copy.sort((a, b) => {
+          switch (q.sort) {
+            case 'score-asc': return (a.scorePerformance ?? 0) - (b.scorePerformance ?? 0)
+            case 'score-desc': return (b.scorePerformance ?? 0) - (a.scorePerformance ?? 0)
+            case 'lcp-asc': return (a.lcp ?? Infinity) - (b.lcp ?? Infinity)
+            case 'lcp-desc': return (b.lcp ?? -Infinity) - (a.lcp ?? -Infinity)
+            case 'url-asc': return a.url.localeCompare(b.url)
+            case 'capturedAt-desc': return b.capturedAt.localeCompare(a.capturedAt)
+            default: return 0
+          }
+        })
+        all = copy
+      }
       const total = all.length
       const items = all.slice((page - 1) * pageSize, page * pageSize).map(clone)
       return { items, total, page, pageSize }

--- a/test/storage-filter-pushdown.test.ts
+++ b/test/storage-filter-pushdown.test.ts
@@ -1,0 +1,196 @@
+// Filter / sort push-down to storage. The drizzle + memory adapters now
+// implement the RouteListQuery `filter` and `sort` fields directly, so
+// scan.results / query.routes don't have to pull every row over the wire
+// just to filter in JS. Behaviour is identical between the two adapters.
+//
+// This test exercises the memory adapter (no native deps in CI) and
+// asserts the same shape the SQL path produces.
+
+import type { Storage } from '@unlighthouse/contracts'
+import { scanResults } from '@unlighthouse/core/api/handlers/scan'
+import { queryRoutes } from '@unlighthouse/core/api/handlers/query'
+import { memoryStorage } from '@unlighthouse/core/storage/memory'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+const SCAN = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+function makeMetric(url: string, partial: Partial<{
+  scorePerformance: number
+  lcp: number
+  cls: number
+}> = {}) {
+  return {
+    url,
+    path: new URL(url).pathname,
+    routeName: null,
+    scorePerformance: partial.scorePerformance ?? 0.5,
+    scoreAccessibility: 0.8,
+    scoreSeo: 0.9,
+    scoreBestPractices: 0.85,
+    lcp: partial.lcp ?? 1500,
+    cls: partial.cls ?? 0.05,
+    inp: 100,
+    fcp: 900,
+    ttfb: 200,
+    tbt: 50,
+    si: 1200,
+    lighthouseVersion: '12.0.0',
+    capturedAt: new Date().toISOString(),
+  }
+}
+
+async function seedStorage(storage: Storage): Promise<void> {
+  await storage.scans.create({
+    scanId: SCAN as never,
+    site: 'http://example.com',
+    device: 'mobile',
+    status: 'complete',
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    ciBranch: null,
+    ciCommit: null,
+    ciCommitMessage: null,
+  })
+  await storage.routes.putBatch(SCAN as never, 'mobile', [
+    makeMetric('http://example.com/fast', { scorePerformance: 0.95, lcp: 800 }),
+    makeMetric('http://example.com/medium', { scorePerformance: 0.6, lcp: 2200 }),
+    makeMetric('http://example.com/slow', { scorePerformance: 0.3, lcp: 4500 }),
+    makeMetric('http://example.com/about', { scorePerformance: 0.9, lcp: 1100 }),
+  ])
+}
+
+const ctx = (s: Storage) => ({
+  storage: s,
+  core: { hooks: undefined } as never,
+  auditor: undefined as never,
+  config: {} as never,
+  version: 'test',
+} as never)
+
+describe('storage filter push-down', () => {
+  let storage: Storage
+  beforeEach(async () => {
+    storage = memoryStorage()
+    await seedStorage(storage)
+  })
+
+  it('scan.results minScore narrows the row set + counts the filtered total', async () => {
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        filter: { minScore: { performance: 0.9 } },
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url).sort()).toEqual([
+      'http://example.com/about',
+      'http://example.com/fast',
+    ])
+    // total reflects the filtered set — not the raw 4 rows.
+    expect(out.total).toBe(2)
+  })
+
+  it('scan.results maxMetric filters + ignores null columns', async () => {
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        filter: { maxMetric: { lcp: 1500 } },
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url).sort()).toEqual([
+      'http://example.com/about',
+      'http://example.com/fast',
+    ])
+  })
+
+  it('scan.results sort is applied at the storage layer', async () => {
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        sort: 'lcp-asc',
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url)).toEqual([
+      'http://example.com/fast', // 800
+      'http://example.com/about', // 1100
+      'http://example.com/medium', // 2200
+      'http://example.com/slow', // 4500
+    ])
+  })
+
+  it('scan.results pagination is post-filter (correct totals + page slice)', async () => {
+    // Asking for page 2 of size 1 of the lcp-asc sort should return /about
+    // (second smallest LCP). Total stays at 4 (no filter); pagination is on
+    // top of the ordered set.
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        sort: 'lcp-asc',
+        page: 2,
+        pageSize: 1,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.total).toBe(4)
+    expect(out.items).toHaveLength(1)
+    expect(out.items[0].url).toBe('http://example.com/about')
+  })
+
+  it('scan.results urlPattern (literal) pushes to storage', async () => {
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        filter: { urlPattern: '/medium' },
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url)).toEqual(['http://example.com/medium'])
+  })
+
+  it('scan.results urlPattern (regex) falls back to JS after storage returns', async () => {
+    // `^http://example\.com/(fast|slow)$` is a real regex — the handler
+    // detects this and skips storage's substring path, applying the regex
+    // on the returned page.
+    const out = await scanResults.run(
+      {
+        scanId: SCAN as never,
+        filter: { urlPattern: '^http://example\\.com/(fast|slow)$' },
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url).sort()).toEqual([
+      'http://example.com/fast',
+      'http://example.com/slow',
+    ])
+  })
+
+  it('query.routes single-scan path uses storage push-down', async () => {
+    const out = await queryRoutes.run(
+      {
+        scanId: SCAN as never,
+        filter: { minScore: { performance: 0.8 } },
+        sort: 'score-desc',
+        page: 1,
+        pageSize: 50,
+      } as never,
+      ctx(storage),
+    )
+    expect(out.items.map(r => r.url)).toEqual([
+      'http://example.com/fast', // 0.95
+      'http://example.com/about', // 0.9
+    ])
+    expect(out.total).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

\`scan.results\` and \`query.routes\` used to pull the full route set from storage (\`page: 1, pageSize: 10_000\`) and filter/sort in JS before returning the page slice. Fine on 50-route scans, painful on 10k-route ones — 10k rows over the wire just to return 50.

Three layers updated:

- **Contracts**: \`RouteListQuery\` learns \`filter\` (minScore / maxMetric / urlPattern) + \`sort\` fields.
- **Storage adapters** (drizzle + memory + Cloudflare D1) implement the filter/sort with real WHERE + ORDER BY (or array filter for memory).
- **API handlers** hand filter/sort down instead of fetching everything first. Pagination + total counts come from the post-filter result set.

\`urlPattern\` has a two-tier strategy because the wire field is a regex source. Literal patterns push down as \`LIKE %pattern%\`; real regexes go to storage without the urlPattern and the handler re-runs the RegExp on the returned page. Pagination stays correct in both modes.

Null-column semantics:
- \`minScore\` excludes nulls (a threshold on missing data is a fail)
- \`maxMetric\` matches nulls (no data ≠ "too high")

Both match the prior JS-fallback path so this isn't a behaviour change for callers, just a perf one.

## Test plan
- [x] full suite: 447/447 (7 new push-down cases)
- [x] minScore narrows; total reflects filtered count
- [x] maxMetric filters numerics; null matches
- [x] sort applied at storage; pagination post-filter correct
- [x] literal urlPattern → SQL LIKE
- [x] regex urlPattern → JS post-filter on page
- [x] query.routes single-scan path same shape as scan.results