### PR TITLE
feat(cli): --device flag accepts comma-separated devices

### DIFF
--- a/packages/unlighthouse/src/cli/ci.ts
+++ b/packages/unlighthouse/src/cli/ci.ts
@@ -8,7 +8,7 @@ import { createConsola } from 'consola'
 import { createUnlighthouseHost } from '../index.ts'
 import { generateReportPayload, outputReport } from '../reporters'
 import createCli from './createCli'
-import { pickOptions, validateHost, validateOptions } from './util'
+import { parseDevices, pickOptions, validateHost, validateOptions } from './util'
 
 const cli = createCli()
 
@@ -53,7 +53,12 @@ async function run() {
     })
   })
 
-  const { scanId } = await unlighthouse.start()
+  // D-029: forward parsed `--device` matrix into the run overrides so CI
+  // runs can exercise mobile + desktop under a single scan id.
+  const deviceOverride = parseDevices(options)
+  const { scanId } = await unlighthouse.start(
+    deviceOverride && deviceOverride.length > 0 ? { device: deviceOverride } : undefined,
+  )
   const { completed: completedCount } = await completed
   const seconds = Math.round((Date.now() - start.getTime()) / 1000)
   logger.success(`Unlighthouse has finished scanning ${unlighthouse.resolvedConfig.site}: ${completedCount} routes in ${seconds}s.`)

--- a/packages/unlighthouse/src/cli/cli.ts
+++ b/packages/unlighthouse/src/cli/cli.ts
@@ -9,7 +9,7 @@ import { joinURL } from 'ufo'
 import { createSitesStore, deriveSiteId } from '../data/sites'
 import { createUnlighthouseHost } from '../index.ts'
 import createCli from './createCli'
