### PR TITLE
docs(cloudflare): three-command deploy walkthrough + example Worker

### DIFF
--- a/packages/cloudflare/examples/basic/README.md
+++ b/packages/cloudflare/examples/basic/README.md
@@ -1,0 +1,98 @@
+# Unlighthouse on Cloudflare — minimal deploy
+
+End-to-end deploy of the `@unlighthouse/cloudflare` preset. Three files,
+three commands. Once it's up, `POST /api/scan/start` kicks off a real
+scan against the configured site; results stream to D1 + R2 + Durable
+Object WebSocket subscribers.
+
+## Prerequisites
+
+- Cloudflare account with Workers + D1 + R2 + Browser Rendering enabled.
+  (Browser Rendering is on the Workers Paid plan, $5/mo.)
+- `wrangler` ≥ 4 installed locally (`pnpm i -g wrangler`, or use
+  `pnpm dlx wrangler …`).
+- `wrangler login` once per machine.
+
+## Setup
+
+```sh
+# 1. Provision the D1 database. Copy the `database_id` it prints into
+#    wrangler.toml under [[d1_databases]].
+wrangler d1 create unlighthouse
+
+# 2. Provision the R2 bucket.
+wrangler r2 bucket create unlighthouse
+
+# 3. Edit wrangler.toml:
+#    - paste the database_id
+#    - replace UNLIGHTHOUSE_CONFIG's site with your real target
+#    - bump UNLIGHTHOUSE_VERSION on each deploy
+
+# 4. Install deps.
+pnpm install
+```
+
+## Deploy
+
+```sh
+pnpm deploy
+```
+
+The first deploy installs the two Durable Object classes
+(`ScanEventsDO`, `RateLimiterDO`) — wrangler prints the migration step
+inline. The D1 schema is applied in-process on first request via the
+package's `INIT_SQL_STATEMENTS`, so there's no separate
+`wrangler d1 migrations apply` step.
+
+## Verify
+
+```sh
+# Health check. Returns { ok: true, version, uptimeMs, storage, activeScans }.
+curl https://<your-worker>.workers.dev/api/health
+
+# Manifest — every command, hook, error code. Useful as a smoke test
+# that the HTTP projection mounted everything correctly.
+curl https://<your-worker>.workers.dev/api/manifest
+
+# Start a scan. The rate limiter gates this endpoint per
+# (x-api-key | cf-connecting-ip); a fresh deploy starts with 10 tokens.
+curl -X POST https://<your-worker>.workers.dev/api/scan/start \
+  -H 'content-type: application/json' \
+  -d '{"site": "https://your-target.com"}'
+
+# Subscribe to the scan's event stream over WebSocket. Send a filter
+# frame as the first message (omit it to receive every event).
+wscat -c "wss://<your-worker>.workers.dev/api/events/subscribe?scanId=<id>"
+> {"events": ["scan:route-complete", "scan:complete"]}
+```
+
+## Tuning
+
+`wrangler.toml` carries every knob:
+
+- `RATE_LIMITER_CAPACITY` / `RATE_LIMITER_REFILL_PER_SEC` — token bucket
+  per (API key | IP). Defaults are 10 / 1 per sec.
+- `UNLIGHTHOUSE_CONFIG` — full inline config JSON. Same schema as the
+  CLI's `unlighthouse.config.ts`. Only `site` is required.
+- `UNLIGHTHOUSE_USE_MOCK_AUDITOR=1` — escape hatch for smoke-testing
+  the wiring without hitting Browser Rendering.
+- `[triggers] crons` — when the R2 TTL sweeper runs. Default hourly;
+  daily is fine for most setups.
+
+## Observability
+
+```sh
+wrangler tail        # live logs from every Worker invocation
+```
+
+The sweeper logs `[r2-sweeper] scanned=N deleted=M` on each cron run.
+Storage adapters log writes through the Worker's tagged logger
+(`unlighthouse/storage/*`).
+
+## Tear-down
+
+```sh
+wrangler delete                                # removes the Worker
+wrangler d1 delete unlighthouse                # removes the D1 database
+wrangler r2 bucket delete unlighthouse         # removes the R2 bucket
+```

