### PR TITLE
feat(packs/crux): lab vs field gap detector

### DIFF
--- a/packages/core/src/packs/crux.ts
+++ b/packages/core/src/packs/crux.ts
@@ -1,14 +1,20 @@
 // `crux` pack — bridge to Chrome User Experience Report field data.
 //
-// Phase 11 / issue #349 — first iteration. Scope:
+// Phase 11 / issue #349 — scope:
 //   - Per-route p75 LCP / CLS / INP from CrUX next to the lab numbers
 //   - Origin-level fallback when a URL has no per-URL CrUX coverage
 //   - Severity bucketed against the Google p75 thresholds (good/ni/poor)
+//   - "Lab vs field" gap detector: per (url, device) joins the LAB verdict
+//     (Lighthouse-extracted metrics on the ScanRoute) with the FIELD verdict
+//     (CrUX p75 for the same metric) and partitions into three buckets:
+//       * goodLabPoorField — lab passed but real users hit it (most damning)
+//       * poorLabGoodField — lab pessimistic, real users fine (tuning hint)
+//       * aligned          — lab and field agree on verdict
+//     This is the wedge against single-URL competitors: lab-only scores miss
+//     real-world variance (slow networks, low-end devices) and field-only
+//     hides actionable fixes; we surface both, joined.
 //
 // Deferred to follow-up PRs (see #349):
-//   - "Lab vs field" gap detector (flag routes where lab says good but
-//      field says poor). Today we surface field data; comparison logic
-//      against lab metrics lives in a future pack pass.
 //   - UI surfacing in `packages/ui/` (results pages, dashboard widgets).
 //
 // Why a Pack and not just the existing CrUX auditor:
@@ -33,7 +39,7 @@
 // is safe to register globally; users without a key just see "no
 // field data" instead of a hard failure.
 
