### PR TITLE
feat(core): subpath export remote-lighthouse auditor

### DIFF
--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -19,6 +19,10 @@ export default defineBuildConfig({
         // breaking the Worker bundle with a Node-only `fileURLToPath` call.
         './src/auditors/mock.ts',
         './src/auditors/cdp-connect.ts',
+        // Remote Lighthouse adapter — Workers-safe (no lighthouse / puppeteer
+        // import). Subpath let CF preset import without touching the
+        // local-auditor barrel that drags lighthouse into the bundle.
+        './src/auditors/remote-lighthouse.ts',
         './src/auditors/crux.ts',
         './src/auditors/psi.ts',
         './src/auditors/route/index.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/auditors/cdp-connect.d.mts",
       "import": "./dist/auditors/cdp-connect.mjs"
     },
+    "./auditors/remote-lighthouse": {
+      "types": "./dist/auditors/remote-lighthouse.d.mts",
+      "import": "./dist/auditors/remote-lighthouse.mjs"
+    },
     "./auditors/crux": {
       "types": "./dist/auditors/crux.d.mts",
       "import": "./dist/auditors/crux.mjs"


### PR DESCRIPTION
## Summary

The `remote-lighthouse` adapter was implemented and barrel-re-exported, but the Worker bundle can't import it through the barrel — that transitively pulls in `auditors/local` → `lighthouse` → `fileURLToPath(import.meta.url)`, which throws on the Workers runtime (no `import.meta.url`). The other auditors (`mock`, `cdp-connect`, `crux`, `psi`, `route`) already have dedicated subpaths to dodge this exact problem; this brings `remote-lighthouse` to parity.

## Why now

Phase 5.5 (next PR) introduces a Cloudflare Containers-backed Lighthouse path. The Worker side of that wiring needs to import `createRemoteLighthouseAuditor` without dragging the heavy stuff into its bundle.

## Verification

- `pnpm -F @unlighthouse/core build` produces `dist/auditors/remote-lighthouse.{mjs,d.mts}` with dependencies listed as just `ofetch` — no `lighthouse`, no `puppeteer-core`.
- `node -e "import('@unlighthouse/core/auditors/remote-lighthouse').then(m => console.log(Object.keys(m)))"` from inside `packages/core` → `['createRemoteLighthouseAuditor']`.
- `pnpm -F @unlighthouse/core test:attw` clean.
- `pnpm -F @unlighthouse/core test:publint` → "All good!"

## Test plan

- [ ] CI green
- [ ] Self-import smoke test inside the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)