### PR TITLE
feat(auditor): wire weighted + rate-limited strategies to config

### DIFF
--- a/packages/contracts/src/config/index.ts
+++ b/packages/contracts/src/config/index.ts
@@ -130,12 +130,33 @@ const AuditorProvider = z.discriminatedUnion('name', [
 
 const AuditorRouterStrategy = z.enum(['round-robin', 'weighted', 'fallback', 'rate-limited'])
 
+// Per-provider routing knobs. `weights` only applies under `weighted`,
+// `rates` only under `rate-limited`; the other strategies ignore both.
+// Keys are provider names (`'local'` / `'psi'` / `'crux'` / …) so multi-
+// `psi`-key setups need to wrap each in `cdp-connect` aliases.
+const AuditorRouterConfig = z.object({
+  /** Weighted strategy: how often each provider gets picked. Defaults to 1. */
+  weights: z.record(z.string(), z.number().nonnegative()).optional(),
+  /**
+   * Rate-limited strategy: token-bucket per provider.
+   * - `capacity`: bucket size (max in-flight + queued)
+   * - `refillPerSec`: tokens added per second
+   * The pick fails over to the next provider when a bucket is empty.
+   */
+  rates: z.record(z.string(), z.object({
+    capacity: z.number().int().positive(),
+    refillPerSec: z.number().positive(),
+  })).optional(),
+})
+
 // Single provider, or a router across many.
 const AuditorConfig = z.union([
   AuditorProvider,
   z.object({
     strategy: AuditorRouterStrategy,
     providers: z.array(AuditorProvider).min(1),
+    /** Per-strategy knobs. Optional; defaults to permissive behaviour. */
+    router: AuditorRouterConfig.optional(),
   }),
 ])
 
@@ -214,6 +235,7 @@ export const defaultConfig: UnlighthouseConfig = {
 export {
   AuditorConfig,
   AuditorProvider,
+  AuditorRouterConfig,
   AuditorRouterStrategy,
   AuthOptions,
   Budget,

--- a/packages/core/src/auditors/route/index.ts
+++ b/packages/core/src/auditors/route/index.ts
@@ -8,6 +8,8 @@ import type {
   Page,
 } from '@unlighthouse/contracts/ports'
 
+export { createTokenBucket, type RateRule, type TokenBucket } from './token-bucket'
+
 export type PickFn = (
   auditors: NamedAuditor[],
   ctx: { url: string },
@@ -74,17 +76,24 @@ export function roundRobinPick(): PickFn {
   }
 }
 
-/** Weighted random selection by name. Missing names default to weight 0. */
+/**
+ * Weighted random selection by name. Providers absent from the weights map
+ * fall back to weight 1 (equal share) rather than 0 — keeps the strategy
+ * useful as a "round-robin-ish" default when no config is supplied.
+ * Passing an explicit `0` for a name still excludes it.
+ */
 export function weightedPick(weights: Record<string, number>): PickFn {
   return (auditors) => {
     if (!auditors.length)
       throw new Error('routeAuditors: no auditors configured')
-    const total = auditors.reduce((sum, a) => sum + (weights[a.name] ?? 0), 0)
+    const weightOf = (name: string) =>
+      Object.prototype.hasOwnProperty.call(weights, name) ? weights[name]! : 1
+    const total = auditors.reduce((sum, a) => sum + weightOf(a.name), 0)
     if (total <= 0)
       return auditors[0].auditor
     let target = Math.random() * total
     for (const a of auditors) {
-      target -= weights[a.name] ?? 0
+      target -= weightOf(a.name)
       if (target <= 0)
         return a.auditor
     }

--- a/packages/core/src/auditors/route/token-bucket.ts
+++ b/packages/core/src/auditors/route/token-bucket.ts
@@ -1,0 +1,90 @@
+// Token-bucket rate limiter for AuditorRouter `rate-limited` strategy.
+// One bucket per provider name. `try()` consumes a token if one is
+// available (returns true) and refuses without blocking (returns false)
+// — the router treats false as "skip this provider, try the next one."
+//
+// Tokens refill at `refillPerSec` continuously (computed lazily on each
+// access, so no setInterval / no timer leak). `capacity` is the hard cap.
+//
+// Intentionally simple: no jitter, no burst smoothing, no async waits.
+// Callers that need a real queue layer on top should compose this with
+// a separate scheduler — the router only needs "can I burn one now?"
+// semantics.
+
+export interface RateRule {
+  capacity: number
+  refillPerSec: number
+}
+
+interface Bucket {
+  tokens: number
+  lastRefillMs: number
+  cap: number
+  perMs: number // refillPerSec / 1000
+}
+
+export interface TokenBucket {
+  /** Attempt to consume one token; returns true on success. */
+  try: (name: string) => boolean
+  /** Read-only token count for tests / observability. */
+  tokensFor: (name: string) => number | null
+}
+
+/**
+ * Build a token-bucket store keyed by provider name. Providers without a
+ * declared rule get an "infinite" bucket — `try()` always returns true so
+ * unconfigured providers fall back to the historical permissive behaviour.
+ */
+export function createTokenBucket(rules: Record<string, RateRule> = {}, now: () => number = Date.now): TokenBucket {
+  const buckets = new Map<string, Bucket>()
+
+  function ensure(name: string): Bucket | null {
+    const rule = rules[name]
+    if (!rule)
+      return null // unconfigured → permissive
+    let b = buckets.get(name)
+    if (!b) {
+      b = {
+        tokens: rule.capacity,
+        lastRefillMs: now(),
+        cap: rule.capacity,
+        perMs: rule.refillPerSec / 1000,
+      }
+      buckets.set(name, b)
+    }
+    return b
+  }
+
+  function refill(b: Bucket): void {
+    const t = now()
+    const elapsed = t - b.lastRefillMs
+    if (elapsed <= 0)
+      return
+    const added = elapsed * b.perMs
+    if (added <= 0)
+      return
+    b.tokens = Math.min(b.cap, b.tokens + added)
+    b.lastRefillMs = t
+  }
+
+  return {
+    try(name) {
+      const b = ensure(name)
+      if (!b)
+        return true // permissive for unconfigured providers
+      refill(b)
+      if (b.tokens >= 1) {
+        b.tokens -= 1
+        return true
+      }
+      return false
+    },
+    tokensFor(name) {
+      const b = buckets.get(name)
+      if (!b)
+        return null
+      refill(b)
+      return b.tokens
+    },
+  }
+}

--- a/packages/unlighthouse/src/auditor.ts
+++ b/packages/unlighthouse/src/auditor.ts
@@ -1,7 +1,7 @@
 // Auditor resolver — maps UnlighthouseConfig to a single Auditor port.
 // v1.md Phase 3: pure switch + factory call, no new abstraction.
 
-import type { AuditorConfig, AuditorProvider, AuditorRouterStrategy, UnlighthouseConfig } from '@unlighthouse/contracts'
+import type { AuditorConfig, AuditorProvider, AuditorRouterConfig, AuditorRouterStrategy, UnlighthouseConfig } from '@unlighthouse/contracts'
 import type { Auditor, NamedAuditor } from '@unlighthouse/contracts/ports'
 import type { PickFn } from '@unlighthouse/core/auditors'
 import type { z } from 'zod'
@@ -12,6 +12,7 @@ import {
   createLocalAuditor,
   createMockAuditor,
   createPsiAuditor,
+  createTokenBucket,
   fallbackAuditor,
   rateLimitedPick,
   roundRobinPick,
@@ -22,6 +23,7 @@ import {
 type AuditorProviderConfig = z.infer<typeof AuditorProvider>
 type AuditorRouterStrategyConfig = z.infer<typeof AuditorRouterStrategy>
 type AuditorConfigValue = z.infer<typeof AuditorConfig>
+type AuditorRouterConfigValue = z.infer<typeof AuditorRouterConfig>
 
 export interface ResolveAuditorOptions {
   config: UnlighthouseConfig
@@ -63,21 +65,31 @@ function buildSingle(p: AuditorProviderConfig, opts: ResolveAuditorOptions): Aud
   }
 }
 
-// Strategy → PickFn. Weighted/rate-limited need per-provider config we don't
-// surface yet; degrade to permissive defaults so runtime never throws.
-// `fallback` is NOT a PickFn — it needs to observe audit errors. Composed via
-// `fallbackAuditor` in `resolveAuditor` instead.
-// TODO(v7): extend AuditorConfig.router with `weights` / `rates` maps.
-function pickerFor(strategy: Exclude<AuditorRouterStrategyConfig, 'fallback'>): PickFn {
+// Strategy → PickFn. `weighted` and `rate-limited` read their per-provider
+// knobs from `router.weights` / `router.rates`; unconfigured providers
+// degrade to a permissive default (`weighted` falls through to the first
+// auditor when all weights are 0; `rate-limited` always allows when no
+// bucket is declared). `fallback` is NOT a PickFn — it needs to observe
+// audit errors. Composed via `fallbackAuditor` in `resolveAuditor` instead.
+function pickerFor(
+  strategy: Exclude<AuditorRouterStrategyConfig, 'fallback'>,
+  router: AuditorRouterConfigValue | undefined,
+): PickFn {
   switch (strategy) {
     case 'round-robin':
       return roundRobinPick()
     case 'weighted':
-      // TODO(v7): wire per-provider weights from config.
-      return weightedPick({})
-    case 'rate-limited':
-      // TODO(v7): wire token-bucket from config; permissive check = always allow.
-      return rateLimitedPick(async () => true)
+      // Defaults to 1 per provider when no weights are declared so the
+      // strategy degrades to round-robin-ish random — better than
+      // collapsing to a single provider.
+      return weightedPick(router?.weights ?? {})
+    case 'rate-limited': {
+      // One token bucket per resolver (shared across all audit calls in the
+      // process). Providers without a `rates` entry stay permissive — the
+      // bucket helper returns true for unknown names.
+      const bucket = createTokenBucket(router?.rates ?? {})
+      return rateLimitedPick(async name => bucket.try(name))
+    }
   }
 }
 
@@ -97,7 +109,7 @@ export function resolveAuditor(opts: ResolveAuditorOptions): Auditor {
     }))
     if (cfg.strategy === 'fallback')
       return fallbackAuditor(auditors)
-    return routeAuditors({ auditors, pick: pickerFor(cfg.strategy) })
+    return routeAuditors({ auditors, pick: pickerFor(cfg.strategy, cfg.router) })
   }
 
   return buildSingle(cfg, opts)

--- a/test/auditor-router-strategies.test.ts
+++ b/test/auditor-router-strategies.test.ts
@@ -1,0 +1,149 @@
+// AuditorRouter `weighted` and `rate-limited` strategies are now config-
+// driven via `AuditorConfig.router.weights` / `.rates`. Pre-this PR the
+// router was wired in but the strategies fell through to permissive
+// defaults regardless of config.
+//
+// Two surfaces under test:
+//   - the token-bucket helper itself (deterministic via injected clock)
+//   - the picker layer it backs (rate-limited skips empty buckets;
+//     weighted respects the weights map)
+
+import type { NamedAuditor } from '@unlighthouse/contracts/ports'
+import {
+  createTokenBucket,
+  rateLimitedPick,
+  weightedPick,
+} from '@unlighthouse/core/auditors'
+import { describe, expect, it } from 'vitest'
+
+// Build a stand-in auditor whose audit() returns its own name. Lets the
+// picker tests assert which provider got selected by reading the result.
+function stub(name: string): NamedAuditor {
+  return {
+    name,
+    auditor: {
+      capabilities: {
+        reliablePerfScores: true,
+        reliableFieldData: false,
+        supportsThrottling: true,
+        categories: ['performance'],
+      },
+      async audit() {
+        return { source: name } as never
+      },
+    },
+  }
+}
+
+describe('createTokenBucket', () => {
+  it('consumes tokens up to capacity then refuses', () => {
+    let t = 0
+    const b = createTokenBucket({ psi: { capacity: 3, refillPerSec: 1 } }, () => t)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(false) // bucket empty
+  })
+
+  it('refills continuously by elapsed wall time', () => {
+    let t = 0
+    const b = createTokenBucket({ psi: { capacity: 2, refillPerSec: 2 } }, () => t)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(false)
+    t += 500 // 0.5s × 2/s = 1 token
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(false)
+    t += 2000 // 2s × 2/s = 4 tokens but capacity caps at 2
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(false)
+  })
+
+  it('is permissive for providers without a declared rule', () => {
+    const b = createTokenBucket({ psi: { capacity: 1, refillPerSec: 1 } })
+    // 'local' has no rule — try() always wins.
+    for (let i = 0; i < 100; i++)
+      expect(b.try('local')).toBe(true)
+    // psi still rate-limited.
+    expect(b.try('psi')).toBe(true)
+    expect(b.try('psi')).toBe(false)
+  })
+
+  it('exposes token count for observability', () => {
+    let t = 0
+    const b = createTokenBucket({ psi: { capacity: 2, refillPerSec: 1 } }, () => t)
+    b.try('psi')
+    expect(b.tokensFor('psi')).toBeCloseTo(1, 5)
+    t += 1000
+    // tokensFor refills lazily on access; should show capacity again.
+    expect(b.tokensFor('psi')).toBeCloseTo(2, 5)
+    // Unknown name returns null (permissive bucket has no state).
+    expect(b.tokensFor('local')).toBeNull()
+  })
+})
+
+describe('weightedPick', () => {
+  it('routes ~3:1 to a 3-weighted provider over a 1-weighted one', () => {
+    const pick = weightedPick({ psi: 3, local: 1 })
+    const auditors = [stub('psi'), stub('local')]
+    const counts = { psi: 0, local: 0 }
+    for (let i = 0; i < 4000; i++) {
+      const got = pick(auditors, { url: '/' }) as { audit: () => Promise<{ source: string }> }
+      // We can't call audit() synchronously, but the picked auditor's identity
+      // round-trips through reference equality — find which stub matches.
+      counts[(got === auditors[0].auditor ? 'psi' : 'local')]++
+    }
+    // 3:1 ratio with 4000 trials should land within tight bounds.
+    expect(counts.psi / counts.local).toBeGreaterThan(2.5)
+    expect(counts.psi / counts.local).toBeLessThan(3.5)
+  })
+
+  it('treats absent names as weight 1 (equal share fallback)', () => {
+    const pick = weightedPick({}) // empty config
+    const auditors = [stub('a'), stub('b')]
+    const counts = { a: 0, b: 0 }
+    for (let i = 0; i < 2000; i++) {
+      const got = pick(auditors, { url: '/' })
+      counts[(got === auditors[0].auditor ? 'a' : 'b')]++
+    }
+    // Equal weights → ~1:1, allow ±10%.
+    const ratio = counts.a / counts.b
+    expect(ratio).toBeGreaterThan(0.85)
+    expect(ratio).toBeLessThan(1.15)
+  })
+
+  it('an explicit weight of 0 excludes that provider', () => {
+    const pick = weightedPick({ a: 0, b: 5 })
+    const auditors = [stub('a'), stub('b')]
+    for (let i = 0; i < 200; i++) {
+      const got = pick(auditors, { url: '/' })
+      expect(got).toBe(auditors[1].auditor) // never picks a
+    }
+  })
+})
+
+describe('rateLimitedPick', () => {
+  it('routes to a provider that passes the check; falls through to the next when one fails', async () => {
+    let t = 0
+    const bucket = createTokenBucket({
+      psi: { capacity: 1, refillPerSec: 0.001 }, // basically empty after first use
+      local: { capacity: 100, refillPerSec: 1 },
+    }, () => t)
+    const pick = rateLimitedPick(async name => bucket.try(name))
+    const auditors = [stub('psi'), stub('local')]
+
+    // First call drains psi (1 token).
+    const first = await pick(auditors, { url: '/' })
+    expect(first).toBe(auditors[0].auditor)
+    // psi now empty; next call falls through to local.
+    const second = await pick(auditors, { url: '/' })
+    expect(second).toBe(auditors[1].auditor)
+  })
+
+  it('throws when every provider fails the check', async () => {
+    const pick = rateLimitedPick(async () => false) // nobody passes
+    const auditors = [stub('a'), stub('b')]
+    await expect(pick(auditors, { url: '/' })).rejects.toThrow(/no auditor passed/i)
+  })
+})


### PR DESCRIPTION
## Summary

`AuditorRouter` declared four strategies (\`round-robin\`, \`weighted\`, \`fallback\`, \`rate-limited\`) but only the first two actually worked. \`weighted\` and \`rate-limited\` fell through to hardcoded permissive defaults in the resolver — there was no surface to configure per-provider weights or quotas, and the TODOs were marked \`v7\`.

This PR fills that gap.

## What changed

**Contracts**: \`AuditorConfig.router\` adds \`weights\` (record of provider name → number) and \`rates\` (record of provider name → \`{ capacity, refillPerSec }\`). Optional; absent keys keep the permissive fallback.

**Core**: new \`createTokenBucket()\` helper. Lazy-refill (no \`setInterval\`, no timer leak), deterministic via injected clock for tests. Providers without a declared rule stay permissive — the bucket returns true for unknown names.

Also tweaked \`weightedPick\`: absent names default to weight 1 instead of 0. Empty config now degrades to equal-share random instead of collapsing to the first provider. Explicit \`0\` still excludes.

**Unlighthouse resolver**: \`pickerFor()\` reads \`router.weights\` / \`router.rates\` and feeds them to the matching strategy. One shared token bucket per resolver — matches the documented "per-provider quota" semantics.

## Test plan
- [x] full suite: 456/456 passing (9 new cases)
- [x] token bucket consumes / refills / caps / handles unknown names
- [x] weightedPick 3:1 distribution within ±15% over 4000 trials
- [x] weightedPick empty config → equal share fallback
- [x] weightedPick explicit \`0\` excludes
- [x] rateLimitedPick falls through to next provider on empty bucket
- [x] rateLimitedPick throws when every provider fails