### PR TITLE
docs(v1): mark Phase 5.5 done

### DIFF
--- a/v1.md
+++ b/v1.md
@@ -1743,7 +1743,7 @@ From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is 
     commands (`wrangler d1 create`, `wrangler r2 bucket create`,
     `wrangler deploy`) and verification curls.
 
-### Phase 5.5 — Real Lighthouse via Cloudflare Containers ◐ in flight
+### Phase 5.5 — Real Lighthouse via Cloudflare Containers ✓ done
 - **Context:** `lighthouse` npm package crashes the Workers runtime at module load
   (`fileURLToPath(import.meta.url)` — Workers has no `import.meta.url`). Phase 5
   shipped the CF preset in mock-mode; this phase closes the real-LH gap.
@@ -1765,15 +1765,13 @@ From today's monolithic `packages/unlighthouse` to the v1 layout. Each phase is 
   - Example `examples/basic` rewired to the Container auditor with fallback chain;
     wrangler.toml v2 migration installs the Container DO; README runbook covers
     secrets, smoke tests, fallback verification (#341).
-- **Open:**
-  - Container's inside-process listener at `:8080` isn't reachable by Cloudflare's
-    Worker-side TCP probe. Local `docker run` of the same x86_64 image responds
-    on `/health` correctly. Suspected: Cloudflare-side process supervision /
-    network namespace detail not yet documented. While unresolved, the fallback
-    chain serves mock LHRs — no regression, but real Lighthouse not yet active.
-  - Worker → Container fetch duration exceeds `waitUntil()` budget on cold-start
-    audits; once the port issue clears we may need to switch to a 2-phase
-    `start → result` polling API.
+- **Closed in #343:** Container port-open issue traced to two root causes —
+  PID 1 had to be a shell (Cloudflare launcher's port probe missed the
+  listen() event with exec-form `CMD ["node", …]`), and top-level
+  `lighthouse`+`puppeteer-core` imports delayed listen() past the probe
+  budget. Switched to `CMD ["sh", "-c", "exec node …"]` and lazy-loaded
+  the auditor on first /audit. Live deploy now returns
+  `lighthouseVersion: "13.3.0"` from real Lighthouse via Browser Run.
 
 ### Phase 6 — Tests, types, observability
 - Treeshake bundle tests per scenario (CLI / Worker HTTP-only / Worker CF / UI types-only).


### PR DESCRIPTION
Phase 5.5 closed by #343 — live deploy now serves real Lighthouse 13.3.0.