### PR TITLE
chore: add FUNDING, CODEOWNERS, dependabot grouping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+* @harlan-zw
+
+/packages/core/        @harlan-zw
+/packages/cloudflare/  @harlan-zw
+/packages/cloudflare-lighthouse/ @harlan-zw
+/packages/contracts/   @harlan-zw
+/packages/mcp/         @harlan-zw
+/packages/audit-pool/  @harlan-zw
+/packages/unlighthouse/ @harlan-zw
+/packages/ui/          @harlan-zw
+
+/docs/                 @harlan-zw
+/.github/              @harlan-zw

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      runtime-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Phase 20 housekeeping from #349. Three config additions:

- `.github/FUNDING.yml` -> harlan-zw sponsors (already present on v1, kept as-is)
- `.github/CODEOWNERS` -> @harlan-zw on every package + docs + .github
- `.github/dependabot.yml` -> weekly grouped npm (dev/runtime) + github-actions, 5 PR cap

## Test plan
- [ ] GitHub renders Sponsor button on repo (FUNDING.yml unchanged, still valid)
- [ ] New PRs request review from @harlan-zw via CODEOWNERS
- [ ] Dependabot opens grouped PRs on next weekly tick

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>