### PR TITLE
feat(export): device column in CSV + JSON exports

### DIFF
--- a/packages/contracts/src/types/index.ts
+++ b/packages/contracts/src/types/index.ts
@@ -140,6 +140,14 @@ export interface UnlighthouseRouteReport {
    * The SEO meta-data, only set once the html payload has been extracted and passed.
    */
   seo?: HTMLExtractPayload
+  /**
+   * D-029: device form-factor this row was audited under. Multi-device matrix
+   * scans emit one report per (url, device); single-device scans land here as
+   * `'mobile'` or `'desktop'` matching the scan's only device. Optional so
+   * legacy fixtures and in-memory adapters that don't track device still
+   * type-check.
+   */
+  device?: 'mobile' | 'desktop'
 }
 
 export interface HTMLExtractPayload {

--- a/packages/unlighthouse/src/cli/ci.ts
+++ b/packages/unlighthouse/src/cli/ci.ts
@@ -73,7 +73,17 @@ async function run() {
     // Hydrate UnlighthouseRouteReport shape from `storage.routes` + LHR blobs;
     // hand off to the existing reporter pipeline (jsonSimple/jsonExpanded/csv).
     const { items } = await unlighthouse.handlerCtx.storage.routes.listForScan(scanId as never, { pageSize: 10_000 })
-    const hydrated = await Promise.all(items.map(async (r) => {
+    // D-029: when `--device` narrows the run to a subset, also narrow the
+    // export so consumers only see the rows they asked for. Matrix scans
+    // (no narrowing, or narrowing to multiple devices) export every (url,
+    // device) row — one CSV/JSON row each.
+    const exportDeviceFilter = deviceOverride && deviceOverride.length > 0
+      ? new Set(deviceOverride)
+      : null
+    const filtered = exportDeviceFilter
+      ? items.filter(r => exportDeviceFilter.has(r.device as never))
+      : items
+    const hydrated = await Promise.all(filtered.map(async (r) => {
       const gz = r.lhrBlobKey ? await unlighthouse.handlerCtx.storage.blobs.get(r.lhrBlobKey) : null
       if (!gz)
         return null
@@ -89,6 +99,10 @@ async function run() {
         : 0
       return {
         route: { path: r.path, url: r.url },
+        // D-029: each storage row is one (url, device) audit. Propagate the
+        // device through to the reporters so multi-device matrix scans emit
+        // distinct rows per form-factor instead of collapsing.
+        device: r.device,
         report: {
           score: scoreAverage,
           categories: categoriesArr,

--- a/packages/unlighthouse/src/reporters/csvExpanded.ts
+++ b/packages/unlighthouse/src/reporters/csvExpanded.ts
@@ -2,7 +2,7 @@ import type { UnlighthouseTabs } from '../index.ts'
 import type { UnlighthouseRouteReport } from '../types'
 import type { ReporterConfig } from './types'
 import { get } from 'lodash-es'
-import { csvSimpleFormat } from './csvSimple'
+import { appendDeviceColumn, csvSimpleFormat } from './csvSimple'
 
 type ReportWithLighthouse = UnlighthouseRouteReport & {
   report: NonNullable<UnlighthouseRouteReport['report']>
@@ -25,8 +25,12 @@ function columnKeys(columns: ReporterConfig['columns']): UnlighthouseTabs[] {
 export function reportCSVExpanded(reports: ReportWithLighthouse[], { columns }: ReporterConfig = {}): string {
   const { headers, body } = csvSimpleFormat(reports)
   const firstReport = reports[0]
-  if (!firstReport || !columns)
+  if (!firstReport || !columns) {
+    // D-029: device column belongs at the end of the row even when no
+    // expanded columns are configured.
+    appendDeviceColumn(headers, body, reports)
     return [headers.join(','), ...body.map(row => row.join(','))].join('\n')
+  }
 
   for (const k of columnKeys(columns)) {
     // already have overview
@@ -74,6 +78,10 @@ export function reportCSVExpanded(reports: ReportWithLighthouse[], { columns }: 
       )
     }
   })
+
+  // D-029: device column appended last so any future expanded columns can
+  // be added before it without breaking parsers anchored at the end.
+  appendDeviceColumn(headers, body, reports)
 
   return [
     headers.join(','),

--- a/packages/unlighthouse/src/reporters/csvSimple.ts
+++ b/packages/unlighthouse/src/reporters/csvSimple.ts
@@ -46,8 +46,28 @@ export function csvSimpleFormat(reports: ReportWithLighthouse[]): { headers: str
   }
 }
 
+// D-029: append the device column last so the existing
+// `URL,Score,<categories>[,<expanded columns>]` prefix is preserved for
+// callers parsing positional indices. Mutates `headers` + `body` in place
+// — both `reportCSVSimple` and `reportCSVExpanded` call this after their
+// own column work, keeping device as the rightmost column.
+export function appendDeviceColumn(
+  headers: string[],
+  body: Array<Array<string | number | boolean>>,
+  reports: Array<{ device?: string }>,
+): void {
+  headers.push('Device')
+  reports.forEach((r, i) => {
+    if (!body[i])
+      return
+    body[i].push(escapeValueForCsv(r.device ?? ''))
+  })
+}
+
 export function reportCSVSimple(reports: UnlighthouseRouteReport[]): string {
-  const { headers, body } = csvSimpleFormat(reports.filter(hasLighthouseReport))
+  const filtered = reports.filter(hasLighthouseReport)
+  const { headers, body } = csvSimpleFormat(filtered)
+  appendDeviceColumn(headers, body, filtered)
   return [
     headers.join(','),
     ...body.map(row => row.join(',')),

--- a/packages/unlighthouse/src/reporters/index.ts
+++ b/packages/unlighthouse/src/reporters/index.ts
@@ -22,7 +22,10 @@ export function generateReportPayload(reporter: 'csvSimple' | 'csv', reports: Un
 export function generateReportPayload(reporter: 'csvExpanded', reports: UnlighthouseRouteReport[], config?: ReporterConfig): string
 export function generateReportPayload(reporter: string, _reports: UnlighthouseRouteReport[], config?: ReporterConfig): any {
   const reports = _reports
-    .sort((a, b) => a.route.path.localeCompare(b.route.path))
+    // D-029: matrix scans emit two rows per path; secondary sort by device
+    // keeps `desktop` ahead of `mobile` for the same path so the CSV / JSON
+    // ordering is deterministic across runs.
+    .sort((a, b) => a.route.path.localeCompare(b.route.path) || (a.device ?? '').localeCompare(b.device ?? ''))
     .filter(hasLighthouseReport)
 
   if (reporter.startsWith('json')) {

--- a/packages/unlighthouse/src/reporters/jsonExpanded.ts
+++ b/packages/unlighthouse/src/reporters/jsonExpanded.ts
@@ -62,15 +62,24 @@ export function reportJsonExpanded(reports: UnlighthouseRouteReport[]): ReportJs
             },
           }
         }, {})
-      return <ExpandedRouteReport>{
+      // D-029: device dimension carried through so the expanded JSON
+      // surfaces matrix scans as one route entry per (path, device).
+      // Field is only set when present on the input to keep legacy
+      // single-device output unchanged.
+      const row = <ExpandedRouteReport>{
         path: report.route.path,
         score: report.report?.score,
         categories,
         metrics,
       }
+      if (report.device)
+        row.device = report.device
+      return row
     })
-    // make the list ordering consistent
-    .sort((a, b) => a.path.localeCompare(b.path))
+    // make the list ordering consistent. Stable secondary sort by device
+    // so multi-device matrix scans always emit `desktop` before `mobile`
+    // (alphabetical) for the same path.
+    .sort((a, b) => a.path.localeCompare(b.path) || (a.device ?? '').localeCompare(b.device ?? ''))
 
   const averageCategories = extractCategoriesFromRoutes(routes)
   const averageMetrics = extractMetricsFromRoutes(routes)

--- a/packages/unlighthouse/src/reporters/jsonSimple.ts
+++ b/packages/unlighthouse/src/reporters/jsonSimple.ts
@@ -8,10 +8,16 @@ export function reportJsonSimple(reports: UnlighthouseRouteReport[]): ReportJson
       report.report?.categories.forEach((category) => {
         scores[category.key] = category.score ?? 0
       })
-      return <SimpleRouteReport> {
+      // D-029: include device when present so multi-device matrix scans
+      // emit one entry per (path, device). Omitted for legacy single-device
+      // fixtures so existing snapshots stay stable.
+      const row = <SimpleRouteReport> {
         path: report.route.path,
         score: report.report?.score,
         ...scores,
       }
+      if (report.device)
+        row.device = report.device
+      return row
     })
 }

--- a/packages/unlighthouse/src/reporters/types.ts
+++ b/packages/unlighthouse/src/reporters/types.ts
@@ -15,6 +15,12 @@ export interface MetricScore {
 export interface SimpleRouteReport {
   path: string
   score?: number | string | null | undefined
+  /**
+   * D-029: device form-factor for the audited row. Only emitted when the
+   * source report carries it — legacy single-device callers still get the
+   * historical `path,score,<categories>` shape.
+   */
+  device?: 'mobile' | 'desktop'
   [key: string]: string | number | null | undefined
 }
 
@@ -27,6 +33,10 @@ export interface ExpandedRouteReport {
   metrics: {
     [key: string]: MetricScore
   }
+  /**
+   * D-029: device form-factor for the audited row. See `SimpleRouteReport.device`.
+   */
+  device?: 'mobile' | 'desktop'
 }
 
 export interface CategoryAverageScore {

--- a/test/csv-reports.test.ts
+++ b/test/csv-reports.test.ts
@@ -6,38 +6,96 @@ import _lighthouseReport from './fixtures/lighthouseReport.mjs'
 
 const lighthouseReport = _lighthouseReport as any as UnlighthouseRouteReport[]
 
+// D-029 matrix fixture: minimal fan-out — same path scanned under mobile +
+// desktop, both with the same category set, but distinct scores so we can
+// see each row is preserved (not collapsed). Deliberately tiny so the
+// snapshot stays readable.
+function makeMatrixReport(path: string, device: 'mobile' | 'desktop', perf: number, a11y: number): UnlighthouseRouteReport {
+  return {
+    tasks: {} as any,
+    artifactPath: '',
+    artifactUrl: '',
+    reportId: `${path}-${device}`,
+    route: { id: path, url: `https://example.com${path}`, $url: new URL(`https://example.com${path}`), path, definition: { name: '_index', path } } as any,
+    device,
+    report: {
+      score: (perf + a11y) / 2,
+      categories: [
+        { key: 'performance', id: 'performance', title: 'Performance', score: perf },
+        { key: 'accessibility', id: 'accessibility', title: 'Accessibility', score: a11y },
+      ],
+      audits: {},
+    } as any,
+  }
+}
+
+const matrixReports: UnlighthouseRouteReport[] = [
+  makeMatrixReport('/', 'mobile', 0.85, 0.92),
+  makeMatrixReport('/', 'desktop', 0.97, 0.92),
+  makeMatrixReport('/about', 'mobile', 0.78, 0.88),
+  makeMatrixReport('/about', 'desktop', 0.95, 0.88),
+]
+
 describe('csv reports', () => {
   it('basic', () => {
     const actual = generateReportPayload('csv', lighthouseReport)
     expect(actual).toMatchInlineSnapshot(`
-      "URL,Score,Performance,Accessibility,Best Practices,SEO
-      "/",98,100,100,100,92
-      "/blog",97,100,97,100,92
-      "/blog/2023-february",97,100,97,100,92
-      "/blog/2023-march",97,100,97,100,92
-      "/blog/how-the-heck-does-vite-work",97,100,97,100,92
-      "/blog/modern-package-development",95,100,97,92,92
-      "/blog/vue-automatic-component-imports",97,100,97,100,92
-      "/projects",97,100,97,100,92
-      "/sponsors",97,100,97,100,92
-      "/talks",97,100,97,100,92"
+      "URL,Score,Performance,Accessibility,Best Practices,SEO,Device
+      "/",98,100,100,100,92,""
+      "/blog",97,100,97,100,92,""
+      "/blog/2023-february",97,100,97,100,92,""
+      "/blog/2023-march",97,100,97,100,92,""
+      "/blog/how-the-heck-does-vite-work",97,100,97,100,92,""
+      "/blog/modern-package-development",95,100,97,92,92,""
+      "/blog/vue-automatic-component-imports",97,100,97,100,92,""
+      "/projects",97,100,97,100,92,""
+      "/sponsors",97,100,97,100,92,""
+      "/talks",97,100,97,100,92,"""
     `)
   })
 
   it('expanded', () => {
     const actual = generateReportPayload('csvExpanded', lighthouseReport, { columns: DefaultColumns })
     expect(actual).toMatchInlineSnapshot(`
-      "URL,Score,Performance,Accessibility,Best Practices,SEO,FCP,LCP,CLS,FID,TBT,Color Contrast,Headings,Image Alts,Link Names,Errors,Inspector Issues,Images Responsive,Image Aspect Ratio,Indexable
-      "/",98,100,100,100,92,140.98,279.17,0,68.82,0,1,1,1,1,1,1,1,1,1
-      "/blog",97,100,97,100,92,149.49,271.21,0,51.46,0,0,1,1,1,1,1,1,1,1
-      "/blog/2023-february",97,100,97,100,92,210.35,350.38,0,61.1,0,0,1,1,1,1,1,1,1,1
-      "/blog/2023-march",97,100,97,100,92,392.09,486.98,0,44.92,0,0,1,1,1,1,1,1,1,1
-      "/blog/how-the-heck-does-vite-work",97,100,97,100,92,205.31,332.11,0,52.51,2.51,0,1,1,1,1,1,1,1,1
-      "/blog/modern-package-development",95,100,97,92,92,422.26,568.43,0,55.73,5.73,0,1,1,1,1,1,1,1,1
-      "/blog/vue-automatic-component-imports",97,100,97,100,92,225.64,507.04,0,91.53,81.86,0,1,1,1,1,1,1,1,1
-      "/projects",97,100,97,100,92,236.85,391.93,0,75.74,25.74,0,1,1,1,1,1,1,1,1
-      "/sponsors",97,100,97,100,92,226.68,405.03,0,58.72,0,0,1,1,1,1,1,1,1,1
-      "/talks",97,100,97,100,92,224.75,244.35,0,33.67,0,0,1,1,1,1,1,1,1,1"
+      "URL,Score,Performance,Accessibility,Best Practices,SEO,FCP,LCP,CLS,FID,TBT,Color Contrast,Headings,Image Alts,Link Names,Errors,Inspector Issues,Images Responsive,Image Aspect Ratio,Indexable,Device
+      "/",98,100,100,100,92,140.98,279.17,0,68.82,0,1,1,1,1,1,1,1,1,1,""
+      "/blog",97,100,97,100,92,149.49,271.21,0,51.46,0,0,1,1,1,1,1,1,1,1,""
+      "/blog/2023-february",97,100,97,100,92,210.35,350.38,0,61.1,0,0,1,1,1,1,1,1,1,1,""
+      "/blog/2023-march",97,100,97,100,92,392.09,486.98,0,44.92,0,0,1,1,1,1,1,1,1,1,""
+      "/blog/how-the-heck-does-vite-work",97,100,97,100,92,205.31,332.11,0,52.51,2.51,0,1,1,1,1,1,1,1,1,""
+      "/blog/modern-package-development",95,100,97,92,92,422.26,568.43,0,55.73,5.73,0,1,1,1,1,1,1,1,1,""
+      "/blog/vue-automatic-component-imports",97,100,97,100,92,225.64,507.04,0,91.53,81.86,0,1,1,1,1,1,1,1,1,""
+      "/projects",97,100,97,100,92,236.85,391.93,0,75.74,25.74,0,1,1,1,1,1,1,1,1,""
+      "/sponsors",97,100,97,100,92,226.68,405.03,0,58.72,0,0,1,1,1,1,1,1,1,1,""
+      "/talks",97,100,97,100,92,224.75,244.35,0,33.67,0,0,1,1,1,1,1,1,1,1,"""
+    `)
+  })
+
+  // D-029 Phase 8 — matrix scans fan-out into one row per (url, device) and
+  // the device column populates rather than being empty. Order is `desktop`
+  // before `mobile` for the same path (alphabetical secondary sort in
+  // `generateReportPayload`).
+  it('preserves multi-device matrix as distinct rows with populated device column', () => {
+    const actual = generateReportPayload('csv', matrixReports)
+    expect(actual).toMatchInlineSnapshot(`
+      "URL,Score,Performance,Accessibility,Device
+      "/",95,97,92,"desktop"
+      "/",89,85,92,"mobile"
+      "/about",92,95,88,"desktop"
+      "/about",83,78,88,"mobile""
+    `)
+  })
+
+  it('matrix scans keep both devices in csvExpanded without extra columns', () => {
+    const actual = generateReportPayload('csvExpanded', matrixReports)
+    // No `columns` config — exercises the early-return branch in
+    // `reportCSVExpanded` to confirm device still lands last.
+    expect(actual).toMatchInlineSnapshot(`
+      "URL,Score,Performance,Accessibility,Device
+      "/",95,97,92,"desktop"
+      "/",89,85,92,"mobile"
+      "/about",92,95,88,"desktop"
+      "/about",83,78,88,"mobile""
     `)
   })
 })

--- a/test/json-reports.test.ts
+++ b/test/json-reports.test.ts
@@ -5,6 +5,35 @@ import _lighthouseReport from './fixtures/lighthouseReport.mjs'
 
 const lighthouseReport = _lighthouseReport as any as UnlighthouseRouteReport[]
 
+// D-029: synthetic matrix fixture — same path on two devices — so the
+// JSON exports can be asserted as one entry per (path, device) without
+// pulling a 36k-line fixture.
+function makeMatrixReport(path: string, device: 'mobile' | 'desktop', perf: number, seo: number): UnlighthouseRouteReport {
+  return {
+    tasks: {} as any,
+    artifactPath: '',
+    artifactUrl: '',
+    reportId: `${path}-${device}`,
+    route: { id: path, url: `https://example.com${path}`, $url: new URL(`https://example.com${path}`), path, definition: { name: '_index', path } } as any,
+    device,
+    report: {
+      score: (perf + seo) / 2,
+      categories: [
+        { key: 'performance', id: 'performance', title: 'Performance', score: perf },
+        { key: 'seo', id: 'seo', title: 'SEO', score: seo },
+      ],
+      audits: {
+        'largest-contentful-paint': { id: 'largest-contentful-paint', title: 'LCP', description: 'd', numericUnit: 'ms', numericValue: 1234, displayValue: '1.2 s' } as any,
+      },
+    } as any,
+  }
+}
+
+const matrixReports: UnlighthouseRouteReport[] = [
+  makeMatrixReport('/', 'mobile', 0.8, 0.9),
+  makeMatrixReport('/', 'desktop', 0.95, 0.9),
+]
+
 describe('reporter', () => {
   it('simple json', () => {
     const actual = generateReportPayload('jsonSimple', lighthouseReport)
@@ -136,6 +165,41 @@ describe('reporter', () => {
     expect(actual.routes[0].categories.accessibility).toBeDefined()
     expect(actual.routes[0].categories.seo).toBeDefined()
     expect(actual.routes[0].categories['best-practices']).toBeDefined()
+  })
+
+  // D-029 Phase 8 — multi-device matrix scans surface one route entry per
+  // (path, device) with the device field populated. Single-device reports
+  // omit the field (back-compat with legacy fixtures asserted in the
+  // snapshots above).
+  it('jsonSimple emits one entry per (path, device) for matrix scans', () => {
+    const actual = generateReportPayload('jsonSimple', matrixReports)
+    expect(actual).toHaveLength(2)
+    const desktop = actual.find(r => r.device === 'desktop')
+    const mobile = actual.find(r => r.device === 'mobile')
+    expect(desktop).toBeDefined()
+    expect(mobile).toBeDefined()
+    expect(desktop!.path).toBe('/')
+    expect(mobile!.path).toBe('/')
+    expect(desktop!.performance).toBeCloseTo(0.95)
+    expect(mobile!.performance).toBeCloseTo(0.8)
+  })
+
+  it('jsonExpanded surfaces device on each route entry for matrix scans', () => {
+    const actual = generateReportPayload('jsonExpanded', matrixReports)
+    expect(actual.routes).toHaveLength(2)
+    // Secondary sort by device → alphabetical → desktop before mobile.
+    expect(actual.routes[0].device).toBe('desktop')
+    expect(actual.routes[1].device).toBe('mobile')
+    expect(actual.routes[0].path).toBe('/')
+    expect(actual.routes[1].path).toBe('/')
+  })
+
+  it('jsonSimple omits the device field for legacy single-device reports', () => {
+    const actual = generateReportPayload('jsonSimple', lighthouseReport)
+    // Snapshot above already asserts shape; this guard catches regressions
+    // where a stray device default would creep into single-device output.
+    for (const r of actual)
+      expect(r.device).toBeUndefined()
   })
 
   it('has metrics information for json expanded report', () => {


### PR DESCRIPTION
## Summary

D-029 Phase 8 follow-up: multi-device matrix scans now preserve the device dimension through CSV (`csv` / `csvExpanded`) and JSON (`jsonSimple` / `jsonExpanded`) exports. Previously the reporters collapsed `(url, device)` rows down to one entry per URL, so mobile and desktop results silently merged on the way out.

- **CSV** — `Device` column appended **last** so the existing `URL,Score,<categories>[,<expanded>]` prefix stays unchanged for parsers anchored on positional indices. Legacy single-device fixtures emit an empty cell; matrix scans get `mobile` / `desktop`.
- **JSON** — `device` field added per route entry. Omitted on legacy single-device output to keep existing snapshots stable.
- **CI export filter** — `--device mobile` (or `--device desktop`) narrows the matrix to one form-factor before the export is written. `--device mobile,desktop` (or omitted) emits the full matrix.
- **Deterministic ordering** — secondary sort by device (alphabetical → `desktop` before `mobile`) so a path's two rows always appear in the same order across runs.

Refs harlan-zw/unlighthouse#349 (Phase 8 — Multi-device matrix).

## Test plan

- [x] `pnpm vitest run test/csv-reports.test.ts test/json-reports.test.ts` (12 passing, includes new matrix fixtures asserting two rows per path, populated `Device` column / `device` field)
- [x] `pnpm vitest run test/d029-*.test.ts` (24 passing — existing matrix fan-out / filter / compare assertions still green)
- [x] `pnpm vitest run test/handlers.test.ts test/storage-port.test.ts test/types.test.ts` (67 passing)
- [x] `pnpm typecheck` clean across all packages
- [x] `pnpm lint` clean
- [x] Back-compat: existing single-device snapshots only change by one trailing empty cell on the CSV side (column appended) — same row count, same prefix column order

`test/ci.test.ts` failures are pre-existing on `origin/v1` (network-dependent end-to-end tests hitting `harlanzw.com`, plus an unrelated `comparison/assertions` resolver issue) and unaffected by this PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)