### PR TITLE
test(ci): unblock Phase 6 test suite + tighten CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - v1
 
   pull_request:
     branches:
       - main
+      - v1
 
 jobs:
   build:
@@ -40,7 +42,7 @@ jobs:
         run: pnpm run test
 
       - name: Test attw
-        run: pnpm run test:attw || true
+        run: pnpm run test:attw
 
       - name: Test publint
-        run: pnpm run test:publint || true
+        run: pnpm run test:publint

--- a/test/stubs/cloudflare-workers.ts
+++ b/test/stubs/cloudflare-workers.ts
@@ -1,0 +1,17 @@
+// Stub for the `cloudflare:workers` virtual module so vitest (running in
+// Node) can import packages that depend on it transitively
+// (@cloudflare/containers extends DurableObject from this module).
+//
+// We don't run the Workers runtime in tests — anything that actually uses
+// these classes (DurableObject lifecycle, ctx, etc.) is exercised against
+// the real deploy. Tests here only need the symbols to resolve.
+
+export class DurableObject {
+  // eslint-disable-next-line ts/no-explicit-any
+  constructor(_ctx?: any, _env?: any) {}
+}
+
+export class WorkerEntrypoint {
+  // eslint-disable-next-line ts/no-explicit-any
+  constructor(_ctx?: any, _env?: any) {}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,12 @@ export const alias: AliasOptions = {
   '@unlighthouse/contracts': r('./packages/contracts/src/index.ts'),
   '@unlighthouse/core': r('./packages/core/src/'),
   '@unlighthouse/cloudflare': r('./packages/cloudflare/src/'),
+  '@unlighthouse/cloudflare-lighthouse': r('./packages/cloudflare-lighthouse/src/'),
   '@unlighthouse/mcp': r('./packages/mcp/src/'),
+  // `cloudflare:workers` is a Workers-runtime virtual module. Stub it so
+  // tests in Node can import packages (@cloudflare/containers etc.) that
+  // depend on it without spinning up miniflare.
+  'cloudflare:workers': r('./test/stubs/cloudflare-workers.ts'),
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Brings the existing Phase 6 test scaffolding (already written in v1.md Phase 6) back to green and tightens CI so regressions actually block merges.

## Changes

1. **Stub \`cloudflare:workers\` for vitest.** \`@cloudflare/containers\` (added in Phase 5.5) extends \`DurableObject\` from the \`cloudflare:workers\` virtual module. Node-side tests couldn't resolve it. Added a minimal stub at \`test/stubs/cloudflare-workers.ts\` and aliased the module in \`vitest.config.ts\`. Restores \`cloudflare-sweeper.test.ts\` (4 tests).
2. **Drop \`|| true\` from attw + publint CI steps.** Phase 5.5 verified every package passes both — regressions should now block.
3. **Run test workflow on push/PR against \`v1\` too.** The v1.x line has been merging without CI gating.

## Verification

- \`pnpm test\` — **34 files, 460 tests, all green**
- \`pnpm test:attw\` — clean across all 6 packages
- \`pnpm test:publint\` — All good!

This unblocks the rest of Phase 6 (already implemented: treeshake invariants 6/6, api-parity 239/239, e2e-http 4/4) → Phase 7 release.

## Test plan

- [x] Full suite locally
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)