--- a/packages/cloudflare/examples/basic/package.json
+++ b/packages/cloudflare/examples/basic/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "unlighthouse-cf-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "dependencies": {
+    "@unlighthouse/cloudflare": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/packages/cloudflare/examples/basic/worker.ts
+++ b/packages/cloudflare/examples/basic/worker.ts
@@ -1,0 +1,45 @@
+// Minimal Unlighthouse Cloudflare Worker.
+//
+// Two default exports: the main fetch handler (HTTP + WebSocket fanout
+// via ScanEventsDO) and the sweeperWorker (cron-triggered R2 TTL sweep).
+// Wrangler routes the cron trigger to the second; everything else goes
+// to the first.
+//
+// Bindings expected on env (declared in wrangler.toml):
+//   DB                R2Bucket   — D1 database for scan + route rows
+//   BLOBS             R2Bucket   — R2 bucket for LHR / reconciled blobs
+//   BROWSER           Browser    — Browser Rendering binding
+//   SCAN_EVENTS_DO    DO         — durable object namespace
+//   RATE_LIMITER_DO   DO         — durable object namespace
+//
+// Vars (also in wrangler.toml):
+//   UNLIGHTHOUSE_CONFIG          JSON-encoded unlighthouse config
+//   UNLIGHTHOUSE_VERSION         surfaced by `manifest` + `health`
+//   RATE_LIMITER_CAPACITY        bucket size (default 10)
+//   RATE_LIMITER_REFILL_PER_SEC  refill rate (default 1)
+
+import {
+  type CloudflareEnv,
+  createCloudflareApp,
+  RateLimiterDO,
+  ScanEventsDO,
+  sweeperWorker,
+} from '@unlighthouse/cloudflare'
+
+// Re-export the Durable Object classes so the Workers runtime can find
+// them when wrangler.toml references `class_name = "ScanEventsDO"` etc.
+export { RateLimiterDO, ScanEventsDO }
+
+// Main HTTP + WS handler.
+const app = {
+  async fetch(req: Request, env: CloudflareEnv, ctx: ExecutionContext) {
+    const handler = createCloudflareApp(env)
+    return handler.fetch(req, env, ctx)
+  },
+  // Cron trigger → R2 TTL sweep. wrangler.toml `[triggers] crons = [...]`
+  // routes scheduled events here; the rest of the file's exports stay
+  // available for normal request traffic.
+  scheduled: sweeperWorker.scheduled,
+}
+
+export default app

--- a/packages/cloudflare/examples/basic/wrangler.toml
+++ b/packages/cloudflare/examples/basic/wrangler.toml
@@ -1,0 +1,68 @@
+# Unlighthouse CF preset — minimal deploy config.
+#
+# Set the values below, then:
+#   pnpm wrangler d1 create unlighthouse           # → copy the database_id
+#   pnpm wrangler r2 bucket create unlighthouse    # → no id needed
+#   pnpm wrangler deploy
+#
+# The DOs migrate themselves on first request; D1's schema is applied
+# in-process by the package's INIT_SQL — no `wrangler d1 migrations`
+# step needed.
+
+name = "unlighthouse"
+main = "worker.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+# ── Bindings ────────────────────────────────────────────────────────────────
+
+[[d1_databases]]
+binding = "DB"
+database_name = "unlighthouse"
+database_id = ""                              # ← paste from `wrangler d1 create`
+
+[[r2_buckets]]
+binding = "BLOBS"
+bucket_name = "unlighthouse"
+
+[browser]
+binding = "BROWSER"
+
+[[durable_objects.bindings]]
+name = "SCAN_EVENTS_DO"
+class_name = "ScanEventsDO"
+
+[[durable_objects.bindings]]
+name = "RATE_LIMITER_DO"
+class_name = "RateLimiterDO"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["ScanEventsDO", "RateLimiterDO"]
+
+# ── Vars ────────────────────────────────────────────────────────────────────
+
+[vars]
+# Inline unlighthouse config (JSON). Same shape as the CLI's
+# `unlighthouse.config.ts` — at minimum `site` is required, the rest
+# defaults from `defaultConfig`.
+UNLIGHTHOUSE_CONFIG = '{"site": "https://example.com"}'
+
+# Surfaced by manifest + health responses. Bump on each deploy.
+UNLIGHTHOUSE_VERSION = "1.0.0-rc.1"
+
+# Token-bucket rate limiter (per API key / IP). Defaults: 10 / 1 per sec.
+RATE_LIMITER_CAPACITY = "10"
+RATE_LIMITER_REFILL_PER_SEC = "1"
+
+# Optional escape hatch — set "1" to fall back to the mock auditor.
+# Only useful for smoke-testing the wiring without hitting Browser Rendering.
+# UNLIGHTHOUSE_USE_MOCK_AUDITOR = "1"
+
+# ── Cron triggers ──────────────────────────────────────────────────────────
+
+# R2 TTL sweeper — walks the bucket hourly and removes any blob whose
+# customMetadata.expiresAt has passed. Adjust the cron expression to your
+# write-volume; once a day is fine for most setups.
+[triggers]
+crons = ["0 * * * *"]