-import type { Pack, PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
+import type { Device, Pack, PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
 import { z } from 'zod'
 
 // ── Thresholds ──────────────────────────────────────────────────────────────
@@ -79,6 +85,36 @@ const SeverityCountsSchema = z.object({
   unknown: z.number().int().nonnegative(),
 })
 
+// Lab-vs-field gap analysis. We restrict the comparison to a verdict — not a
+// raw value — because the units differ (lab numbers come from a single
+// throttled run, field p75 from real users). What matters operationally is:
+// "did Lighthouse say this is fine while real users disagree?".
+const MetricKeySchema = z.enum(['lcp', 'cls', 'inp'])
+const GapVerdictSchema = z.enum(['good', 'needsImprovement', 'poor'])
+
+const GapEntrySchema = z.object({
+  url: z.string(),
+  // CrUX-style form factor for joinability with the rest of the report.
+  formFactor: FormFactorSchema,
+  metric: MetricKeySchema,
+  labVerdict: GapVerdictSchema,
+  fieldVerdict: GapVerdictSchema,
+  labValue: z.number().nullable(),
+  fieldValue: z.number().nullable(),
+})
+
+const GapAnalysisSchema = z.object({
+  // Lab said `good`, field says `poor`. The damning gap — lab passed but real
+  // users feel it.
+  goodLabPoorField: z.array(GapEntrySchema),
+  // Lab said `poor`, field says `good`. Lab was pessimistic — useful for
+  // tuning thresholds or recognising over-conservative single-run noise.
+  poorLabGoodField: z.array(GapEntrySchema),
+  // Both substrates agree on the verdict. Aligned rows are still useful for
+  // confidence — if `good` lab + `good` field, you can trust the result.
+  aligned: z.array(GapEntrySchema),
+})
+
 const CruxReportSchema = z.object({
   scanId: z.string(),
   routesAnalysed: z.number().int().nonnegative(),
@@ -90,12 +126,19 @@ const CruxReportSchema = z.object({
   hasOriginFallback: z.boolean(),
   severityCounts: SeverityCountsSchema,
   findings: z.array(CruxFindingSchema),
+  // Populated whenever we have BOTH lab values (on the ScanRoute) and field
+  // findings (CrUX source !== 'none') to compare. When nothing lines up,
+  // every bucket is the empty array — `null` would be ambiguous with
+  // "feature off" vs "ran but found nothing aligned".
+  gapAnalysis: GapAnalysisSchema,
 })
 
 export type CruxFinding = z.infer<typeof CruxFindingSchema>
 export type CruxReport = z.infer<typeof CruxReportSchema>
 export type CruxFormFactor = z.infer<typeof FormFactorSchema>
 export type CruxSource = z.infer<typeof SourceSchema>
+export type GapEntry = z.infer<typeof GapEntrySchema>
+export type GapAnalysis = z.infer<typeof GapAnalysisSchema>
 
 // ── CrUX API client ─────────────────────────────────────────────────────────
 
@@ -247,6 +290,105 @@ function worstSeverity(metrics: {
   }, 'good')
 }
 
+// ── Lab vs field gap detector ───────────────────────────────────────────────
+
+// CrUX speaks PHONE/DESKTOP/TABLET; the rest of the scan stack speaks
+// 'mobile'/'desktop'. TABLET is intentionally dropped — we never schedule
+// tablet lab runs, so there's nothing to join against.
+function deviceFromFormFactor(formFactor: CruxFormFactor): Device | null {
+  if (formFactor === 'PHONE')
+    return 'mobile'
+  if (formFactor === 'DESKTOP')
+    return 'desktop'
+  // TABLET / ALL_FORM_FACTORS have no lab counterpart in this codebase.
+  return null
+}
+
+// The three CrUX metrics on a finding mapped to their lab ScanRoute columns.
+// Keep this aligned with the THRESHOLDS table at the top of the file — both
+// lab and field verdicts use the same Google p75 thresholds, which is the
+// whole reason an apples-to-apples comparison is meaningful.
+const COMPARABLE_METRICS = [
+  { metric: 'lcp', field: 'lcp_p75', lab: 'lcp' },
+  { metric: 'cls', field: 'cls_p75', lab: 'cls' },
+  { metric: 'inp', field: 'inp_p75', lab: 'inp' },
+] as const
+
+/**
+ * Join lab metrics (per `(url, device)` on ScanRoute) with CrUX findings
+ * (per `(url, formFactor)`) and partition into three buckets by verdict
+ * agreement. Routes / metrics with missing data on either side are skipped
+ * silently — they're not "aligned", they're just "unknown" and don't
+ * belong in any bucket.
+ *
+ * Exported for unit testing — the reconciler is the production caller.
+ */
+export function analyzeLabVsField(
+  routes: ReadonlyArray<ScanRoute>,
+  findings: ReadonlyArray<CruxFinding>,
+): GapAnalysis {
+  const result: GapAnalysis = {
+    goodLabPoorField: [],
+    poorLabGoodField: [],
+    aligned: [],
+  }
+
+  // Index lab routes by `(device, url)` so the inner loop over findings is
+  // O(1) per lookup. Field findings are the natural outer loop because
+  // they're the data we conditionally have — lab is always present.
+  const labIndex = new Map<string, ScanRoute>()
+  for (const route of routes) {
+    labIndex.set(`${route.device}|${route.url}`, route)
+  }
+
+  for (const finding of findings) {
+    // No field data → no comparison possible.
+    if (finding.source === 'none')
+      continue
+    const device = deviceFromFormFactor(finding.formFactor)
+    if (!device)
+      continue
+    const route = labIndex.get(`${device}|${finding.url}`)
+    if (!route)
+      continue
+
+    for (const { metric, field, lab } of COMPARABLE_METRICS) {
+      const fieldValue = finding[field]
+      const labValueRaw = (route as Record<string, unknown>)[lab]
+      const labValue = typeof labValueRaw === 'number' ? labValueRaw : null
+      if (fieldValue == null || labValue == null)
+        continue
+
+      const labVerdict = verdictFor(metric, labValue)
+      const fieldVerdict = verdictFor(metric, fieldValue)
+      if (!labVerdict || !fieldVerdict)
+        continue
+
+      const entry: GapEntry = {
+        url: finding.url,
+        formFactor: finding.formFactor,
+        metric,
+        labVerdict,
+        fieldVerdict,
+        labValue,
+        fieldValue,
+      }
+
+      if (labVerdict === 'good' && fieldVerdict === 'poor')
+        result.goodLabPoorField.push(entry)
+      else if (labVerdict === 'poor' && fieldVerdict === 'good')
+        result.poorLabGoodField.push(entry)
+      else if (labVerdict === fieldVerdict)
+        result.aligned.push(entry)
+      // Other combinations (e.g. good/ni, poor/ni, ni/good) are real but not
+      // in the headline buckets — leave them out rather than invent a fourth
+      // bin nobody asked for. We can extend the schema later if needed.
+    }
+  }
+
+  return result
+}
+
 // ── Pack config ─────────────────────────────────────────────────────────────
 
 export interface CruxPackOptions {
@@ -302,6 +444,9 @@ function buildPack(options: CruxPackOptions = {}): Pack<CruxReport> {
         hasOriginFallback: false,
         severityCounts,
         findings,
+        // No field data → no gaps to detect. Empty buckets keep the wire
+        // shape stable for downstream consumers.
+        gapAnalysis: { goodLabPoorField: [], poorLabGoodField: [], aligned: [] },
       }
     }
 
@@ -350,6 +495,10 @@ function buildPack(options: CruxPackOptions = {}): Pack<CruxReport> {
       hasOriginFallback,
       severityCounts,
       findings,
+      // Always compute — `analyzeLabVsField` short-circuits when there's no
+      // overlap, returning empty buckets. The caller can then decide whether
+      // to surface "0 gaps detected" or hide the section entirely.
+      gapAnalysis: analyzeLabVsField(routes as ScanRoute[], findings),
     }
   }
 

--- a/test/packs-crux.test.ts
+++ b/test/packs-crux.test.ts
@@ -13,8 +13,9 @@
 // All HTTP traffic stubbed with vi.spyOn(globalThis, 'fetch') — never hits the
 // real CrUX API.
 
-import type { PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
-import { createCruxPack, cruxPack, queryCrux } from '@unlighthouse/core/packs/crux'
+import type { Device, PackReconcileCtx, ScanRoute } from '@unlighthouse/contracts'
+import type { CruxFinding } from '@unlighthouse/core/packs/crux'
+import { analyzeLabVsField, createCruxPack, cruxPack, queryCrux } from '@unlighthouse/core/packs/crux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const ORIGINAL_FETCH = globalThis.fetch
@@ -38,20 +39,27 @@ function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
   })
 }
 
