### PR TITLE
docs(v1): Phase 5.5 + D-031 — real Lighthouse via CF Containers

### DIFF
--- a/v1.md
+++ b/v1.md
@@ -1669,6 +1669,23 @@ Every host (`unlighthouse.ts`, `cli/mcp.ts`, `cloudflare/app.ts`) reads `version
 
 **Revisit if:** a high-traffic pack consistently needs `opportunities` / `diagnostics` for >80% of routes, at which point promote those arrays into the reconciled shape rather than fetching raw LHR per call.
 
+### D-031 — Real Lighthouse on Cloudflare runs in a Container, never in the Worker
+
+**Decision:** The Cloudflare preset's real-audit path runs `lighthouse` inside a Cloudflare Container, addressable from the Worker through a Durable Object stub. The Worker stays Chromium- and Lighthouse-free. The Container uses Cloudflare Browser Run's external CDP endpoint (`wss://api.cloudflare.com/.../browser-rendering/devtools/browser?keep_alive=600000`) to drive a managed Chromium remotely, then runs `lighthouse(url, opts, undefined, page)` against the connected puppeteer page. Worker-side wiring is `createContainerLighthouseAuditor` (a thin wrapper around `createRemoteLighthouseAuditor` with a DO-stub transport) composed via `fallbackAuditor([container, crux?, mock])`.
+
+**Why:**
+- The `lighthouse` npm package crashes at module load on the Workers runtime — its top-level code calls `fileURLToPath(import.meta.url)`, and `import.meta.url` is undefined on Workers. This is a permanent architectural mismatch; no bundler workaround.
+- Cloudflare Containers GA'd 2026-04-13 on the Workers Paid plan and give us a Node process slot next to the Worker with one auth boundary (DO binding), one deploy command (`wrangler deploy`), and scale-to-zero billing (`sleepAfter`). No second platform to manage.
+- Browser Run's external CDP endpoint (plain CDP since 2026-06-13) accepts `puppeteer.connect({ browserWSEndpoint, headers: { Authorization: 'Bearer …' } })` from Node, so the existing `cdp-connect` adapter is reused verbatim inside the Container.
+- A separate Node host (Fly.io, Railway, etc.) would have worked but adds a second auth boundary and a second deploy target. The Container keeps everything in-Cloudflare.
+
+**Trade-offs:**
+- Worker→Container fetch must run 30-90s while the audit is in flight; Workers' subrequest timeout while the client is connected is undocumented but the `waitUntil()` budget can bite on cold-starts. If this breaks, switch the Container API to 2-phase (`POST /audit/start → jobId`, polled `GET /result/:jobId` with `ctx.waitUntil`).
+- `fallbackAuditor` AND-collapses capability bits across all tiers, so `reliablePerfScores` falls to `false` because the bottom-tier mock advertises it that way. Production deploys can drop mock from the chain once the Container is stable; v1.0 keeps it for shake-out.
+- Container cold-start adds ~3-5s before the first audit after `sleepAfter` (10 min). Acceptable; document, optionally add a cron warmer later.
+
+**Revisit if:** Cloudflare ships first-class Workers-side Lighthouse support, OR the Workers runtime gains the missing Node-URL primitives lighthouse needs at module load, OR a high-volume deploy outgrows the Container model and a horizontally-scaled external host becomes cheaper.
+
 ## Migration plan
 
 From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is independently mergeable.
@@ -1725,6 +1742,38 @@ From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is 
     See `packages/cloudflare/examples/basic/README.md` for the three
     commands (`wrangler d1 create`, `wrangler r2 bucket create`,
     `wrangler deploy`) and verification curls.
+
+### Phase 5.5 — Real Lighthouse via Cloudflare Containers ◐ in flight
+- **Context:** `lighthouse` npm package crashes the Workers runtime at module load
+  (`fileURLToPath(import.meta.url)` — Workers has no `import.meta.url`). Phase 5
+  shipped the CF preset in mock-mode; this phase closes the real-LH gap.
+- **Architecture (D-031):** Worker keeps HTTP/storage/orchestration, a Cloudflare
+  Container runs `createCdpConnectAuditor` against Browser Run's external CDP
+  endpoint, Worker calls the Container via DO stub binding. The Worker bundle
+  stays Lighthouse-free; the Container is the only place `lighthouse` runs.
+  Three tier `fallbackAuditor([container, crux?, mock])` keeps the API up if any
+  tier fails.
+- **Done:**
+  - `@unlighthouse/core/auditors/remote-lighthouse` exported on its own subpath
+    so Workers can import without dragging the local-auditor barrel (#339).
+  - `@unlighthouse/cloudflare-lighthouse` package with split `./worker` (Workers-
+    safe bridge via `createContainerLighthouseAuditor`) + `./server` (Node-side
+    h3 service on Browser Run external CDP). Self-contained Dockerfile with
+    vendored workspace tarballs (#340).
+  - `LighthouseContainer` DO wrapper in `@unlighthouse/cloudflare`, secret
+    propagation via constructor envVars.
+  - Example `examples/basic` rewired to the Container auditor with fallback chain;
+    wrangler.toml v2 migration installs the Container DO; README runbook covers
+    secrets, smoke tests, fallback verification (#341).
+- **Open:**
+  - Container's inside-process listener at `:8080` isn't reachable by Cloudflare's
+    Worker-side TCP probe. Local `docker run` of the same x86_64 image responds
+    on `/health` correctly. Suspected: Cloudflare-side process supervision /
+    network namespace detail not yet documented. While unresolved, the fallback
+    chain serves mock LHRs — no regression, but real Lighthouse not yet active.
+  - Worker → Container fetch duration exceeds `waitUntil()` budget on cold-start
+    audits; once the port issue clears we may need to switch to a 2-phase
+    `start → result` polling API.
 
 ### Phase 6 — Tests, types, observability
 - Treeshake bundle tests per scenario (CLI / Worker HTTP-only / Worker CF / UI types-only).


### PR DESCRIPTION
## Summary

Documents Phase 5.5 between Phase 5 (CF preset code-complete) and Phase 7 (release):

- **Phase 5.5 entry** lists what shipped in #339 + #340 + #341 and the one open thread (Container's `:8080` listener not yet reachable from inside Cloudflare's runtime — `fallbackAuditor` keeps the API serving mock LHRs until that lands).
- **D-031 decision record** on D-030's heels: why the Container model and not a Worker-side bundle or an external host. Captures trade-offs on Workers subrequest timeouts, fallbackAuditor capability AND-collapse, and Container cold-start budget.

## Test plan

- [ ] CI green (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)