### PR TITLE
feat(cf-lighthouse): Container-hosted real-Lighthouse package

### DIFF
--- a/packages/cloudflare-lighthouse/.dockerignore
+++ b/packages/cloudflare-lighthouse/.dockerignore
@@ -1,0 +1,16 @@
+# Build context is the monorepo root. Keep it lean.
+**/node_modules
+**/.turbo
+**/.cache
+**/dist
+**/.git
+**/.github
+**/test
+**/tests
+**/*.test.ts
+**/*.spec.ts
+**/.DS_Store
+**/.vscode
+**/coverage
+**/*.md
+!packages/cloudflare-lighthouse/dist

--- a/packages/cloudflare-lighthouse/Dockerfile
+++ b/packages/cloudflare-lighthouse/Dockerfile
@@ -1,0 +1,36 @@
+# Cloudflare Container image for unlighthouse Lighthouse host.
+#
+# Connects to Cloudflare Browser Run remotely via CDP — no Chromium in
+# the image. Final size ≈ 250-300 MB.
+#
+# Build context: monorepo root (so we can `pnpm install` properly with
+# workspace links). Wrangler's `wrangler deploy` builds + pushes this
+# image automatically when `[[containers]]` is declared in wrangler.toml.
+
+FROM node:22-alpine AS deps
+WORKDIR /workspace
+# Manifest layer — cached unless deps change.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/cloudflare-lighthouse/package.json packages/cloudflare-lighthouse/
+COPY packages/core/package.json packages/core/
+COPY packages/contracts/package.json packages/contracts/
+COPY packages/audit-pool/package.json packages/audit-pool/
+RUN corepack enable && \
+    pnpm install --frozen-lockfile --prod \
+      --filter @unlighthouse/cloudflare-lighthouse...
+
+FROM node:22-alpine AS build
+WORKDIR /workspace
+COPY --from=deps /workspace/node_modules ./node_modules
+COPY --from=deps /workspace/packages/cloudflare-lighthouse/node_modules ./packages/cloudflare-lighthouse/node_modules
+COPY packages/cloudflare-lighthouse/dist packages/cloudflare-lighthouse/dist
+COPY packages/cloudflare-lighthouse/package.json packages/cloudflare-lighthouse/
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+# Only the cloudflare-lighthouse package + its deps need to land in /app.
+COPY --from=build /workspace/packages/cloudflare-lighthouse ./
+COPY --from=build /workspace/node_modules ./node_modules
+EXPOSE 8080
+CMD ["node", "dist/server.mjs"]

--- a/packages/cloudflare-lighthouse/build.config.ts
+++ b/packages/cloudflare-lighthouse/build.config.ts
@@ -1,0 +1,44 @@
+import { defineBuildConfig } from 'obuild/config'
+
+// Two separate bundles by design — keeps the Worker bundle hermetic.
+//
+// `worker-helper.ts` runs inside a Cloudflare Worker; it must NOT
+// transitively reference `lighthouse` or `puppeteer-core`. The only path
+// it touches is `@unlighthouse/core/auditors/remote-lighthouse`, which
+// itself only depends on `ofetch`.
+//
+// `server.ts` runs inside the Cloudflare Container (Node 22). It imports
+// `createCdpConnectAuditor` from `@unlighthouse/core/auditors/cdp-connect`,
+// which pulls `lighthouse` + `puppeteer-core`. That's fine — the
+// Container is a real Node host, not a Workers runtime.
+export default defineBuildConfig({
+  entries: [
+    {
+      type: 'bundle',
+      input: ['./src/worker-helper.ts'],
+      rolldown: {
+        external: [
+          '@cloudflare/workers-types',
+          '@unlighthouse/contracts',
+          '@unlighthouse/contracts/ports',
+          '@unlighthouse/core/auditors/remote-lighthouse',
+        ],
+      },
+    },
+    {
+      type: 'bundle',
+      input: ['./src/server.ts'],
+      rolldown: {
+        external: [
+          'lighthouse',
+          'puppeteer-core',
+          'h3',
+          'ofetch',
+          '@unlighthouse/contracts',
+          '@unlighthouse/contracts/ports',
+          '@unlighthouse/core/auditors/cdp-connect',
+        ],
+      },
+    },
+  ],
+})

--- a/packages/cloudflare-lighthouse/package.json
+++ b/packages/cloudflare-lighthouse/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@unlighthouse/cloudflare-lighthouse",
+  "type": "module",
+  "version": "0.0.0-v1",
+  "private": true,
+  "description": "Cloudflare Containers-backed real-Lighthouse audit server + Worker-side bridge. Worker calls a DO-bound Container that runs createCdpConnectAuditor against Cloudflare Browser Run's external CDP endpoint.",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    "./worker": {
+      "types": "./dist/worker-helper.d.mts",
+      "import": "./dist/worker-helper.mjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.mts",
+      "import": "./dist/server.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "Dockerfile",
+    ".dockerignore"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "build": "obuild",
+    "stub": "obuild --stub",
+    "typecheck": "tsc --noEmit",
+    "test:attw": "attw --pack --profile esm-only",
+    "test:publint": "publint"
+  },
+  "dependencies": {
+    "@unlighthouse/contracts": "workspace:*",
+    "@unlighthouse/core": "workspace:*",
+    "h3": "catalog:dependencies",
+    "lighthouse": "catalog:dependencies",
+    "ofetch": "catalog:dependencies",
+    "puppeteer-core": "catalog:dependencies"
+  },
+  "devDependencies": {}
+}

--- a/packages/cloudflare-lighthouse/src/server.ts
+++ b/packages/cloudflare-lighthouse/src/server.ts
@@ -1,0 +1,119 @@
+// Node-side HTTP server inside the Cloudflare Container.
+//
+// One route: POST /audit { url, config? } → Lighthouse Report JSON.
+// Plus GET /health for the Container runtime's liveness probe.
+//
+// Auth: Authorization: Bearer ${SHARED_AUDIT_TOKEN} (validated constant-time-ish
+// via a string comparison — Node v22 doesn't ship `timingSafeEqual` for
+// strings without the buffer dance; we're behind the DO binding anyway so
+// the threat model is "defence in depth" not "first auth boundary").
+//
+// Browser delivery: Cloudflare Browser Run's external CDP endpoint
+//   wss://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}
+//     /browser-rendering/devtools/browser?keep_alive=600000
+// authenticated with Authorization: Bearer ${CF_BROWSER_RUN_TOKEN}.
+//
+// The keep_alive=600000 (10 min max per Browser Run limits) keeps Cloudflare's
+// Chromium warm across audits. cdp-connect.ts disconnects (not closes) the
+// puppeteer client after each audit, so the underlying browser stays alive.
+
+import { Buffer } from 'node:buffer'
+import { createServer } from 'node:http'
+import { createCdpConnectAuditor } from '@unlighthouse/core/auditors/cdp-connect'
+import {
+  createApp,
+  createRouter,
+  defineEventHandler,
+  getHeader,
+  readBody,
+  toNodeListener,
+} from 'h3'
+
+const PORT = Number(process.env.PORT ?? 8080)
+const SHARED_AUDIT_TOKEN = required('SHARED_AUDIT_TOKEN')
+const CF_ACCOUNT_ID = required('CF_ACCOUNT_ID')
+const CF_BROWSER_RUN_TOKEN = required('CF_BROWSER_RUN_TOKEN')
+
+function required(name: string): string {
+  const v = process.env[name]
+  if (!v)
+    throw new Error(`[cloudflare-lighthouse] missing env var ${name}`)
+  return v
+}
+
+const BROWSER_RUN_WS = `wss://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}`
+  + `/browser-rendering/devtools/browser?keep_alive=600000`
+
+// Constant-time-ish bearer compare. Lengths must match before timingSafeEqual.
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length)
+    return false
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  // eslint-disable-next-line ts/no-require-imports
+  const { timingSafeEqual } = require('node:crypto') as typeof import('node:crypto')
+  return timingSafeEqual(ab, bb)
+}
+
+const auditor = createCdpConnectAuditor({
+  browserWSEndpoint: BROWSER_RUN_WS,
+  headers: { Authorization: `Bearer ${CF_BROWSER_RUN_TOKEN}` },
+})
+
+const app = createApp()
+const router = createRouter()
+
+router.get(
+  '/health',
+  defineEventHandler(() => ({
+    ok: true,
+    service: 'unlighthouse-lighthouse',
+    node: process.versions.node,
+  })),
+)
+
+router.post(
+  '/audit',
+  defineEventHandler(async (event) => {
+    const expectedAuth = `Bearer ${SHARED_AUDIT_TOKEN}`
+    const auth = getHeader(event, 'authorization') ?? ''
+    if (!constantTimeEqual(auth, expectedAuth)) {
+      event.node.res.statusCode = 401
+      return { error: 'unauthorized' }
+    }
+
+    const body = await readBody<{
+      url?: string
+      config?: Record<string, unknown>
+      device?: 'mobile' | 'desktop'
+    }>(event)
+
+    if (!body?.url || typeof body.url !== 'string') {
+      event.node.res.statusCode = 400
+      return { error: 'url required' }
+    }
+
+    try {
+      return await auditor.audit(body.url, undefined, {
+        device: body.device,
+        lighthouseConfig: body.config,
+      })
+    }
+    catch (err) {
+      event.node.res.statusCode = 502
+      // eslint-disable-next-line no-console
+      console.error('[cloudflare-lighthouse] audit failed:', err)
+      return {
+        error: 'audit_failed',
+        detail: err instanceof Error ? err.message : String(err),
+      }
+    }
+  }),
+)
+
+app.use(router)
+
+createServer(toNodeListener(app)).listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`[cloudflare-lighthouse] listening on :${PORT}`)
+})

--- a/packages/cloudflare-lighthouse/src/worker-helper.ts
+++ b/packages/cloudflare-lighthouse/src/worker-helper.ts
@@ -1,0 +1,77 @@
+// Worker-safe bridge between createCloudflareApp's `auditorFactory` and the
+// LighthouseContainer DO.
+//
+// Wraps `createRemoteLighthouseAuditor` from core with a custom `transport`
+// that fetches via the Container DO stub rather than over HTTP — so the
+// `endpoint` URL passed to the underlying auditor is purely cosmetic
+// (the transport hijacks the request). No public hostname is needed; the
+// DO binding is the auth boundary, but we still send a Bearer to give the
+// Container something to validate (defence-in-depth in case Cloudflare
+// ever changes Container reachability semantics).
+//
+// We intentionally do NOT import `@cloudflare/workers-types` here. The
+// server entry of this package transitively pulls Node DOM types from
+// `core/auditors/cdp-connect`'s AbortSignal usage, and Workers types'
+// `AbortSignal` conflicts with the DOM one. Keeping this entry types-light
+// avoids a multi-tsconfig split. Consumers (the Worker's `auditorFactory`)
+// import Workers types separately.
+
+import type { Auditor } from '@unlighthouse/contracts/ports'
+import { createRemoteLighthouseAuditor } from '@unlighthouse/core/auditors/remote-lighthouse'
+
+/**
+ * Minimal local shape of the Container DO namespace surface this helper
+ * uses. Matches `DurableObjectNamespace` from @cloudflare/workers-types
+ * for the `getByName(name).fetch(req)` path. Consumers will pass their
+ * actual `env.LIGHTHOUSE_CONTAINER` binding here.
+ */
+export interface ContainerNamespaceLike {
+  getByName: (name: string) => { fetch: (req: Request) => Promise<Response> }
+}
+
+export interface ContainerLighthouseOptions {
+  /** Container DO binding (e.g. `env.LIGHTHOUSE_CONTAINER`). */
+  container: ContainerNamespaceLike
+  /** Bearer token shared with the Container. Set via `wrangler secret put`. */
+  token: string
+  /**
+   * Routing key for the Container DO instance. Default `'default'` keeps a
+   * single warm Container per Worker — fine for low-volume deploys. Set this
+   * to e.g. the scanId if you want one Container per concurrent scan.
+   */
+  instanceName?: string
+  /** Per-audit timeout in ms. Default 180_000 (Lighthouse 30-90s + slack). */
+  timeoutMs?: number
+}
+
+export function createContainerLighthouseAuditor(opts: ContainerLighthouseOptions): Auditor {
+  return createRemoteLighthouseAuditor({
+    // Synthetic endpoint — the transport intercepts before ofetch touches it.
+    endpoint: 'https://container.internal/audit',
+    token: opts.token,
+    timeoutMs: opts.timeoutMs ?? 180_000,
+    transport: async (req) => {
+      const stub = opts.container.getByName(opts.instanceName ?? 'default')
+      const res = await stub.fetch(new Request('https://container.internal/audit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'authorization': `Bearer ${req.token}`,
+        },
+        body: JSON.stringify({
+          url: req.url,
+          config: req.lighthouseConfig,
+        }),
+        signal: req.signal,
+      }))
+      if (!res.ok) {
+        const text = await res.text().catch(() => '<unreadable>')
+        throw new Error(`LighthouseContainer audit failed: ${res.status} ${text}`)
+      }
+      const lhr = await res.json()
+      if (!lhr || typeof lhr !== 'object' || !('categories' in (lhr as object)))
+        throw new Error('LighthouseContainer returned an invalid LHR')
+      return lhr as Awaited<ReturnType<Auditor['audit']>>
+    },
+  })
+}