-import { pickOptions, validateHost, validateOptions } from './util'
+import { parseDevices, pickOptions, validateHost, validateOptions } from './util'
 
 async function createServer(resolvedConfig: { server: any }) {
   const app = createApp()
@@ -90,7 +90,15 @@ async function run() {
 
   const { server, app } = await createServer(unlighthouse.resolvedConfig)
   await unlighthouse.setServerContext({ url: server.url, server: server.server, app })
-  const { scanId } = await unlighthouse.start()
+  // D-029: multi-device matrix scans flow through `core.run` overrides — not
+  // `scanner.device` (which still carries a single primary device for adapter
+  // back-compat). `parseDevices` returns the parsed `--device` list (or
+  // undefined when the flag was omitted); pass it through so a single scan
+  // run can audit both mobile and desktop.
+  const deviceOverride = parseDevices(options)
+  const { scanId } = await unlighthouse.start(
+    deviceOverride && deviceOverride.length > 0 ? { device: deviceOverride } : undefined,
+  )
 
   // Register this scan's site in the persistent registry so it shows up on the dashboard.
   const siteUrl = unlighthouse.resolvedConfig.site

--- a/packages/unlighthouse/src/cli/createCli.ts
+++ b/packages/unlighthouse/src/cli/createCli.ts
@@ -9,6 +9,7 @@ export default function createCli() {
     .version(version)
     .example('unlighthouse --site unlighthouse.dev')
     .example('unlighthouse --site unlighthouse.dev --urls /guide,/api,/glossary --desktop')
+    .example('unlighthouse --site unlighthouse.dev --device mobile,desktop')
 
   cli.option('--root <root>', 'Define the project root. Useful for changing where the config is read from or setting up sampling.')
   cli.option('--config-file <config-file>', 'Path to config file.')
@@ -18,6 +19,7 @@ export default function createCli() {
 
   cli.option('--desktop', 'Simulate device as desktop.')
   cli.option('--mobile', 'Simulate device as mobile.')
+  cli.option('--device <devices>', 'Devices to audit (comma-separated): `mobile`, `desktop`, or `mobile,desktop`.')
 
   cli.option('--site <site>', 'Host URL to scan.')
   cli.option('--user-agent <user-agent>', 'Specify a top-level user agent all requests will use.')

--- a/packages/unlighthouse/src/cli/types.ts
+++ b/packages/unlighthouse/src/cli/types.ts
@@ -15,6 +15,7 @@ export interface CliOptions {
   throttle?: boolean
   desktop?: boolean
   mobile?: boolean
+  device?: string
   cache?: boolean
   noCache?: boolean
   version?: boolean

--- a/packages/unlighthouse/src/cli/util.ts
+++ b/packages/unlighthouse/src/cli/util.ts
@@ -7,6 +7,44 @@ import { pick } from 'lodash-es'
 import { fetchUrlRaw, normaliseHost } from '../index.ts'
 import { handleError } from './errors'
 
+type Device = 'mobile' | 'desktop'
+
+const VALID_DEVICES: readonly Device[] = ['mobile', 'desktop']
+
+/**
+ * Parse the `--device` CLI flag into a deduplicated ordered list. Accepts a
+ * single value (`mobile`) or a comma-separated list (`mobile,desktop`).
+ * When the flag is absent returns `undefined`. Exits via `handleError` on
+ * an invalid value so the caller doesn't have to.
+ *
+ * When both `--device` and one of `--mobile`/`--desktop` are supplied,
+ * `--device` wins. When `--device` is absent the legacy `--mobile`/`--desktop`
+ * booleans drive `scanner.device` exactly as before.
+ */
+export function parseDevices(options: CiOptions | CliOptions): Device[] | undefined {
+  if (typeof options.device !== 'string' || options.device.trim() === '')
+    return undefined
+  const parts = options.device.split(',').map(s => s.trim()).filter(Boolean)
+  if (parts.length === 0)
+    return undefined
+  const seen = new Set<Device>()
+  const out: Device[] = []
+  for (const part of parts) {
+    if (!(VALID_DEVICES as readonly string[]).includes(part)) {
+      handleError(
+        `Invalid --device value "${part}". Expected one of: ${VALID_DEVICES.join(', ')}, or a comma-separated list (e.g. "mobile,desktop").`,
+      )
+      return undefined
+    }
+    const d = part as Device
+    if (!seen.has(d)) {
+      seen.add(d)
+      out.push(d)
+    }
+  }
+  return out
+}
+
 export async function validateHost(resolvedConfig: ResolvedUserConfig, logger?: Logger) {
   const site = resolvedConfig.site
   // site will not be set from integrations yet
@@ -102,7 +140,16 @@ export function pickOptions(options: CiOptions | CliOptions): UserConfig {
   else if (options.disableI18nPages)
     scanner.ignoreI18nPages = true
 
-  if (options.desktop)
+  // `--device` wins over `--mobile`/`--desktop` (back-compat). For a
+  // single-device list we set `scanner.device` directly. For a multi-device
+  // list we still set `scanner.device` to the first (primary) device for
+  // back-compat with adapters/UI reading `config.scanner.device`; the full
+  // matrix is surfaced to `host.start()` via `parseDevices` in cli/ci.ts and
+  // flows through `core.run({ overrides: { device } })`.
+  const devices = parseDevices(options)
+  if (devices && devices.length > 0)
+    scanner.device = devices[0]
+  else if (options.desktop)
     scanner.device = 'desktop'
   else if (options.mobile)
     scanner.device = 'mobile'

--- a/packages/unlighthouse/src/host.ts
+++ b/packages/unlighthouse/src/host.ts
@@ -5,7 +5,7 @@
  * Replaces the 465-line createUnlighthouse in unlighthouse.ts (deleted in Step H).
  */
 import type { HookMap, Logger, ResolvedUserConfig, RuntimeSettings, UserConfig } from '@unlighthouse/contracts'
-import type { UnlighthouseCore } from '@unlighthouse/contracts/ports'
+import type { UnlighthouseCore, UnlighthouseCoreRunOverrides } from '@unlighthouse/contracts/ports'
 import type { WS } from '@unlighthouse/core/api'
 import type { HandlerCtx } from '@unlighthouse/core/api/handlers/types'
 import type { Hookable } from 'hookable'
@@ -66,8 +66,12 @@ export interface UnlighthouseHost {
   generateClient: () => Promise<void>
   setServerContext: (arg: { url: string, server: any, app: any }) => Promise<void>
   handlerCtx: HandlerCtx
-  /** Begin the scan via core.run(). Returns the started session's scanId. */
-  start: () => Promise<{ scanId: string }>
+  /**
+   * Begin the scan via core.run(). Returns the started session's scanId.
+   * Optional `overrides` are forwarded as `UnlighthouseCoreRunOverrides`
+   * (e.g. multi-device matrix from `--device mobile,desktop`).
+   */
+  start: (overrides?: UnlighthouseCoreRunOverrides) => Promise<{ scanId: string }>
 }
 
 export interface CreateUnlighthouseHostOptions {
@@ -394,10 +398,10 @@ export async function createUnlighthouseHost(opts: CreateUnlighthouseHostOptions
 
   // ── start ────────────────────────────────────────────────────────────────
 
-  const start = async () => {
+  const start = async (overrides?: UnlighthouseCoreRunOverrides) => {
     const { core } = ensurePorts()
     logger.debug?.(`Starting v1 scan [Site: ${resolvedConfig.site}]`)
-    const session = core.run()
+    const session = core.run(overrides ? { overrides } : undefined)
     return { scanId: session.scanId }
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import createCli from '../packages/unlighthouse/src/cli/createCli'
-import { pickOptions } from '../packages/unlighthouse/src/cli/util'
+import { parseDevices, pickOptions } from '../packages/unlighthouse/src/cli/util'
 
 const argsv = (args: string[]) => ['node', 'unlighthouse.js', '--site', 'unlighthouse.dev', ...args]
 
@@ -84,5 +84,81 @@ describe('cli args', () => {
         "my-other-header": "value",
       }
     `)
+  })
+
+  describe('--device flag', () => {
+    it('parses a single device', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--device', 'mobile']))
+      expect(parseDevices(options)).toEqual(['mobile'])
+    })
+
+    it('parses a comma-separated list', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--device', 'mobile,desktop']))
+      expect(parseDevices(options)).toEqual(['mobile', 'desktop'])
+    })
+
+    it('preserves order and deduplicates entries', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--device', 'desktop, mobile , desktop']))
+      expect(parseDevices(options)).toEqual(['desktop', 'mobile'])
+    })
+
+    it('returns undefined when --device is absent', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv([]))
+      expect(parseDevices(options)).toBeUndefined()
+    })
+
+    it('exits with a clear error for an invalid device', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--device', 'tablet']))
+
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('__exit__')
+      }) as never)
+      // Consola writes to process.stderr; capture it so we can assert the
+      // message names the offending value and the valid options without
+      // leaking the error into the test output.
+      const stderrChunks: string[] = []
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(((chunk: unknown) => {
+          stderrChunks.push(String(chunk))
+          return true
+        }) as never)
+
+      expect(() => parseDevices(options)).toThrow('__exit__')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      const errOutput = stderrChunks.join('')
+      expect(errOutput).toContain('tablet')
+      expect(errOutput).toContain('mobile')
+      expect(errOutput).toContain('desktop')
+
+      exitSpy.mockRestore()
+      stderrSpy.mockRestore()
+    })
+
+    it('--device wins over --mobile / --desktop for scanner.device', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--mobile', '--device', 'desktop']))
+      const picked = pickOptions(options)
+      expect(picked.scanner?.device).toBe('desktop')
+    })
+
+    it('sets scanner.device to the first device for a multi-device list', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--device', 'desktop,mobile']))
+      const picked = pickOptions(options)
+      expect(picked.scanner?.device).toBe('desktop')
+    })
+
+    it('legacy --mobile still resolves scanner.device when --device is absent', () => {
+      const cli = createCli()
+      const { options } = cli.parse(argsv(['--mobile']))
+      const picked = pickOptions(options)
+      expect(picked.scanner?.device).toBe('mobile')
+    })
   })
 })

--- a/test/host-visited-client.test.ts
+++ b/test/host-visited-client.test.ts
@@ -68,11 +68,16 @@ async function bootHost(opts: { autoStartOnVisit: boolean }): Promise<HostFixtur
   return { server, baseUrl, start: startSpy }
 }
 
+// 30s hook budget — host setup (sqlite open + migrations + storage wiring +
+// resolvePath for the client pkg) can exceed vitest's 10s default on CI when
+// other suites (test/ci.test.ts real scans) saturate CPU/disk in parallel.
+const HOOK_TIMEOUT = 30_000
+
 describe('autoStartOnVisit — end-to-end (real host + real HTTP)', () => {
   describe('when behavior.autoStartOnVisit = true', () => {
     let fx: HostFixture
-    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: true }) })
-    afterAll(async () => { await new Promise(r => fx.server.close(() => r(null))) })
+    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: true }) }, HOOK_TIMEOUT)
+    afterAll(async () => { if (fx?.server) await new Promise(r => fx.server.close(() => r(null))) }, HOOK_TIMEOUT)
 
     it('GET / triggers host.start() exactly once', async () => {
       await fetch(`${fx.baseUrl}/`)
@@ -89,8 +94,8 @@ describe('autoStartOnVisit — end-to-end (real host + real HTTP)', () => {
 
   describe('when behavior.autoStartOnVisit = false', () => {
     let fx: HostFixture
-    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: false }) })
-    afterAll(async () => { await new Promise(r => fx.server.close(() => r(null))) })
+    beforeAll(async () => { fx = await bootHost({ autoStartOnVisit: false }) }, HOOK_TIMEOUT)
+    afterAll(async () => { if (fx?.server) await new Promise(r => fx.server.close(() => r(null))) }, HOOK_TIMEOUT)
 
     it('GET / does NOT trigger host.start()', async () => {
       await fetch(`${fx.baseUrl}/`)


### PR DESCRIPTION
## Summary

Phase 8 from #349. Surfaces the multi-device matrix dimension (already supported in contracts + core via D-029) on the CLI.

- New `--device <devices>` flag accepts either a single device (`mobile` / `desktop`) or a comma-separated list (`mobile,desktop`).
- Parsing dedupes while preserving order and exits with a clear error on invalid values.
- Backwards compatible with the existing `--mobile` / `--desktop` boolean toggles — when both are passed, `--device` wins; when `--device` is absent the legacy boolean behaviour is unchanged.
- `scanner.device` still carries the primary (first) device for adapter / UI back-compat.
- Multi-device matrix is plumbed end-to-end via `host.start(overrides)` → `core.run({ overrides: { device } })`.

## Test plan

- [x] `--device mobile` parses to `['mobile']`
- [x] `--device mobile,desktop` parses to `['mobile', 'desktop']`
- [x] Dedupes + preserves order
- [x] Invalid value (`--device tablet`) exits 1 with an error naming the offending value and valid options
- [x] `--device` wins over `--mobile` / `--desktop` for `scanner.device`
- [x] Legacy `--mobile` continues to set `scanner.device` when `--device` is absent
- [x] `pnpm typecheck` green
- [x] `pnpm lint` clean
- [x] `pnpm vitest run test/cli.test.ts` — 15/15 pass