### PR TITLE
feat(ui): side-by-side device tabs per route

### DIFF
--- a/packages/ui/composables/useLighthouseReportModal.ts
+++ b/packages/ui/composables/useLighthouseReportModal.ts
@@ -1,31 +1,88 @@
 import type { UnlighthouseRouteReport } from '@unlighthouse/contracts'
 import { useUnlighthouseConfig } from './useUnlighthouseConfig'
 
+// D-029: matrix scans may have both mobile + desktop iframe URLs for the same
+// route. The modal carries both so the device tabs can swap iframes without
+// re-opening.
+export interface LighthouseReportModalDevices {
+  mobile?: string
+  desktop?: string
+}
+
+function resolveReportUrl(report: UnlighthouseRouteReport | any): string {
+  if (!report)
+    return ''
+  if (report.artifactUrl) {
+    // Static client: artifactUrl already points at the report directory; the
+    // file lives at /lighthouse.html beneath it.
+    return report.artifactUrl.endsWith('.html')
+      ? report.artifactUrl
+      : `${report.artifactUrl.replace(/\/$/, '')}/lighthouse.html`
+  }
+  const { apiUrl } = useUnlighthouseConfig()
+  if (apiUrl.value && report.route?.path) {
+    const path = encodeURIComponent(report.route.path || '/')
+    return `${apiUrl.value}/reports/${path}/lighthouse.html`
+  }
+  return ''
+}
+
 export function useLighthouseReportModal() {
   const isOpen = useState<boolean>('unlighthouse:lh-modal-open', () => false)
   const url = useState<string>('unlighthouse:lh-modal-url', () => '')
+  const devices = useState<LighthouseReportModalDevices>('unlighthouse:lh-modal-devices', () => ({}))
+  const activeDevice = useState<'mobile' | 'desktop' | null>('unlighthouse:lh-modal-device', () => null)
 
   function open(report: UnlighthouseRouteReport | any) {
     if (!report?.artifactUrl && !report?.route?.path)
       return
 
-    const { apiUrl } = useUnlighthouseConfig()
-    let reportUrl = report.artifactUrl
-    if (!reportUrl && apiUrl.value) {
-      const path = encodeURIComponent(report.route?.path || '/')
-      reportUrl = `${apiUrl.value}/reports/${path}/lighthouse.html`
-    }
-
+    const reportUrl = resolveReportUrl(report)
     if (reportUrl) {
       url.value = reportUrl
+      devices.value = report?.device
+        ? { [report.device]: reportUrl } as LighthouseReportModalDevices
+        : {}
+      activeDevice.value = report?.device ?? null
       isOpen.value = true
     }
+  }
+
+  // Open the modal for a (url, device)-grouped pair. When both reports are
+  // present the modal renders device tabs; when only one, falls back to the
+  // single iframe.
+  function openGroup(group: { mobile?: UnlighthouseRouteReport, desktop?: UnlighthouseRouteReport }, preferred?: 'mobile' | 'desktop') {
+    const next: LighthouseReportModalDevices = {}
+    if (group.mobile)
+      next.mobile = resolveReportUrl(group.mobile)
+    if (group.desktop)
+      next.desktop = resolveReportUrl(group.desktop)
+    const initial = preferred && next[preferred]
+      ? preferred
+      : (next.mobile ? 'mobile' : (next.desktop ? 'desktop' : null))
+    const initialUrl = initial ? next[initial] : ''
+    if (!initialUrl)
+      return
+    devices.value = next
+    activeDevice.value = initial
+    url.value = initialUrl
+    isOpen.value = true
+  }
+
+  function setActiveDevice(device: 'mobile' | 'desktop') {
+    const next = devices.value[device]
+    if (!next)
+      return
+    activeDevice.value = device
+    url.value = next
   }
 
   function close() {
     isOpen.value = false
     url.value = ''
+    devices.value = {}
+    activeDevice.value = null
   }
 
-  return { isOpen, url, open, close }
+  return { isOpen, url, devices, activeDevice, open, openGroup, setActiveDevice, close }
 }

