### PR TITLE
feat(packs): @unlighthouse-pack/crux scaffold + CrUX client

### DIFF
--- a/packages/core/src/packs/crux.ts
+++ b/packages/core/src/packs/crux.ts
@@ -1,0 +1,380 @@
+// `crux` pack — bridge to Chrome User Experience Report field data.
+//
+// Phase 11 / issue #349 — first iteration. Scope:
+//   - Per-route p75 LCP / CLS / INP from CrUX next to the lab numbers
+//   - Origin-level fallback when a URL has no per-URL CrUX coverage
+//   - Severity bucketed against the Google p75 thresholds (good/ni/poor)
+//
+// Deferred to follow-up PRs (see #349):
+//   - "Lab vs field" gap detector (flag routes where lab says good but
+//      field says poor). Today we surface field data; comparison logic
+//      against lab metrics lives in a future pack pass.
+//   - UI surfacing in `packages/ui/` (results pages, dashboard widgets).
+//
+// Why a Pack and not just the existing CrUX auditor:
+//   - The auditor (`packages/core/src/auditors/crux.ts`) synthesises a full
+//     LHR shaped row from CrUX history — it REPLACES a lab audit when used
+//     as a provider.
+//   - This pack runs ALONGSIDE any auditor (local, psi, …). It enriches
+//     existing ScanRoutes with field p75 numbers so a lab scan can ship
+//     "here's the lab metric AND the CrUX p75 for the same URL" without
+//     having to swap auditors.
+//
+// Network: uses `globalThis.fetch` (Node 20+, undici). No new HTTP deps.
+// Tests stub `globalThis.fetch` to avoid hitting the live API.
+//
+// API key resolution (matches the `psi.apiKey` style — see
+// `packages/contracts/src/config/index.ts` AuditorProvider discriminator
+// where `crux` already declares `apiKey?: string`):
+//   1. Explicit config: `auditor.cruxApiKey` (zod-validated string)
+//   2. Fallback: `process.env.CRUX_API_KEY`
+// If neither is set, the pack short-circuits — the report is still
+// emitted but every finding has `source: 'none'`. This means the pack
+// is safe to register globally; users without a key just see "no
+// field data" instead of a hard failure.
+
+import type { Pack, PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
+import { z } from 'zod'
+
+// ── Thresholds ──────────────────────────────────────────────────────────────
+// web.dev/articles/vitals — kept in sync with the cwv pack's THRESHOLDS table
+// and the CrUX auditor's CWV_THRESHOLDS so a CrUX-sourced row scores the same
+// way the lab row would on the same number.
+
+const THRESHOLDS = {
+  lcp: { good: 2500, poor: 4000 },
+  cls: { good: 0.1, poor: 0.25 },
+  inp: { good: 200, poor: 500 },
+} as const
+
+type MetricKey = keyof typeof THRESHOLDS
+
+// ── Wire-format ─────────────────────────────────────────────────────────────
+
+const FormFactorSchema = z.enum(['PHONE', 'DESKTOP', 'TABLET', 'ALL_FORM_FACTORS'])
+const SourceSchema = z.enum(['url', 'origin', 'none'])
+const SeveritySchema = z.enum(['good', 'needsImprovement', 'poor', 'unknown'])
+
+const CruxFindingSchema = z.object({
+  url: z.string(),
+  formFactor: FormFactorSchema,
+  // CrUX CLS is a raw float (e.g. 0.05) — NOT scaled like lab CLS-units * 1000.
+  // Keep them separate in the report so consumers don't have to guess the unit.
+  lcp_p75: z.number().nullable(),
+  cls_p75: z.number().nullable(),
+  inp_p75: z.number().nullable(),
+  // Which CrUX endpoint produced the row:
+  //   'url'    — per-URL record matched
+  //   'origin' — per-URL missed, origin-level fallback hit
+  //   'none'   — both missed (new site, low traffic) or no API key
+  source: SourceSchema,
+  // Worst severity across the three core metrics. 'unknown' when source='none'.
+  severity: SeveritySchema,
+})
+
+const SeverityCountsSchema = z.object({
+  good: z.number().int().nonnegative(),
+  needsImprovement: z.number().int().nonnegative(),
+  poor: z.number().int().nonnegative(),
+  unknown: z.number().int().nonnegative(),
+})
+
+const CruxReportSchema = z.object({
+  scanId: z.string(),
+  routesAnalysed: z.number().int().nonnegative(),
+  // How many CrUX queries we issued total. routesAnalysed * formFactors in
+  // the simple case; mostly here so consumers can spot "is the pack even
+  // doing anything?" vs "we queried but got nothing back".
+  totalRoutesQueried: z.number().int().nonnegative(),
+  // True iff at least one route fell back to the origin-level record.
+  hasOriginFallback: z.boolean(),
+  severityCounts: SeverityCountsSchema,
+  findings: z.array(CruxFindingSchema),
+})
+
+export type CruxFinding = z.infer<typeof CruxFindingSchema>
+export type CruxReport = z.infer<typeof CruxReportSchema>
+export type CruxFormFactor = z.infer<typeof FormFactorSchema>
+export type CruxSource = z.infer<typeof SourceSchema>
+
+// ── CrUX API client ─────────────────────────────────────────────────────────
+
+const CRUX_ENDPOINT = 'https://chromeuxreport.googleapis.com/v1/records:queryRecord'
+
+// Raw CrUX response shape — only the fields we read. See:
+// https://developer.chrome.com/docs/crux/api/#queryrecord
+interface CruxApiRecord {
+  key: {
+    formFactor?: 'PHONE' | 'DESKTOP' | 'TABLET'
+    origin?: string
+    url?: string
+  }
+  metrics?: {
+    largest_contentful_paint?: { percentiles?: { p75?: number | string } }
+    cumulative_layout_shift?: { percentiles?: { p75?: number | string } }
+    interaction_to_next_paint?: { percentiles?: { p75?: number | string } }
+  }
+}
+
+interface CruxApiEnvelope {
+  record?: CruxApiRecord
+  error?: { code?: number, message?: string, status?: string }
+}
+
+export interface CruxQueryResult {
+  source: CruxSource
+  lcp_p75: number | null
+  cls_p75: number | null
+  inp_p75: number | null
+}
+
+function originOf(url: string): string {
+  const parsed = new URL(url)
+  return `${parsed.protocol}//${parsed.host}`
+}
+
+function readP75(metric: { percentiles?: { p75?: number | string } } | undefined): number | null {
+  const raw = metric?.percentiles?.p75
+  if (raw == null)
+    return null
+  const num = typeof raw === 'string' ? Number.parseFloat(raw) : raw
+  return Number.isFinite(num) ? num : null
+}
+
+function metricsFromRecord(record: CruxApiRecord | undefined): {
+  lcp_p75: number | null
+  cls_p75: number | null
+  inp_p75: number | null
+} {
+  return {
+    lcp_p75: readP75(record?.metrics?.largest_contentful_paint),
+    cls_p75: readP75(record?.metrics?.cumulative_layout_shift),
+    inp_p75: readP75(record?.metrics?.interaction_to_next_paint),
+  }
+}
+
+async function postCrux(
+  apiKey: string,
+  body: Record<string, unknown>,
+): Promise<{ ok: true, record?: CruxApiRecord } | { ok: false, status: number }> {
+  const res = await fetch(`${CRUX_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (res.status === 404)
+    return { ok: false, status: 404 }
+  if (!res.ok) {
+    // 400 from CrUX usually means "no data" (e.g. origin not in dataset).
+    // Treat as a soft miss so the pack continues with origin fallback / none.
+    if (res.status === 400)
+      return { ok: false, status: 400 }
+    const body = await res.text().catch(() => '')
+    throw new Error(`CrUX API ${res.status}: ${body.slice(0, 200)}`)
+  }
+  const json = (await res.json()) as CruxApiEnvelope
+  return { ok: true, record: json.record }
+}
+
+/**
+ * Query the CrUX REST API for a single URL. Returns p75 values plus
+ * a `source` tag indicating which lookup hit:
+ *  - `'url'`    — per-URL record matched
+ *  - `'origin'` — per-URL missed (404 / 400), origin-level fallback hit
+ *  - `'none'`   — both missed, or the response carried no metric payload
+ *
+ * Throws only on unexpected (non-400/404) HTTP errors; per-route misses
+ * are normal and represented in the return value.
+ */
+export async function queryCrux(
+  url: string,
+  formFactor: CruxFormFactor,
+  apiKey: string,
+): Promise<CruxQueryResult> {
+  const formFactorBody = formFactor === 'ALL_FORM_FACTORS' ? {} : { formFactor }
+
+  // 1) Try per-URL record.
+  const urlAttempt = await postCrux(apiKey, { url, ...formFactorBody })
+  if (urlAttempt.ok && urlAttempt.record) {
+    const metrics = metricsFromRecord(urlAttempt.record)
+    if (metrics.lcp_p75 != null || metrics.cls_p75 != null || metrics.inp_p75 != null)
+      return { source: 'url', ...metrics }
+  }
+
+  // 2) Per-URL missed → origin-level fallback.
+  const originAttempt = await postCrux(apiKey, { origin: originOf(url), ...formFactorBody })
+  if (originAttempt.ok && originAttempt.record) {
+    const metrics = metricsFromRecord(originAttempt.record)
+    if (metrics.lcp_p75 != null || metrics.cls_p75 != null || metrics.inp_p75 != null)
+      return { source: 'origin', ...metrics }
+  }
+
+  return { source: 'none', lcp_p75: null, cls_p75: null, inp_p75: null }
+}
+
+// ── Severity ────────────────────────────────────────────────────────────────
+
+function verdictFor(metric: MetricKey, value: number | null): 'good' | 'needsImprovement' | 'poor' | null {
+  if (value == null)
+    return null
+  const t = THRESHOLDS[metric]
+  if (value <= t.good)
+    return 'good'
+  if (value <= t.poor)
+    return 'needsImprovement'
+  return 'poor'
+}
+
+// Severity rank — bigger is worse. The route-level severity is the worst
+// across the three metrics we have data for.
+const SEVERITY_RANK = { good: 0, needsImprovement: 1, poor: 2, unknown: 3 } as const
+
+function worstSeverity(metrics: {
+  lcp_p75: number | null
+  cls_p75: number | null
+  inp_p75: number | null
+}): CruxFinding['severity'] {
+  const verdicts = [
+    verdictFor('lcp', metrics.lcp_p75),
+    verdictFor('cls', metrics.cls_p75),
+    verdictFor('inp', metrics.inp_p75),
+  ].filter((v): v is 'good' | 'needsImprovement' | 'poor' => v != null)
+
+  if (!verdicts.length)
+    return 'unknown'
+  return verdicts.reduce<'good' | 'needsImprovement' | 'poor'>((acc, v) => {
+    return SEVERITY_RANK[v] > SEVERITY_RANK[acc] ? v : acc
+  }, 'good')
+}
+
+// ── Pack config ─────────────────────────────────────────────────────────────
+
+export interface CruxPackOptions {
+  apiKey?: string
+  formFactor?: CruxFormFactor
+}
+
+// Pulled out so tests can override the key resolution path without
+// fiddling with `process.env`.
+function resolveApiKey(opts: CruxPackOptions, ctx: PackReconcileCtx): string | null {
+  // `(ctx as any).config?.auditor?.cruxApiKey` would be the long-term path
+  // once the reconcile ctx carries the full UnlighthouseOptions blob. For
+  // now the auditor config drops into the pack via the explicit `apiKey`
+  // option (host wiring sets it from `auditor.cruxApiKey` / the `crux`
+  // provider). Environment is the user-facing escape hatch.
+  void ctx
+  if (opts.apiKey)
+    return opts.apiKey
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+  return env?.CRUX_API_KEY ?? null
+}
+
+// ── Reconciler ──────────────────────────────────────────────────────────────
+
+function buildPack(options: CruxPackOptions = {}): Pack<CruxReport> {
+  async function reconcile(ctx: PackReconcileCtx): Promise<CruxReport> {
+    const formFactor: CruxFormFactor = options.formFactor ?? 'PHONE'
+    const apiKey = resolveApiKey(options, ctx)
+    const routes = ctx.routes
+    const findings: CruxFinding[] = []
+    const severityCounts = { good: 0, needsImprovement: 0, poor: 0, unknown: 0 }
+    let hasOriginFallback = false
+    let totalRoutesQueried = 0
+
+    // No key → emit a stub report so consumers see "pack ran, no data".
+    if (!apiKey) {
+      for (const r of routes) {
+        findings.push({
+          url: r.url,
+          formFactor,
+          lcp_p75: null,
+          cls_p75: null,
+          inp_p75: null,
+          source: 'none',
+          severity: 'unknown',
+        })
+        severityCounts.unknown++
+      }
+      return {
+        scanId: ctx.scanId,
+        routesAnalysed: routes.length,
+        totalRoutesQueried: 0,
+        hasOriginFallback: false,
+        severityCounts,
+        findings,
+      }
+    }
+
+    // Sequential — keeps us under the CrUX free-tier 150 QPM ceiling in
+    // common cases. A future PR can add bounded parallelism via Promise
+    // pool once we wire CrUX into compare/run.
+    for (const route of routes as ScanRoute[]) {
+      totalRoutesQueried++
+      try {
+        const result = await queryCrux(route.url, formFactor, apiKey)
+        if (result.source === 'origin')
+          hasOriginFallback = true
+        const severity = result.source === 'none'
+          ? 'unknown'
+          : worstSeverity(result)
+        severityCounts[severity]++
+        findings.push({
+          url: route.url,
+          formFactor,
+          lcp_p75: result.lcp_p75,
+          cls_p75: result.cls_p75,
+          inp_p75: result.inp_p75,
+          source: result.source,
+          severity,
+        })
+      }
+      catch (e) {
+        ctx.logger?.warn?.(`crux pack: query failed for ${route.url}: ${(e as Error).message}`)
+        findings.push({
+          url: route.url,
+          formFactor,
+          lcp_p75: null,
+          cls_p75: null,
+          inp_p75: null,
+          source: 'none',
+          severity: 'unknown',
+        })
+        severityCounts.unknown++
+      }
+    }
+
+    return {
+      scanId: ctx.scanId,
+      routesAnalysed: routes.length,
+      totalRoutesQueried,
+      hasOriginFallback,
+      severityCounts,
+      findings,
+    }
+  }
+
+  return {
+    name: 'crux',
+    description: 'Per-route p75 LCP/CLS/INP from the Chrome User Experience Report. Falls back to origin-level data when per-URL coverage is unavailable.',
+    version: '0.1.0',
+    // No auditor requirements — the pack queries CrUX directly during
+    // reconcile and doesn't depend on any LH audit being present.
+    auditors: [],
+    reconciler: reconcile,
+    reportSchema: CruxReportSchema,
+  }
+}
+
+/**
+ * Default registered pack instance. Host wiring (CLI / server) can call
+ * `createCruxPack({ apiKey })` to override the key from auditor config.
+ */
+export const cruxPack: Pack<CruxReport> = buildPack()
+
+/**
+ * Factory for hosts that want to pass an explicit API key / formFactor
+ * (e.g. CLI reads `auditor.cruxApiKey` from the resolved config).
+ */
+export function createCruxPack(options: CruxPackOptions = {}): Pack<CruxReport> {
+  return buildPack(options)
+}

--- a/packages/core/src/packs/index.ts
+++ b/packages/core/src/packs/index.ts
@@ -3,6 +3,7 @@
 
 import type { Pack } from '@unlighthouse/contracts'
 import { a11yQuickWinsPack } from './a11y-quick-wins'
+import { cruxPack } from './crux'
 import { cwvPack } from './cwv'
 import { imagesPack } from './images'
 import { jsBundlePack } from './js-bundle'
@@ -11,6 +12,8 @@ import { seoBasicsPack } from './seo-basics'
 
 export { a11yQuickWinsPack } from './a11y-quick-wins'
 export type { A11yFinding, A11yReport } from './a11y-quick-wins'
+export { createCruxPack, cruxPack, queryCrux } from './crux'
+export type { CruxFinding, CruxFormFactor, CruxReport, CruxSource } from './crux'
 export { cwvPack } from './cwv'
 export type { CwvFix, CwvReport, MetricSnapshot } from './cwv'
 export { imagesPack } from './images'
@@ -27,6 +30,7 @@ export type { SeoFinding, SeoReport, SeoRouteCheck } from './seo-basics'
 export const builtInPacks: Record<string, Pack<unknown>> = {
   [overviewPack.name]: overviewPack as Pack<unknown>,
   [cwvPack.name]: cwvPack as Pack<unknown>,
+  [cruxPack.name]: cruxPack as Pack<unknown>,
   [imagesPack.name]: imagesPack as Pack<unknown>,
   [a11yQuickWinsPack.name]: a11yQuickWinsPack as Pack<unknown>,
   [jsBundlePack.name]: jsBundlePack as Pack<unknown>,

--- a/test/packs-crux.test.ts
+++ b/test/packs-crux.test.ts
@@ -1,0 +1,296 @@
+// Phase 11 / issue #349 — crux pack unit tests.
+//
+// Covers:
+//   - URL-level CrUX hit
+//   - URL miss → origin fallback (records `hasOriginFallback`)
+//   - Complete miss (both endpoints 404) → severity 'unknown'
+//   - Severity bucketing against Google's p75 thresholds:
+//       LCP: good ≤2500, ni ≤4000, poor >4000
+//       CLS: good ≤0.1,  ni ≤0.25, poor >0.25
+//       INP: good ≤200,  ni ≤500,  poor >500
+//   - No API key → stub report (all findings source='none')
+//
+// All HTTP traffic stubbed with vi.spyOn(globalThis, 'fetch') — never hits the
+// real CrUX API.
+
+import type { PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
+import { createCruxPack, cruxPack, queryCrux } from '@unlighthouse/core/packs/crux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_ENV_KEY = process.env.CRUX_API_KEY
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_ENV_KEY === undefined)
+    delete process.env.CRUX_API_KEY
+  else
+    process.env.CRUX_API_KEY = ORIGINAL_ENV_KEY
+  vi.restoreAllMocks()
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function buildRoute(url: string): ScanRoute {
+  return {
+    scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    url,
+    device: 'mobile',
+    path: new URL(url).pathname,
+    routeName: null,
+    scorePerformance: 0.9,
+    scoreAccessibility: 0.95,
+    scoreSeo: 0.85,
+    scoreBestPractices: 0.9,
+    lcp: 1200,
+    cls: 0.01,
+    inp: 100,
+    fcp: 1000,
+    ttfb: 200,
+    tbt: 50,
+    si: 1500,
+    lighthouseVersion: '12.0.0',
+    capturedAt: new Date().toISOString(),
+    lhrBlobKey: 'scans/x/lhr/x.json',
+    reportBlobKey: null,
+  } as ScanRoute
+}
+
+function ctxFor(routes: ScanRoute[]): PackReconcileCtx {
+  return {
+    scanId: routes[0]?.scanId ?? ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as never),
+    routes,
+  }
+}
+
+interface CruxMetrics {
+  lcp?: number
+  cls?: number
+  inp?: number
+}
+
+function cruxRecord(metrics: CruxMetrics, key: { url?: string, origin?: string }) {
+  return {
+    record: {
+      key: { formFactor: 'PHONE' as const, ...key },
+      metrics: {
+        ...(metrics.lcp != null && {
+          largest_contentful_paint: { percentiles: { p75: metrics.lcp } },
+        }),
+        ...(metrics.cls != null && {
+          // CrUX serialises CLS as a stringified float — the client parses it.
+          cumulative_layout_shift: { percentiles: { p75: String(metrics.cls) } },
+        }),
+        ...(metrics.inp != null && {
+          interaction_to_next_paint: { percentiles: { p75: metrics.inp } },
+        }),
+      },
+    },
+  }
+}
+
+// ── queryCrux client ────────────────────────────────────────────────────────
+
+describe('queryCrux', () => {
+  it('returns source=url when the per-URL record matches', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(cruxRecord({ lcp: 1800, cls: 0.05, inp: 150 }, { url: 'https://example.com/' })),
+    ) as never
+
+    const result = await queryCrux('https://example.com/', 'PHONE', 'fake-key')
+    expect(result).toEqual({ source: 'url', lcp_p75: 1800, cls_p75: 0.05, inp_p75: 150 })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to origin when URL request 404s', async () => {
+    let call = 0
+    globalThis.fetch = vi.fn(async (_url, init?: { body?: string }) => {
+      call++
+      const body = JSON.parse(init?.body as string) as { url?: string, origin?: string }
+      if (call === 1) {
+        expect(body.url).toBe('https://example.com/missing')
+        return new Response(JSON.stringify({ error: { code: 404, message: 'not found' } }), { status: 404 })
+      }
+      expect(body.origin).toBe('https://example.com')
+      expect(body.url).toBeUndefined()
+      return jsonResponse(cruxRecord({ lcp: 2200, cls: 0.08, inp: 180 }, { origin: 'https://example.com' }))
+    }) as never
+
+    const result = await queryCrux('https://example.com/missing', 'PHONE', 'fake-key')
+    expect(result).toEqual({ source: 'origin', lcp_p75: 2200, cls_p75: 0.08, inp_p75: 180 })
+    expect(call).toBe(2)
+  })
+
+  it('returns source=none when both URL and origin miss', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { code: 404 } }), { status: 404 }),
+    ) as never
+
+    const result = await queryCrux('https://unknown.example/', 'PHONE', 'fake-key')
+    expect(result).toEqual({ source: 'none', lcp_p75: null, cls_p75: null, inp_p75: null })
+  })
+
+  it('treats a 400 (origin not in dataset) as a soft miss, not a throw', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { code: 400, message: 'chrome ux report data not found' } }), { status: 400 }),
+    ) as never
+
+    const result = await queryCrux('https://obscure.example/', 'PHONE', 'fake-key')
+    expect(result.source).toBe('none')
+  })
+
+  it('throws on unexpected non-2xx (e.g. 401 auth error)', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('{"error":"unauthorized"}', { status: 401 }),
+    ) as never
+
+    await expect(queryCrux('https://example.com/', 'PHONE', 'bad-key')).rejects.toThrow(/401/)
+  })
+})
+
+// ── cruxPack reconciler ─────────────────────────────────────────────────────
+
+describe('cruxPack reconciler', () => {
+  beforeEach(() => {
+    delete process.env.CRUX_API_KEY
+  })
+
+  it('emits stub findings (source=none) when no API key is configured', async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as never
+    const routes = [buildRoute('https://example.com/')]
+    const report = await cruxPack.reconciler(ctxFor(routes))
+
+    expect(report.routesAnalysed).toBe(1)
+    expect(report.totalRoutesQueried).toBe(0)
+    expect(report.findings).toHaveLength(1)
+    expect(report.findings[0]).toMatchObject({ source: 'none', severity: 'unknown' })
+    expect(report.severityCounts.unknown).toBe(1)
+    // Never reached out to the network.
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('reads CRUX_API_KEY from process.env as a fallback', async () => {
+    process.env.CRUX_API_KEY = 'env-key'
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(cruxRecord({ lcp: 1500, cls: 0.05, inp: 120 }, { url: 'https://example.com/' })),
+    ) as never
+
+    const report = await cruxPack.reconciler(ctxFor([buildRoute('https://example.com/')]))
+    expect(report.totalRoutesQueried).toBe(1)
+    expect(report.findings[0]?.source).toBe('url')
+  })
+
+  it('assigns severity from Google p75 thresholds — good / needsImprovement / poor', async () => {
+    // Three routes, each landing in a different bucket so we can pin the
+    // boundary behaviour in one go.
+    const fetchSpy = vi.fn(async (_url, init?: { body?: string }) => {
+      const body = JSON.parse(init?.body as string) as { url?: string }
+      // "/good" — all metrics under the good ceiling.
+      if (body.url === 'https://example.com/good')
+        return jsonResponse(cruxRecord({ lcp: 1500, cls: 0.05, inp: 150 }, { url: body.url }))
+      // "/ni" — at least one metric in the needs-improvement band, none poor.
+      if (body.url === 'https://example.com/ni')
+        return jsonResponse(cruxRecord({ lcp: 3200, cls: 0.05, inp: 150 }, { url: body.url }))
+      // "/poor" — at least one metric past the poor threshold.
+      if (body.url === 'https://example.com/poor')
+        return jsonResponse(cruxRecord({ lcp: 1500, cls: 0.05, inp: 800 }, { url: body.url }))
+      return new Response('{}', { status: 404 })
+    })
+    globalThis.fetch = fetchSpy as never
+
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler(ctxFor([
+      buildRoute('https://example.com/good'),
+      buildRoute('https://example.com/ni'),
+      buildRoute('https://example.com/poor'),
+    ]))
+
+    const byUrl = Object.fromEntries(report.findings.map(f => [f.url, f]))
+    expect(byUrl['https://example.com/good']?.severity).toBe('good')
+    expect(byUrl['https://example.com/ni']?.severity).toBe('needsImprovement')
+    expect(byUrl['https://example.com/poor']?.severity).toBe('poor')
+    expect(report.severityCounts).toMatchObject({ good: 1, needsImprovement: 1, poor: 1, unknown: 0 })
+  })
+
+  it('records hasOriginFallback when at least one route falls back', async () => {
+    let call = 0
+    globalThis.fetch = vi.fn(async (_url, init?: { body?: string }) => {
+      const body = JSON.parse(init?.body as string) as { url?: string, origin?: string }
+      call++
+      if (body.url === 'https://example.com/hit')
+        return jsonResponse(cruxRecord({ lcp: 1500 }, { url: body.url }))
+      if (body.url === 'https://example.com/miss')
+        return new Response('{}', { status: 404 })
+      // Origin fallback for /miss.
+      if (body.origin === 'https://example.com')
+        return jsonResponse(cruxRecord({ lcp: 2800, cls: 0.05, inp: 150 }, { origin: body.origin }))
+      return new Response('{}', { status: 404 })
+    }) as never
+
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler(ctxFor([
+      buildRoute('https://example.com/hit'),
+      buildRoute('https://example.com/miss'),
+    ]))
+    expect(report.hasOriginFallback).toBe(true)
+    const miss = report.findings.find(f => f.url === 'https://example.com/miss')
+    expect(miss?.source).toBe('origin')
+    expect(miss?.severity).toBe('needsImprovement') // LCP 2800 > 2500
+    const hit = report.findings.find(f => f.url === 'https://example.com/hit')
+    expect(hit?.source).toBe('url')
+    expect(call).toBeGreaterThanOrEqual(3)
+  })
+
+  it('marks routes as source=none when both CrUX endpoints miss', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('{}', { status: 404 })) as never
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler(ctxFor([buildRoute('https://example.com/missing')]))
+    expect(report.hasOriginFallback).toBe(false)
+    expect(report.findings[0]?.source).toBe('none')
+    expect(report.findings[0]?.severity).toBe('unknown')
+    expect(report.severityCounts.unknown).toBe(1)
+  })
+
+  it('catches per-route errors and continues, marking the failed row unknown', async () => {
+    let call = 0
+    globalThis.fetch = vi.fn(async (_url, init?: { body?: string }) => {
+      call++
+      const body = JSON.parse(init?.body as string) as { url?: string, origin?: string }
+      if (body.url === 'https://example.com/boom')
+        return new Response('{"error":"server"}', { status: 500 })
+      if (body.url === 'https://example.com/ok')
+        return jsonResponse(cruxRecord({ lcp: 1500, cls: 0.05, inp: 150 }, { url: body.url }))
+      return new Response('{}', { status: 404 })
+    }) as never
+
+    const warns: string[] = []
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler({
+      ...ctxFor([buildRoute('https://example.com/boom'), buildRoute('https://example.com/ok')]),
+      logger: { info: () => {}, warn: (m: string) => warns.push(m), error: () => {}, debug: () => {} } as never,
+    })
+    expect(report.findings).toHaveLength(2)
+    expect(report.findings.find(f => f.url === 'https://example.com/boom')?.source).toBe('none')
+    expect(report.findings.find(f => f.url === 'https://example.com/ok')?.source).toBe('url')
+    expect(warns.some(m => m.includes('crux pack: query failed'))).toBe(true)
+    expect(call).toBeGreaterThanOrEqual(2)
+  })
+
+  it('validates the report payload against the zod schema', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(cruxRecord({ lcp: 1500, cls: 0.05, inp: 150 }, { url: 'https://example.com/' })),
+    ) as never
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler(ctxFor([buildRoute('https://example.com/')]))
+    const parsed = pack.reportSchema.safeParse(report)
+    expect(parsed.success).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
First-iteration scaffold for Phase 11 / #349 — a Pack that bridges to the Chrome User Experience Report (CrUX) field data alongside the existing lab metrics.

- `packages/core/src/packs/crux.ts` — pack module containing:
  - `queryCrux(url, formFactor, apiKey)` REST client (uses `globalThis.fetch`, no new HTTP deps)
  - URL-level lookup with origin-level fallback on `400` / `404`
  - `CruxReportSchema` Zod schema mirroring the `cwv` pack's shape (`scanId`, `routesAnalysed`, `totalRoutesQueried`, `hasOriginFallback`, `severityCounts`, `findings`)
  - Severity bucketing against Google's p75 thresholds (LCP 2500/4000, CLS 0.1/0.25, INP 200/500)
  - API key resolution: explicit `createCruxPack({ apiKey })` option, or `process.env.CRUX_API_KEY` fallback — matches the `psi.apiKey` pattern
- Registration in `packages/core/src/packs/index.ts` so `getPack('crux')` works
- `test/packs-crux.test.ts` — 12 unit tests; all network mocked via `vi.spyOn(globalThis, 'fetch')`

## Notes
- CLS stays in **raw float units** (e.g. `0.05`) — *not* scaled `* 1000` like lab CLS-units. Documented in the schema comments so downstream consumers don't guess the unit.
- The pack is safe to register globally: no API key → emits a stub report with all findings tagged `source: 'none'`, never hits the network.
- Sequential per-route queries (keeps under CrUX's 150 QPM free-tier ceiling). Parallelism can land when the pack is wired into `compare` / `run`.

## Deferred to follow-up PRs (noted in TODOs)
- Lab-vs-field gap detector (flag routes where lab says good but field says poor)
- UI surfacing in `packages/ui/` (results pages, dashboard widgets)
- CLI / compare wiring so the pack auto-runs when an API key is present

Refs #349

## Test plan
- [x] `pnpm vitest run test/packs-crux.test.ts` — 12 passing
- [x] `pnpm --filter @unlighthouse/core typecheck` — clean
- [x] `pnpm typecheck` (all packages) — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run test/packs-crux.test.ts test/pack-reconciled-migration.test.ts test/crux-lhr-pipeline.test.ts` — 20 passing (no regressions in adjacent suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)