--- a/v1.md
+++ b/v1.md
@@ -1709,13 +1709,22 @@ From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is 
 - Create `packages/mcp/`. Implement MCP projection generator. Ship `bin/unlighthouse-mcp`. Document Claude/Cursor/Cline config.
 - **Ship gate:** Claude Code adds Unlighthouse MCP, calls `scan_start` end-to-end.
 
-### Phase 5 — Cloudflare preset (independent track after Phase 2)
-- Create `packages/cloudflare/`.
-- Port `cloud.unlighthouse.dev` adapters.
-- Implement `ScanEventsDO` and `RateLimiterDO` with WebSocket hibernation.
-- Implement `crawlers/cloudflare-crawl` + wire `auditors/cdp-connect` to the Worker's Browser Rendering binding (`puppeteer.launch(env.MYBROWSER)` path, D-022).
-- Implement `createCloudflareApp()` preset.
+### Phase 5 — Cloudflare preset (independent track after Phase 2) ✓ code-complete
+- Create `packages/cloudflare/`. ✓
+- Port `cloud.unlighthouse.dev` adapters. ✓
+- Implement `ScanEventsDO` and `RateLimiterDO` with WebSocket hibernation. ✓
+  Subscriber filters land in PR #335; producer RPC bridges core's hook bus
+  via `hookable.afterEach` so emitted events fan out automatically.
+- Implement `crawlers/cloudflare-crawl` + wire `auditors/cdp-connect` to the Worker's Browser Rendering binding (`puppeteer.launch(env.MYBROWSER)` path, D-022). ✓
+  Adapter lives at `packages/cloudflare/src/auditors/browser-rendering.ts`;
+  lazy-launches the browser on first audit, reuses across calls.
+- Implement `createCloudflareApp()` preset. ✓
 - **Ship gate:** End-to-end CF deploy scans 10 URLs, writes to D1+R2, streams events. attw clean for Worker target.
+  - attw + publint clean ✓ (run `pnpm test:attw` / `pnpm test:publint`)
+  - **Manual verification** needed against a real Cloudflare account.
+    See `packages/cloudflare/examples/basic/README.md` for the three
+    commands (`wrangler d1 create`, `wrangler r2 bucket create`,
+    `wrangler deploy`) and verification curls.
 
 ### Phase 6 — Tests, types, observability
 - Treeshake bundle tests per scenario (CLI / Worker HTTP-only / Worker CF / UI types-only).


### PR DESCRIPTION
## Summary

Unblocks the v1.md Phase 5 ship-gate by giving operators a copy-paste deploy path. Three files under \`packages/cloudflare/examples/basic/\`:

- \`worker.ts\` — minimal Worker entry. Composes createCloudflareApp for HTTP/WS, re-exports sweeperWorker.scheduled for cron, re-exports the two DO classes so wrangler can find them.
- \`wrangler.toml\` — filled-in template. D1 + R2 + Browser + DO bindings, cron schedule, every documented env var declared. Operator fills two values (\`database_id\` + the target site).
- \`README.md\` — three-command deploy (\`wrangler d1 create\`, \`wrangler r2 bucket create\`, \`wrangler deploy\`), verify curls, tuning knobs, tail / tear-down.

v1.md Phase 5 section updated to mark every code task done and point at the README for the remaining hands-on verification.

## Test plan
- [x] full suite: 460/460 passing (no production code changed)
- [x] examples ship inside the repo, not in the published package (files field still ["dist"])