--- a/packages/ui/composables/useReports.ts
+++ b/packages/ui/composables/useReports.ts
@@ -6,7 +6,12 @@ export function useReports() {
   const reports = reportsState()
 
   function onRouteReport(report: UnlighthouseRouteReport) {
-    const idx = reports.value.findIndex(r => r.route.path === report.route.path)
+    // D-029: matrix scans emit one report per (url, device). Key by both so
+    // mobile + desktop rows for the same path don't overwrite each other.
+    const idx = reports.value.findIndex(r =>
+      r.route.path === report.route.path
+      && (r.device ?? null) === (report.device ?? null),
+    )
     if (idx >= 0)
       reports.value[idx] = report
     else

--- a/packages/ui/pages/results/[scanId]/index.vue
+++ b/packages/ui/pages/results/[scanId]/index.vue
@@ -12,8 +12,27 @@ const { page, perPage, searchText } = useResultsSearch()
 const {
   isOpen: lighthouseReportModalOpen,
   url: iframeModalUrl,
+  devices: modalDevices,
+  activeDevice: modalActiveDevice,
   open: openLighthouseReportIframeModal,
+  openGroup: openLighthouseReportGroupModal,
+  setActiveDevice: setModalDevice,
 } = useLighthouseReportModal()
+
+// `device` is set per report row. The modal's device tabs only render when
+// both forms are present for the same group (route.path).
+const modalDeviceItems = computed(() => {
+  const items: { label: string, value: 'mobile' | 'desktop' }[] = []
+  if (modalDevices.value.mobile)
+    items.push({ label: 'Mobile', value: 'mobile' })
+  if (modalDevices.value.desktop)
+    items.push({ label: 'Desktop', value: 'desktop' })
+  return items
+})
+const modalDeviceTabValue = computed({
+  get: () => modalActiveDevice.value ?? 'mobile',
+  set: (v: 'mobile' | 'desktop') => setModalDevice(v),
+})
 
 definePageMeta({ layout: 'site' })
 
@@ -40,6 +59,7 @@ const reports = computed(() => {
       const overall = present.length ? present.reduce((a, b) => a + b, 0) / present.length : null
       return {
         route: { path: r.path, url: r.url, id: r.path },
+        device: r.device,
         // artifactUrl omitted; openLighthouseReportIframeModal falls back to apiUrl/reports/:path
         report: overall != null
           ? {
@@ -74,13 +94,59 @@ function getCategoryScore(r: any, cat: string): number | null {
   return score != null ? Math.round(score * 100) : null
 }
 
-// Summary stats
+// D-029: matrix scans emit one report per (url, device). Group by route.path
+// so the UI shows one row per route with side-by-side device scores when
+// both forms ran. Single-device scans degrade to the original single-row
+// layout because group.mobile or group.desktop is undefined.
+interface RouteGroup {
+  path: string
+  url?: string
+  mobile?: any
+  desktop?: any
+  // The "primary" report used for sort / filter / screenshot — mobile when
+  // available (canonical Lighthouse default), otherwise desktop, otherwise
+  // whatever single-device report exists.
+  primary: any
+  devices: ('mobile' | 'desktop')[]
+}
+
+function groupReports(rows: any[]): RouteGroup[] {
+  const byPath = new Map<string, RouteGroup>()
+  for (const r of rows) {
+    const path = r.route?.path ?? '/'
+    let g = byPath.get(path)
+    if (!g) {
+      g = { path, url: r.route?.url, primary: r, devices: [] }
+      byPath.set(path, g)
+    }
+    const device = r.device as 'mobile' | 'desktop' | undefined
+    if (device === 'mobile') {
+      g.mobile = r
+      if (!g.devices.includes('mobile'))
+        g.devices.push('mobile')
+    }
+    else if (device === 'desktop') {
+      g.desktop = r
+      if (!g.devices.includes('desktop'))
+        g.devices.push('desktop')
+    }
+    // Pick canonical primary: prefer mobile, then desktop, else first seen.
+    g.primary = g.mobile ?? g.desktop ?? g.primary
+    g.url ??= r.route?.url
+  }
+  return [...byPath.values()]
+}
+
+// Summary stats — average the primary device's score per group so multi-device
+// matrix scans don't double-count the same logical route.
 function avgScoreByCategory(cat: string) {
-  const data = reports.value || []
-  const scores = data.map((r: any) => r.report?.categories?.[cat]?.score).filter((s: any) => s != null)
+  const data = groupReports(reports.value || [])
+  const scores = data
+    .map(g => g.primary?.report?.categories?.[cat]?.score)
+    .filter((s: any) => s != null) as number[]
   if (!scores.length)
     return null
-  return Math.round((scores.reduce((a: number, b: number) => a + b, 0) / scores.length) * 100)
+  return Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 100)
 }
 
 const overallAvgScore = computed(() => {
@@ -95,7 +161,7 @@ const overallAvgScore = computed(() => {
 })
 
 const summaryStats = computed(() => {
-  const data = reports.value || []
+  const data = groupReports(reports.value || [])
   const perf = avgScoreByCategory('performance')
   const a11y = avgScoreByCategory('accessibility')
   const bp = avgScoreByCategory('best-practices')
@@ -110,49 +176,50 @@ const summaryStats = computed(() => {
   ]
 })
 
-// Fuzzy search + sort + filter
-const searchResults = computed((): any[] => {
-  let data: any[] = reports.value || []
+// Fuzzy search + sort + filter — operates on grouped rows so paginate/sort
+// reflect logical routes, not (route, device) pairs.
+const searchResults = computed((): RouteGroup[] => {
+  let data: RouteGroup[] = groupReports(reports.value || [])
 
-  // Fuzzy search
+  // Fuzzy search across path / url at the group level.
   if (searchText.value && data.length) {
     const fuse = new Fuse(data, {
       threshold: 0.4,
-      keys: ['route.path', 'route.url'],
+      keys: ['path', 'url'],
     })
     data = fuse.search(searchText.value).map(i => i.item)
   }
 
-  // Quick filter
+  // Quick filter: scores come from the primary report (mobile when present).
   if (quickFilter.value !== 'all') {
-    const scored = data.filter((r: any) => getOverallScore(r) !== null)
+    const scored = data.filter(g => getOverallScore(g.primary) !== null)
     if (quickFilter.value === 'worst5') {
-      data = [...scored].sort((a, b) => (getOverallScore(a) ?? 0) - (getOverallScore(b) ?? 0)).slice(0, 5)
+      data = [...scored].sort((a, b) => (getOverallScore(a.primary) ?? 0) - (getOverallScore(b.primary) ?? 0)).slice(0, 5)
     }
     else if (quickFilter.value === 'best5') {
-      data = [...scored].sort((a, b) => (getOverallScore(b) ?? 0) - (getOverallScore(a) ?? 0)).slice(0, 5)
+      data = [...scored].sort((a, b) => (getOverallScore(b.primary) ?? 0) - (getOverallScore(a.primary) ?? 0)).slice(0, 5)
     }
     else if (quickFilter.value === 'below50') {
-      data = scored.filter((r: any) => (getOverallScore(r) ?? 100) < 50)
+      data = scored.filter(g => (getOverallScore(g.primary) ?? 100) < 50)
     }
   }
 
-  // Sort
+  // Sort by group key — same comparators as before, just reading from primary.
   if (sortBy.value === 'path') {
     data = [...data].sort((a, b) => {
-      const cmp = (a.route?.path || '').localeCompare(b.route?.path || '')
+      const cmp = (a.path || '').localeCompare(b.path || '')
       return sortDir.value === 'asc' ? cmp : -cmp
     })
   }
   else if (sortBy.value === 'score') {
     data = [...data].sort((a, b) => {
-      const diff = (getOverallScore(a) ?? -1) - (getOverallScore(b) ?? -1)
+      const diff = (getOverallScore(a.primary) ?? -1) - (getOverallScore(b.primary) ?? -1)
       return sortDir.value === 'asc' ? diff : -diff
     })
   }
   else {
     data = [...data].sort((a, b) => {
-      const diff = (getCategoryScore(a, sortBy.value) ?? -1) - (getCategoryScore(b, sortBy.value) ?? -1)
+      const diff = (getCategoryScore(a.primary, sortBy.value) ?? -1) - (getCategoryScore(b.primary, sortBy.value) ?? -1)
       return sortDir.value === 'asc' ? diff : -diff
     })
   }
@@ -160,10 +227,19 @@ const searchResults = computed((): any[] => {
   return data
 })
 
-const paginatedResults = computed((): any[] => {
+const paginatedResults = computed((): RouteGroup[] => {
   const offset = (page.value - 1) * perPage
   return searchResults.value.slice(offset, offset + perPage)
 })
+
+function openRouteModal(group: RouteGroup, preferred?: 'mobile' | 'desktop') {
+  if (group.mobile && group.desktop) {
+    openLighthouseReportGroupModal({ mobile: group.mobile, desktop: group.desktop }, preferred)
+  }
+  else {
+    openLighthouseReportIframeModal(group.primary)
+  }
+}
 
 const categoryAbbrev: Record<string, string> = {
   'Performance': 'Perf',
@@ -250,21 +326,21 @@ const filterOptions = [
     <!-- Results -->
     <div v-else class="grid gap-3">
       <div
-        v-for="report in paginatedResults"
-        :key="report.route?.path"
+        v-for="g in paginatedResults"
+        :key="g.path"
         class="group bg-elevated/40 hover:bg-elevated/80 border border-default hover:border-accented rounded-sm p-4 transition-colors cursor-pointer"
-        @click="openLighthouseReportIframeModal(report)"
+        @click="openRouteModal(g)"
       >
         <div class="flex items-center gap-3 md:gap-4">
-          <!-- Screenshot -->
+          <!-- Screenshot (from primary report) -->
           <div class="w-16 h-12 md:w-24 md:h-16 rounded-sm overflow-hidden bg-elevated/60 shrink-0 hidden sm:block">
             <img
-              v-if="report.report && report.artifactUrl"
-              :src="resolveArtifactPath(report, 'screenshot.jpeg')"
+              v-if="g.primary?.report && g.primary?.artifactUrl"
+              :src="resolveArtifactPath(g.primary, 'screenshot.jpeg')"
               class="w-full h-full object-cover object-top"
               loading="lazy"
             >
-            <div v-else-if="report.report" class="w-full h-full flex items-center justify-center">
+            <div v-else-if="g.primary?.report" class="w-full h-full flex items-center justify-center">
               <UIcon name="i-heroicons-photo" class="w-5 h-5 text-dimmed" />
             </div>
             <USkeleton v-else class="w-full h-full rounded-none" />
@@ -273,17 +349,68 @@ const filterOptions = [
           <!-- Route Info -->
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-1">
-              <span class="font-mono text-xs sm:text-sm text-highlighted truncate">{{ report.route?.path || '/' }}</span>
+              <span class="font-mono text-xs sm:text-sm text-highlighted truncate">{{ g.path || '/' }}</span>
+              <!-- Device pills appear only when both forms are present. -->
+              <span
+                v-if="g.mobile && g.desktop"
+                class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[10px] bg-elevated/60 text-dimmed border border-default"
+                :title="`Mobile + Desktop coverage`"
+              >
+                <UIcon name="i-heroicons-device-phone-mobile" class="size-3" />
+                <UIcon name="i-heroicons-computer-desktop" class="size-3" />
+              </span>
+              <!-- Single-device pill when only one ran (only useful in matrix
+                   scans where some routes failed on one device). -->
+              <span
+                v-else-if="g.mobile || g.desktop"
+                class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[10px] bg-elevated/60 text-dimmed border border-default"
+              >
+                <UIcon :name="g.mobile ? 'i-heroicons-device-phone-mobile' : 'i-heroicons-computer-desktop'" class="size-3" />
+                {{ g.mobile ? 'Mobile' : 'Desktop' }}
+              </span>
             </div>
             <div class="text-xs text-dimmed truncate hidden sm:block">
-              {{ report.route?.url }}
+              {{ g.url }}
             </div>
           </div>
 
-          <!-- Scores -->
-          <div v-if="report.report?.categories" class="flex items-center gap-1.5 sm:gap-3">
+          <!-- Scores: side-by-side mobile + desktop when both present,
+               otherwise the single device's flat row (back-compat). -->
+          <div v-if="g.mobile?.report?.categories && g.desktop?.report?.categories" class="flex items-stretch gap-4">
             <div
-              v-for="(cat, catKey) in report.report.categories"
+              v-for="dev in (['mobile', 'desktop'] as const)"
+              :key="dev"
+              class="flex flex-col items-center gap-1"
+            >
+              <div class="flex items-center gap-1 text-[10px] text-dimmed uppercase tracking-wide">
+                <UIcon
+                  :name="dev === 'mobile' ? 'i-heroicons-device-phone-mobile' : 'i-heroicons-computer-desktop'"
+                  class="size-3"
+                />
+                {{ dev }}
+              </div>
+              <div class="flex items-center gap-1.5 sm:gap-2">
+                <div
+                  v-for="(cat, catKey) in g[dev]!.report.categories"
+                  :key="catKey"
+                  class="text-center"
+                >
+                  <div
+                    class="w-7 h-7 sm:w-9 sm:h-9 rounded-sm flex items-center justify-center font-mono font-semibold text-xs"
+                    :class="[getScoreBg(Math.round((cat as any).score * 100)), getScoreColor(Math.round((cat as any).score * 100))]"
+                  >
+                    {{ (cat as any).score != null ? Math.round((cat as any).score * 100) : '-' }}
+                  </div>
+                  <div class="text-[10px] text-dimmed mt-1 hidden lg:block">
+                    {{ categoryAbbrev[(cat as any).title] || (cat as any).title }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else-if="g.primary?.report?.categories" class="flex items-center gap-1.5 sm:gap-3">
+            <div
+              v-for="(cat, catKey) in g.primary.report.categories"
               :key="catKey"
               class="text-center"
             >
@@ -306,12 +433,12 @@ const filterOptions = [
 
           <!-- View Report Button -->
           <UiMotionButton
-            v-if="report.report"
+            v-if="g.primary?.report"
             variant="ghost"
             size="xs"
             icon="i-heroicons-document-magnifying-glass"
             class="opacity-60 group-hover:opacity-100 transition-opacity shrink-0"
-            @click.stop="openLighthouseReportIframeModal(report)"
+            @click.stop="openRouteModal(g)"
           >
             <span class="hidden md:inline">View report</span>
           </UiMotionButton>
@@ -331,10 +458,19 @@ const filterOptions = [
       />
     </div>
 
-    <!-- Lighthouse Report Modal -->
+    <!-- Lighthouse Report Modal — device tabs render only when both forms are
+         present, falling back to the bare iframe for single-device scans. -->
     <UModal v-model:open="lighthouseReportModalOpen" title="Lighthouse report" :ui="{ content: '!max-w-6xl !bg-default' }">
       <template #body>
-        <iframe v-if="iframeModalUrl" :src="iframeModalUrl" class="w-full h-[85vh] bg-white rounded-sm" />
+        <div v-if="modalDeviceItems.length > 1" class="mb-3">
+          <UTabs
+            v-model="modalDeviceTabValue"
+            :items="modalDeviceItems"
+            size="xs"
+            :ui="{ list: 'w-fit' }"
+          />
+        </div>
+        <iframe v-if="iframeModalUrl" :src="iframeModalUrl" class="w-full h-[80vh] bg-white rounded-sm" />
       </template>
     </UModal>
   </div>

--- a/packages/ui/plugins/live-reports.client.ts
+++ b/packages/ui/plugins/live-reports.client.ts
@@ -19,7 +19,12 @@ export default defineNuxtPlugin({
     const isOffline = useState<boolean>('unlighthouse:offline', () => false)
 
     nuxtApp.hook('transport:route-report', (report) => {
-      const idx = reports.value.findIndex(r => r.route.path === report.route.path)
+      // D-029: matrix scans emit one report per (url, device). Key by both so
+      // mobile + desktop rows for the same path don't overwrite each other.
+      const idx = reports.value.findIndex(r =>
+        r.route.path === report.route.path
+        && (r.device ?? null) === (report.device ?? null),
+      )
       if (idx >= 0)
         reports.value[idx] = report
       else


### PR DESCRIPTION
## Summary
- Group route reports by `route.path` so matrix scans (D-029) render mobile + desktop scores side-by-side in the results list; single-device scans keep the existing single-row layout.
- Add a device tab to the Lighthouse report modal that swaps iframe URLs when both forms are present, and a small dual-device pill on the row when both ran.
- Fix the live-reports + `useReports` store keying on `route.path` alone — it was overwriting one device's report with the other on matrix scans.

Refs harlan-zw/unlighthouse#349 — Phase 8 (Multi-device matrix), UI bullet.

## Test plan
- [ ] On a single-device scan, the results page looks unchanged: one row per route, single set of category scores, modal opens without a tab strip.
- [ ] On a multi-device scan (mobile + desktop), each route renders one row with two labelled score columns side-by-side and a dual-device pill next to the path.
- [ ] Clicking a multi-device row opens the modal with a `Mobile` / `Desktop` tab strip; switching tabs swaps the iframe in place.
- [ ] Sort / filter / pagination still operate at the route level (not the (route, device) level) — counts in the pagination summary match logical routes.
- [ ] `pnpm --filter @unlighthouse/ui typecheck` is clean.
- [ ] `pnpm --filter @unlighthouse/ui build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)