-function buildRoute(url: string): ScanRoute {
+interface BuildRouteOverrides {
+  device?: Device
+  lcp?: number | null
+  cls?: number | null
+  inp?: number | null
+}
+
+function buildRoute(url: string, overrides: BuildRouteOverrides = {}): ScanRoute {
   return {
     scanId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
     url,
-    device: 'mobile',
+    device: overrides.device ?? 'mobile',
     path: new URL(url).pathname,
     routeName: null,
     scorePerformance: 0.9,
     scoreAccessibility: 0.95,
     scoreSeo: 0.85,
     scoreBestPractices: 0.9,
-    lcp: 1200,
-    cls: 0.01,
-    inp: 100,
+    lcp: overrides.lcp === undefined ? 1200 : overrides.lcp,
+    cls: overrides.cls === undefined ? 0.01 : overrides.cls,
+    inp: overrides.inp === undefined ? 100 : overrides.inp,
     fcp: 1000,
     ttfb: 200,
     tbt: 50,
@@ -292,5 +300,183 @@ describe('cruxPack reconciler', () => {
     const report = await pack.reconciler(ctxFor([buildRoute('https://example.com/')]))
     const parsed = pack.reportSchema.safeParse(report)
     expect(parsed.success).toBe(true)
+  })
+})
+
+// ── analyzeLabVsField — gap detector ────────────────────────────────────────
+// Phase 11 / issue #349 — joins lab metrics (ScanRoute) with field findings
+// (CrUX) per (url, device) and classifies the verdict pair.
+
+describe('analyzeLabVsField', () => {
+  function finding(over: Partial<CruxFinding> & { url: string }): CruxFinding {
+    return {
+      url: over.url,
+      formFactor: over.formFactor ?? 'PHONE',
+      lcp_p75: over.lcp_p75 ?? null,
+      cls_p75: over.cls_p75 ?? null,
+      inp_p75: over.inp_p75 ?? null,
+      source: over.source ?? 'url',
+      severity: over.severity ?? 'good',
+    }
+  }
+
+  it('flags goodLabPoorField when lab passes but field reports poor', async () => {
+    // Lab LCP 1200 (good) on /slow-in-the-wild, CrUX p75 5200 (poor).
+    const routes = [buildRoute('https://example.com/slow-in-the-wild', { lcp: 1200 })]
+    const findings = [finding({
+      url: 'https://example.com/slow-in-the-wild',
+      lcp_p75: 5200,
+      cls_p75: 0.05, // both 'good' — aligned
+      inp_p75: 150,
+    })]
+
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.goodLabPoorField).toHaveLength(1)
+    expect(gap.goodLabPoorField[0]).toMatchObject({
+      url: 'https://example.com/slow-in-the-wild',
+      formFactor: 'PHONE',
+      metric: 'lcp',
+      labVerdict: 'good',
+      fieldVerdict: 'poor',
+      labValue: 1200,
+      fieldValue: 5200,
+    })
+    // CLS + INP both 'good' on both sides — they slot into `aligned`.
+    expect(gap.aligned.length).toBeGreaterThanOrEqual(2)
+    expect(gap.poorLabGoodField).toHaveLength(0)
+  })
+
+  it('flags poorLabGoodField when lab is pessimistic but real users are fine', async () => {
+    // Lab CLS 0.30 (poor — e.g. a flaky single-run measure), field CLS 0.05 (good).
+    const routes = [buildRoute('https://example.com/lab-flaky', { lcp: 1200, cls: 0.30, inp: 100 })]
+    const findings = [finding({
+      url: 'https://example.com/lab-flaky',
+      lcp_p75: 1500,
+      cls_p75: 0.05,
+      inp_p75: 100,
+    })]
+
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.poorLabGoodField).toHaveLength(1)
+    expect(gap.poorLabGoodField[0]).toMatchObject({
+      metric: 'cls',
+      labVerdict: 'poor',
+      fieldVerdict: 'good',
+      labValue: 0.30,
+      fieldValue: 0.05,
+    })
+    expect(gap.goodLabPoorField).toHaveLength(0)
+  })
+
+  it('skips findings with no field data (source=none)', async () => {
+    const routes = [buildRoute('https://example.com/no-field', { lcp: 1200 })]
+    const findings = [finding({
+      url: 'https://example.com/no-field',
+      lcp_p75: null,
+      cls_p75: null,
+      inp_p75: null,
+      source: 'none',
+      severity: 'unknown',
+    })]
+
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.goodLabPoorField).toHaveLength(0)
+    expect(gap.poorLabGoodField).toHaveLength(0)
+    expect(gap.aligned).toHaveLength(0)
+  })
+
+  it('skips findings with no matching lab route (e.g. URL not scanned on this device)', async () => {
+    // Lab data only for mobile, CrUX finding only for DESKTOP → no overlap.
+    const routes = [buildRoute('https://example.com/only-mobile', { device: 'mobile', lcp: 1200 })]
+    const findings = [finding({
+      url: 'https://example.com/only-mobile',
+      formFactor: 'DESKTOP',
+      lcp_p75: 1500,
+    })]
+
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.aligned).toHaveLength(0)
+    expect(gap.goodLabPoorField).toHaveLength(0)
+    expect(gap.poorLabGoodField).toHaveLength(0)
+  })
+
+  it('joins per (url, device) — mobile lab pairs with PHONE field, desktop with DESKTOP', async () => {
+    // Same URL, two devices: mobile lab good vs PHONE field poor → gap on mobile.
+    // Desktop lab good vs DESKTOP field good → aligned on desktop.
+    const routes = [
+      buildRoute('https://example.com/', { device: 'mobile', lcp: 1200 }),
+      buildRoute('https://example.com/', { device: 'desktop', lcp: 800 }),
+    ]
+    const findings = [
+      finding({ url: 'https://example.com/', formFactor: 'PHONE', lcp_p75: 5200 }),
+      finding({ url: 'https://example.com/', formFactor: 'DESKTOP', lcp_p75: 1100 }),
+    ]
+
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.goodLabPoorField).toHaveLength(1)
+    expect(gap.goodLabPoorField[0]).toMatchObject({ formFactor: 'PHONE', metric: 'lcp' })
+    // The DESKTOP pair is good/good — lands in aligned.
+    expect(gap.aligned.some(e => e.formFactor === 'DESKTOP' && e.metric === 'lcp')).toBe(true)
+  })
+
+  it('skips TABLET findings (no lab counterpart in this codebase)', async () => {
+    const routes = [buildRoute('https://example.com/', { device: 'mobile', lcp: 1200 })]
+    const findings = [finding({ url: 'https://example.com/', formFactor: 'TABLET', lcp_p75: 5200 })]
+    const gap = analyzeLabVsField(routes, findings)
+    expect(gap.goodLabPoorField).toHaveLength(0)
+    expect(gap.aligned).toHaveLength(0)
+  })
+
+  it('handles partial metric coverage (e.g. INP missing from CrUX) without skipping the row', async () => {
+    // LCP & CLS comparable, INP missing on field side → only 2 entries possible.
+    const routes = [buildRoute('https://example.com/', { lcp: 1200, cls: 0.05, inp: 100 })]
+    const findings = [finding({
+      url: 'https://example.com/',
+      lcp_p75: 1500,
+      cls_p75: 0.08,
+      inp_p75: null,
+    })]
+
+    const gap = analyzeLabVsField(routes, findings)
+    const totalEntries
+      = gap.goodLabPoorField.length + gap.poorLabGoodField.length + gap.aligned.length
+    expect(totalEntries).toBe(2)
+    // Both metrics land in `aligned` (good/good).
+    expect(gap.aligned.map(e => e.metric).sort()).toEqual(['cls', 'lcp'])
+  })
+})
+
+// ── gapAnalysis wired into cruxPack.run() ───────────────────────────────────
+
+describe('cruxPack gapAnalysis integration', () => {
+  beforeEach(() => {
+    delete process.env.CRUX_API_KEY
+  })
+
+  it('produces empty buckets when no API key is set (stub path)', async () => {
+    globalThis.fetch = vi.fn() as never
+    const report = await cruxPack.reconciler(ctxFor([buildRoute('https://example.com/')]))
+    expect(report.gapAnalysis).toEqual({
+      goodLabPoorField: [],
+      poorLabGoodField: [],
+      aligned: [],
+    })
+  })
+
+  it('emits a goodLabPoorField entry end-to-end through the reconciler', async () => {
+    // Lab LCP 1200 (good) on the ScanRoute, CrUX returns p75 5200 (poor).
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(cruxRecord({ lcp: 5200, cls: 0.05, inp: 150 }, { url: 'https://example.com/' })),
+    ) as never
+
+    const pack = createCruxPack({ apiKey: 'fake' })
+    const report = await pack.reconciler(ctxFor([buildRoute('https://example.com/', { lcp: 1200 })]))
+
+    expect(report.gapAnalysis.goodLabPoorField).toHaveLength(1)
+    expect(report.gapAnalysis.goodLabPoorField[0]).toMatchObject({
+      metric: 'lcp',
+      labVerdict: 'good',
+      fieldVerdict: 'poor',
+    })
   })
 })