--- a/packages/cloudflare-lighthouse/tsconfig.json
+++ b/packages/cloudflare-lighthouse/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -34,6 +34,7 @@
     "test:publint": "publint"
   },
   "dependencies": {
+    "@cloudflare/containers": "catalog:",
     "@cloudflare/puppeteer": "catalog:",
     "@unlighthouse/contracts": "workspace:*",
     "@unlighthouse/core": "workspace:*",

--- a/packages/cloudflare/src/do/lighthouse-container.ts
+++ b/packages/cloudflare/src/do/lighthouse-container.ts
@@ -1,0 +1,34 @@
+// Cloudflare Container DO wrapper for the unlighthouse Lighthouse host.
+//
+// Container source + Dockerfile live in `@unlighthouse/cloudflare-lighthouse`.
+// This class is just the Worker-side DO that backs the binding declared in
+// wrangler.toml — Cloudflare's runtime auto-routes incoming `fetch()` calls
+// to the container's `defaultPort`.
+//
+// Lifecycle config:
+//  - `defaultPort = 8080` — matches `process.env.PORT ?? 8080` in server.ts.
+//  - `sleepAfter = '10m'` — Container hibernates after 10 min of no requests.
+//    Matches Browser Run's max `keep_alive` so the inside-Container Browser
+//    Run session and the Container itself wake/sleep together.
+
+import { Container } from '@cloudflare/containers'
+
+export class LighthouseContainer extends Container {
+  override defaultPort = 8080
+  override sleepAfter = '10m'
+
+  override onStart(): void {
+    // eslint-disable-next-line no-console
+    console.log('[LighthouseContainer] started')
+  }
+
+  override onStop(): void {
+    // eslint-disable-next-line no-console
+    console.log('[LighthouseContainer] stopped')
+  }
+
+  override onError(error: unknown): void {
+    // eslint-disable-next-line no-console
+    console.error('[LighthouseContainer] error:', error)
+  }
+}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -11,6 +11,7 @@ export type { CloudflareApp, CloudflareEnv, CreateCloudflareAppOptions } from '.
 export { createCloudflareApp } from './app'
 export { cloudflareCrawler } from './crawlers/cloudflare-crawl'
 export type { CloudflareCrawlerOptions } from './crawlers/cloudflare-crawl'
+export { LighthouseContainer } from './do/lighthouse-container'
 export { RateLimiterDO } from './do/rate-limiter'
 export type { RateLimiterCheckResult, RateLimiterConfig, RateLimiterEnv } from './do/rate-limiter'
 export { ScanEventsDO } from './do/scan-events'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@arethetypeswrong/cli':
       specifier: 0.18.2
       version: 0.18.2
+    '@cloudflare/containers':
+      specifier: ^0.0.18
+      version: 0.0.18
     '@cloudflare/puppeteer':
       specifier: ^1.1.0
       version: 1.1.0
@@ -346,6 +349,9 @@ importers:
 
   packages/cloudflare:
     dependencies:
+      '@cloudflare/containers':
+        specifier: 'catalog:'
+        version: 0.0.18
       '@cloudflare/puppeteer':
         specifier: 'catalog:'
         version: 1.1.0
@@ -362,6 +368,27 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260511.1
+
+  packages/cloudflare-lighthouse:
+    dependencies:
+      '@unlighthouse/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@unlighthouse/core':
+        specifier: workspace:*
+        version: link:../core
+      h3:
+        specifier: catalog:dependencies
+        version: 1.15.11
+      lighthouse:
+        specifier: catalog:dependencies
+        version: 13.3.0
+      ofetch:
+        specifier: catalog:dependencies
+        version: 1.5.1
+      puppeteer-core:
+        specifier: catalog:dependencies
+        version: 24.43.1
 
   packages/contracts:
     dependencies:
@@ -1074,6 +1101,9 @@ packages:
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
     engines: {node: '>= 20.12.0'}
+
+  '@cloudflare/containers@0.0.18':
+    resolution: {integrity: sha512-3XC8AXMWTX7tQJA2jOcjYXEr5S4aFS8lH5T56Fsr8X3sfaD2KoB0XghFpmMsOHK+fc88z6K0LTaVmcX2ELOZ9w==}
 
   '@cloudflare/kv-asset-handler@0.4.1':
     resolution: {integrity: sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==}
@@ -3958,9 +3988,6 @@ packages:
 
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
-
-  '@types/node@25.0.3':
-    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/node@25.7.0':
     resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
@@ -9136,9 +9163,6 @@ packages:
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   undici-types@7.21.0:
     resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
 
@@ -10177,6 +10201,8 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
+
+  '@cloudflare/containers@0.0.18': {}
 
   '@cloudflare/kv-asset-handler@0.4.1':
     dependencies:
@@ -13099,10 +13125,6 @@ snapshots:
     dependencies:
       '@types/node': 25.7.0
 
-  '@types/node@25.0.3':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@25.7.0':
     dependencies:
       undici-types: 7.21.0
@@ -14279,7 +14301,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 25.7.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -19229,8 +19251,6 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
-
-  undici-types@7.16.0: {}
 
   undici-types@7.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ overrides:
 catalog:
   '@antfu/eslint-config': ^9.0.0
   '@arethetypeswrong/cli': 0.18.2
+  '@cloudflare/containers': ^0.0.18
   '@cloudflare/puppeteer': ^1.1.0
   '@cloudflare/workers-types': ^4.20260511.1
   '@modelcontextprotocol/sdk': ^1.29.0


### PR DESCRIPTION
## Summary

New workspace package `@unlighthouse/cloudflare-lighthouse` that hosts real Lighthouse inside a Cloudflare Container, addressable from the Worker via DO stub. Plus the `LighthouseContainer` DO wrapper in `@unlighthouse/cloudflare`.

## Why

Workers can't host the `lighthouse` package — its top-level `fileURLToPath(import.meta.url)` crashes the runtime. Cloudflare GA'd Containers in April 2026, which gives us a Node-process slot next to the Worker with one auth boundary (DO binding) and one deploy command (`wrangler deploy`).

## Architecture

```
Worker → env.LIGHTHOUSE_CONTAINER.getByName(...).fetch(/audit)
       → Container (Node) running createCdpConnectAuditor
       → wss://api.cloudflare.com/.../browser-rendering/devtools/browser
       → Browser Run (managed Chromium)
```

The image contains no Chromium — Cloudflare hosts the browser remotely. Expected image size ~250-300 MB.

## What's in this PR

- `packages/cloudflare-lighthouse/` — full new package with two split entries (Workers-safe `./worker`, Node-only `./server`) + Dockerfile.
- `packages/cloudflare/src/do/lighthouse-container.ts` — DO wrapper, re-exported from index.
- `@cloudflare/containers` added to the workspace catalog.

Not yet wired into the example deploy — that's the next PR.

## Verification

- `pnpm -F @unlighthouse/cloudflare-lighthouse build` — both bundles clean; worker entry's deps list is just `@unlighthouse/core/auditors/remote-lighthouse`, no `lighthouse`/`puppeteer-core`.
- `pnpm -F @unlighthouse/cloudflare-lighthouse typecheck` — clean.
- `pnpm -F @unlighthouse/cloudflare-lighthouse test:attw` + `test:publint` — both green.
- `pnpm -F @unlighthouse/cloudflare build` — `LighthouseContainer` export appears in the bundle's exports list.

## Test plan

- [ ] CI green
- [ ] Manual `docker build` from monorepo root works (will be exercised by `wrangler deploy` in next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)