### PR TITLE
feat(ui): restore typecheck — add tanstack deps + fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:pkg": "pnpm -r --filter './packages/**' run build",
     "stub": "pnpm -r --parallel run stub",
     "lint": "eslint . --fix",
-    "typecheck": "pnpm -r --filter './packages/**' --filter '!@unlighthouse/ui' --if-present run typecheck",
+    "typecheck": "pnpm -r --filter './packages/**' --if-present run typecheck",
     "bump": "bumpp package.json packages-aliased/*/package.json packages/*/package.json --commit --push --tag",
     "release": "pnpm build && pnpm bump",
     "test": "vitest",

--- a/packages/core/src/packs/cwv.ts
+++ b/packages/core/src/packs/cwv.ts
@@ -108,10 +108,14 @@ function p75(values: number[]): number | null {
   const pos = (sorted.length - 1) * 0.75
   const lo = Math.floor(pos)
   const hi = Math.ceil(pos)
+  const loVal = sorted[lo]
+  const hiVal = sorted[hi]
+  if (loVal === undefined || hiVal === undefined)
+    return null
   if (lo === hi)
-    return sorted[lo]
+    return loVal
   const frac = pos - lo
-  return sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+  return loVal + (hiVal - loVal) * frac
 }
 
 function metricFromRow(row: ScanRoute, metric: MetricKey): number | null {

--- a/packages/core/src/packs/images.ts
+++ b/packages/core/src/packs/images.ts
@@ -112,7 +112,7 @@ function normaliseImageUrl(url: string): string {
     return `${u.origin}${u.pathname}`
   }
   catch {
-    return url.split('?')[0]
+    return url.split('?')[0] ?? url
   }
 }
 

--- a/packages/core/src/packs/js-bundle.ts
+++ b/packages/core/src/packs/js-bundle.ts
@@ -118,7 +118,7 @@ function normaliseUrl(u: string): string {
     return `${p.origin}${p.pathname}`
   }
   catch {
-    return u.split('?')[0]
+    return u.split('?')[0] ?? u
   }
 }
 