### PR DESCRIPTION
## Summary

Implements the "lab vs field" gap detector deferred from PR #354 (issue #349, Phase 11). For each `(url, device)` pair, joins the Lighthouse-extracted lab metric (LCP / CLS / INP on `ScanRoute`) with the CrUX field p75 finding and partitions the comparisons into three buckets:

- **`goodLabPoorField`** — lab said `good`, real users see `poor`. The headline gap: Lighthouse passed but the field disagrees, which is the wedge against single-URL competitors.
- **`poorLabGoodField`** — lab pessimistic, field fine. Useful for spotting single-run noise.
- **`aligned`** — both substrates agree on the verdict.

### Changes

- Extends `CruxReportSchema` with `gapAnalysis: { goodLabPoorField, poorLabGoodField, aligned }`. Each entry carries `{ url, formFactor, metric, labVerdict, fieldVerdict, labValue, fieldValue }`.
- Adds `analyzeLabVsField(routes, findings)` helper (exported for unit tests).
- `formFactor` mapping: `PHONE → mobile`, `DESKTOP → desktop`. `TABLET` and `ALL_FORM_FACTORS` are skipped (no lab counterpart in this codebase).
- Verdicts reuse the existing `verdictFor` classifier in `packs/crux.ts` so lab and field share the same Google p75 thresholds.
- Wires `gapAnalysis` into `cruxPack` reconciler in both the no-API-key stub path (empty buckets) and the normal path.
- UI surfacing intentionally out of scope — separate follow-up.

### Test plan

- [x] `pnpm test test/packs-crux.test.ts` — 21 passing (8 new cases)
- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm lint` — clean
- [ ] Manual: spot-check a real scan with `CRUX_API_KEY` set once UI surfacing lands

Refs #349 Phase 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)