--- a/packages/ui/layers/design-system/components/data/cells/TableScoreTile.vue
+++ b/packages/ui/layers/design-system/components/data/cells/TableScoreTile.vue
@@ -8,7 +8,7 @@ const {
   /** Metric name (e.g. "Performance", "LCP"). Used for the aria-label. */
   label?: string
   /** Background class derived from caller's threshold logic (e.g. scoreBgClass()). */
-  bgClass?: string
+  bgClass?: string | string[] | Record<string, boolean>
 }>()
 
 const status = computed<'good' | 'ni' | 'poor' | 'neutral'>(() => {

--- a/packages/ui/layers/design-system/types/chart.ts
+++ b/packages/ui/layers/design-system/types/chart.ts
@@ -4,7 +4,7 @@ export interface ChartAxis<T extends string | number | Date = string> extends Ax
   tickThreshold?: number
 }
 
-export interface ChartXYAxis<X, Y> {
+export interface ChartXYAxis<X extends string | number | Date, Y extends string | number | Date> {
   x: ChartAxis<X> & {
     position?: 'top' | 'bottom'
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,10 @@
     "postinstall": "nuxi prepare"
   },
   "dependencies": {
+    "@internationalized/date": "catalog:dependencies",
     "@nuxt/ui": "catalog:dependencies",
+    "@tanstack/table-core": "catalog:dependencies",
+    "@tanstack/vue-table": "catalog:dependencies",
     "@unovis/ts": "catalog:dependencies",
     "@unovis/vue": "catalog:dependencies",
     "@vueuse/core": "catalog:dependencies",
@@ -27,6 +30,7 @@
     "lodash-es": "catalog:dependencies",
     "motion-v": "catalog:",
     "nuxt": "catalog:",
+    "scule": "catalog:dependencies",
     "tailwindcss": "catalog:dependencies",
     "three": "catalog:dependencies",
     "ufo": "catalog:dependencies",

--- a/packages/ui/utils/index.ts
+++ b/packages/ui/utils/index.ts
@@ -91,10 +91,11 @@ export function thresholdHex(value: number, good: number, poor: number): string 
   return semanticColors[thresholdToSemantic(value, good, poor)].hex
 }
 
-export function calcTrendPercent(current: number, base: number): number {
+export function calcTrendPercent(current: number, base: number, inverted = false): number {
   if (base === 0)
     return 0
-  return ((current - base) / base) * 100
+  const delta = ((current - base) / base) * 100
+  return inverted ? -delta : delta
 }
 
 export function formatTimeRemaining(ms: number | null): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,12 +112,21 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.4.0
       version: 1.4.0
+    '@internationalized/date':
+      specifier: ^3.12.1
+      version: 3.12.1
     '@nuxt/ui':
       specifier: ^4.7.1
       version: 4.7.1
     '@puppeteer/browsers':
       specifier: ^2.13.2
       version: 2.13.2
+    '@tanstack/table-core':
+      specifier: ^8.21.3
+      version: 8.21.3
+    '@tanstack/vue-table':
+      specifier: ^8.21.3
+      version: 8.21.3
     '@unovis/ts':
       specifier: ^1.6.5
       version: 1.6.5
@@ -226,6 +235,9 @@ catalogs:
     sanitize-filename:
       specifier: ^1.6.4
       version: 1.6.4
+    scule:
+      specifier: ^1.3.0
+      version: 1.3.0
     sitemapper:
       specifier: ^4.1.6
       version: 4.1.6
@@ -567,9 +579,18 @@ importers:
 
   packages/ui:
     dependencies:
+      '@internationalized/date':
+        specifier: catalog:dependencies
+        version: 3.12.1
       '@nuxt/ui':
         specifier: catalog:dependencies
         version: 4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(axios@1.16.0)(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(embla-carousel@8.6.0)(ioredis@5.8.2)(magicast@0.5.1)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-router@4.5.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))(yjs@13.6.29)(zod@4.4.3)
+      '@tanstack/table-core':
+        specifier: catalog:dependencies
+        version: 8.21.3
+      '@tanstack/vue-table':
+        specifier: catalog:dependencies
+        version: 8.21.3(vue@3.5.25(typescript@6.0.3))
       '@unovis/ts':
         specifier: catalog:dependencies
         version: 1.6.5
@@ -594,6 +615,9 @@ importers:
       nuxt:
         specifier: 4.2.2
         version: 4.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@25.7.0)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.4)(rolldown@1.0.0)(rollup@4.53.5)(terser@5.44.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      scule:
+        specifier: catalog:dependencies
+        version: 1.3.0
       tailwindcss:
         specifier: catalog:dependencies
         version: 4.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,8 +60,11 @@ catalog:
 catalogs:
   dependencies:
     '@clack/prompts': ^1.4.0
+    '@internationalized/date': ^3.12.1
     '@nuxt/ui': ^4.7.1
     '@puppeteer/browsers': ^2.13.2
+    '@tanstack/table-core': ^8.21.3
+    '@tanstack/vue-table': ^8.21.3
     '@unovis/ts': ^1.6.5
     '@unovis/vue': ^1.6.5
     '@vueuse/core': ^14.3.0
@@ -98,6 +101,7 @@ catalogs:
     radix3: ^1.1.2
     regexparam: ^3.0.0
     sanitize-filename: ^1.6.4
+    scule: ^1.3.0
     sitemapper: ^4.1.6
     slugify: ^1.6.9
     tailwindcss: ^4.3.0


### PR DESCRIPTION
Closes part of Phase 17 in #349. Adds `@tanstack/vue-table` + `@tanstack/table-core` to `packages/ui` deps and fixes the TS errors so UI typecheck can be re-enabled in CI.

## Summary

- Added `@tanstack/vue-table` + `@tanstack/table-core` (8.21.3) to the `dependencies` catalog and `packages/ui/package.json`. Three design-system table components (`UiTable.vue`, `UiTableHeaderCell.vue`, `UiDataTableSection.vue`) already import them.
- Added `@internationalized/date` + `scule` to the catalog and as explicit `packages/ui` deps — `layers/design-system/utils/format-value.ts` was depending on them transitively through `@nuxt/ui`.
- Dropped the `--filter '!@unlighthouse/ui'` exclusion from the root `typecheck` script.

## Type fixes

`nuxt typecheck` runs with `strict: true` + `noUncheckedIndexedAccess: true`, which surfaced a handful of legitimate issues:

- `packages/core/src/packs/cwv.ts` — `sorted[lo]` / `sorted[hi]` are `number | undefined` under `noUncheckedIndexedAccess`. Hoisted both into locals and returned `null` if either is undefined.
- `packages/core/src/packs/{images,js-bundle}.ts` — `url.split('?')[0]` is `string | undefined`. Added `?? url` fallback.
- `TableScoreTile.vue` — `bgClass` was typed `string` but every caller passes a `string[]`. Widened to `string | string[] | Record<string, boolean>` (Vue's class-binding union).
- `utils/index.ts::calcTrendPercent` — the documented `TableTrendCell.vue` caller already passes an `inverted` third arg; added it to the signature so a positive change on an inverted metric flips sign.
- `layers/design-system/types/chart.ts::ChartXYAxis<X, Y>` — generics weren't constrained, but they get forwarded into `@unovis`'s `ChartAxis<X extends string | number | Date>`. Added matching constraints.

## Test plan

- [x] `pnpm --filter @unlighthouse/ui typecheck` passes cleanly.
- [x] `pnpm typecheck` from repo root passes across all 9 workspace packages.
- [x] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)