### PR TITLE
feat(next): scaffold @unlighthouse/next plugin

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,77 @@
+# @unlighthouse/next
+
+[Next.js](https://nextjs.org) integration for [Unlighthouse](https://unlighthouse.dev).
+Wrap your `next.config.js` and your production builds get auto-scanned
+with Lighthouse.
+
+> Status: scaffold (v1, Phase 15 of issue #349). Build-time scan is wired
+> up; preview-deploy middleware + PR-comment diff posting are follow-ups.
+
+## Install
+
+```bash
+pnpm add -D @unlighthouse/next unlighthouse
+```
+
+`unlighthouse` is a peer-runtime dep — your host project provides it so
+config, version, and storage match whatever else you run from the CLI.
+
+## Use — HOC
+
+```js
+// next.config.js
+const { withUnlighthouse } = require('@unlighthouse/next')
+
+module.exports = withUnlighthouse(
+  {
+    reactStrictMode: true,
+    // ...your existing Next config
+  },
+  {
+    // optional — defaults to $UNLIGHTHOUSE_SITE or http://localhost:3000
+    site: 'http://localhost:3000',
+    // optional — defaults to Unlighthouse's own default
+    outputPath: '.unlighthouse-report',
+  },
+)
+```
+
+```bash
+NODE_ENV=production pnpm next build
+# ↑ when the client compiler finishes, the scan kicks off in the background
+```
+
+The HOC attaches a `webpack.compiler.hooks.done.tap()` hook on the client
+compiler only. It dedupes repeated `done` events from the same build and
+only fires under `NODE_ENV=production`.
+
+Set `UNLIGHTHOUSE_SKIP=true` in your env to disable the hook entirely
+for a specific CI matrix without editing config.
+
+## Use — CLI
+
+If you'd rather not touch `next.config.js`, drop the bin into your
+pipeline:
+
+```bash
+pnpm next build
+pnpm next start &
+NEXT_PID=$!
+pnpm dlx unlighthouse-next --site http://localhost:3000
+kill $NEXT_PID
+```
+
+## Options
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `site` | `string` | `$UNLIGHTHOUSE_SITE` or `http://localhost:3000` | URL to crawl. |
+| `outputPath` | `string` | Unlighthouse default | Where reports land. |
+| `enableOnBuild` | `boolean` | `true` | Set `false` to disable the webpack hook. |
+| `unlighthouse` | `object` | `{}` | Extra `UserConfig` forwarded to `createUnlighthouseHost`. |
+
+## Roadmap
+
+- Middleware that scans on preview deploys (Vercel / Netlify hooks).
+- PR-comment diff posting via GitHub API.
+- Dev-mode HUD with live per-page Lighthouse scores.

--- a/packages/next/build.config.ts
+++ b/packages/next/build.config.ts
@@ -1,0 +1,24 @@
+import { defineBuildConfig } from 'obuild/config'
+
+// `next` is a peer dep; `unlighthouse` is a workspace runtime dep loaded
+// dynamically. Keep both external so the plugin bundle stays tiny and the
+// host project's installed copy wins at resolution time.
+const externals = [
+  'next',
+  'unlighthouse',
+  'node:fs',
+  'node:path',
+  'node:url',
+  'node:child_process',
+  'node:process',
+]
+
+export default defineBuildConfig({
+  entries: [
+    {
+      type: 'bundle',
+      input: ['./src/index.ts', './src/cli.ts'],
+      rolldown: { external: externals },
+    },
+  ],
+})

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@unlighthouse/next",
+  "type": "module",
+  "version": "0.0.0-v1",
+  "private": true,
+  "description": "Next.js integration for Unlighthouse — wrap your next.config to scan the build output automatically.",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "bin": {
+    "unlighthouse-next": "./dist/cli.mjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "build": "obuild",
+    "stub": "obuild --stub",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:attw": "attw --pack --profile esm-only",
+    "test:publint": "publint"
+  },
+  "peerDependencies": {
+    "next": "^13.0.0 || ^14.0.0 || ^15.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": false
+    }
+  },
+  "dependencies": {
+    "unlighthouse": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/next/src/cli.ts
+++ b/packages/next/src/cli.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * `unlighthouse-next` bin — for users who'd rather not wrap their
+ * `next.config.js`. Run after `next build && next start`:
+ *
+ *   pnpm dlx unlighthouse-next --site http://localhost:3000
+ *
+ * This is intentionally minimal — it just forwards to `runScan()`. Any
+ * heavier orchestration (auto-spawning `next start`, awaiting readiness,
+ * tearing it down after) is a follow-up tied to the Phase 15 middleware
+ * bullet.
+ */
+
+import process from 'node:process'
+import { runScan } from './index'
+
+interface CliArgs {
+  site?: string
+  outputPath?: string
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--site' || arg === '-s') {
+      args.site = argv[++i]
+    }
+    else if (arg.startsWith('--site=')) {
+      args.site = arg.slice('--site='.length)
+    }
+    else if (arg === '--output-path' || arg === '-o') {
+      args.outputPath = argv[++i]
+    }
+    else if (arg.startsWith('--output-path=')) {
+      args.outputPath = arg.slice('--output-path='.length)
+    }
+    else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+  }
+  return args
+}
+
+function printHelp(): void {
+  console.log(`unlighthouse-next — scan a Next.js app with Unlighthouse.
+
+Usage:
+  unlighthouse-next [options]
+
+Options:
+  -s, --site <url>           Site to scan (default: $UNLIGHTHOUSE_SITE or http://localhost:3000)
+  -o, --output-path <path>   Where to write the report
+  -h, --help                 Show this help
+
+Run \`next build && next start\` first, then point this at the running server.`)
+}
+
+async function main(): Promise<void> {
+  if (process.env.UNLIGHTHOUSE_SKIP === 'true') {
+    console.log('[unlighthouse:next] UNLIGHTHOUSE_SKIP=true — skipping scan.')
+    return
+  }
+  const args = parseArgs(process.argv.slice(2))
+  await runScan({
+    site: args.site,
+    outputPath: args.outputPath,
+  })
+}
+
+main().catch((err) => {
+  console.error('[unlighthouse:next] cli failed:', err)
+  process.exit(1)
+})

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,0 +1,226 @@
+/**
+ * @unlighthouse/next — Next.js integration.
+ *
+ * First-iteration scaffold (Phase 15, issue #349):
+ *   - `withUnlighthouse(nextConfig, options)` HOC wraps a user's
+ *     `next.config.js` export. It attaches a webpack `done` hook on the
+ *     client compiler so the scan runs once after a production build.
+ *   - Companion `unlighthouse-next` bin (see `./cli.ts`) is shipped for
+ *     users who don't want to touch their config — they run the CLI
+ *     after `next build`.
+ *
+ * What is NOT in this iteration (deferred follow-ups):
+ *   - Middleware that scans on preview deploys (Vercel / Netlify hooks)
+ *   - PR-comment diff posting via GitHub API
+ *   - Dev-mode HUD with live per-page Lighthouse scores
+ *
+ * Design notes:
+ *   - Next has no first-class plugin API like Vite. The cleanest hook
+ *     point is `webpack(config)` in `next.config.js`. We attach to the
+ *     compiler's `done` hook, but Next runs both server + client
+ *     compilers and emits `done` for each → we dedupe via a one-shot
+ *     latch keyed off `isServer`.
+ *   - `unlighthouse` is imported dynamically. The plugin doesn't bundle
+ *     it — the host project's installed copy wins, matching how the
+ *     Vite sibling behaves.
+ *   - The scan is fire-and-forget by default. Next's build process is
+ *     already long; we don't add to its critical path.
+ *   - Honour `UNLIGHTHOUSE_SKIP=true` so users can disable the hook in
+ *     specific CI matrices without editing config.
+ */
+
+const PLUGIN_NAME = 'unlighthouse:next'
+
+export interface UnlighthouseNextOptions {
+  /**
+   * The site URL Unlighthouse should crawl. Defaults to
+   * `http://localhost:3000` — i.e. the user is expected to have a
+   * `next start` running. For now we don't auto-spawn one; that's a
+   * follow-up (Phase 15 middleware bullet).
+   */
+  site?: string
+  /**
+   * Output directory (relative to the Next project root) for the
+   * Unlighthouse report. Defaults to Unlighthouse's own default
+   * (typically `.unlighthouse/<host>`).
+   */
+  outputPath?: string
+  /**
+   * Run the scan during `next build`? Defaults to `true`. The hook is
+   * skipped automatically outside `NODE_ENV=production` regardless.
+   */
+  enableOnBuild?: boolean
+  /**
+   * Extra options forwarded to `createUnlighthouseHost({ userConfig })`.
+   * Anything supported by Unlighthouse's `UserConfig` is passed through;
+   * `site` / `outputPath` from above win over fields of the same name.
+   */
+  unlighthouse?: Record<string, unknown>
+}
+
+/**
+ * Minimal shape of `NextConfig` we touch. We avoid importing Next's own
+ * type to keep the package importable in environments where `next` isn't
+ * installed (shape-only tests, type-checking on machines without Next).
+ * Real Next consumers get the full type via their own import.
+ */
+export interface MinimalNextConfig {
+  webpack?: (config: unknown, context: WebpackContext) => unknown
+  [key: string]: unknown
+}
+
+export interface WebpackContext {
+  isServer: boolean
+  dev: boolean
+  buildId?: string
+  // Next passes many more fields; we don't depend on them.
+  [key: string]: unknown
+}
+
+interface WebpackCompiler {
+  hooks: {
+    done: {
+      tap: (name: string, fn: () => void) => void
+    }
+  }
+}
+
+/**
+ * Wraps a Next.js config with an Unlighthouse post-build hook.
+ *
+ * @example
+ * ```js
+ * // next.config.js
+ * const { withUnlighthouse } = require('@unlighthouse/next')
+ * module.exports = withUnlighthouse({ reactStrictMode: true }, {
+ *   site: 'http://localhost:3000',
+ * })
+ * ```
+ */
+export function withUnlighthouse<T extends MinimalNextConfig>(
+  nextConfig: T = {} as T,
+  options: UnlighthouseNextOptions = {},
+): T & { webpack: NonNullable<MinimalNextConfig['webpack']> } {
+  const { enableOnBuild = true } = options
+  const userWebpack = nextConfig.webpack
+
+  return {
+    ...nextConfig,
+    webpack(config: unknown, context: WebpackContext) {
+      // Always preserve the user's existing webpack hook. We chain on
+      // top — never replace.
+      const result = userWebpack ? userWebpack(config, context) : config
+
+      if (!enableOnBuild)
+        return result
+      // Only the client compiler — the server compiler also fires `done`
+      // and we don't want to scan twice.
+      if (context.isServer)
+        return result
+      // Skip during `next dev`. The scan should only run for real builds.
+      if (context.dev)
+        return result
+      // CI escape hatch.
+      if (process.env.UNLIGHTHOUSE_SKIP === 'true')
+        return result
+      // Only run for `NODE_ENV=production` (i.e. `next build`).
+      if (process.env.NODE_ENV !== 'production')
+        return result
+
+      const compiler = config as WebpackCompiler
+      if (!compiler?.hooks?.done?.tap) {
+        // Defensive — if the shape we expect isn't there, don't crash
+        // the build. Just no-op and warn once.
+
+        console.warn(`[${PLUGIN_NAME}] could not attach to webpack done hook — skipping scan.`)
+        return result
+      }
+
+      // Next's webpack(config) is called fresh for each compiler pass; a
+      // module-level latch keyed by buildId is the simplest dedupe. If
+      // there's no buildId we fall back to a single global latch.
+      const latchKey = context.buildId ?? '__no_build_id__'
+      if (scannedBuilds.has(latchKey))
+        return result
+      scannedBuilds.add(latchKey)
+
+      compiler.hooks.done.tap(PLUGIN_NAME, () => {
+        // Debounce: webpack can emit `done` more than once for the
+        // same compiler (e.g. when reading from cache). Coalesce calls
+        // arriving within the debounce window.
+        scheduleScan(options)
+      })
+
+      return result
+    },
+  } as T & { webpack: NonNullable<MinimalNextConfig['webpack']> }
+}
+
+// Module-scoped state. Safe because Next spawns a fresh Node process per
+// `next build` invocation — the latch resets between runs.
+const scannedBuilds = new Set<string>()
+let scanTimer: ReturnType<typeof setTimeout> | undefined
+let scanRunning = false
+
+function scheduleScan(options: UnlighthouseNextOptions): void {
+  if (scanTimer)
+    clearTimeout(scanTimer)
+  // 250ms debounce is enough to absorb the burst of `done` events
+  // webpack tends to fire during cache-hit builds.
+  scanTimer = setTimeout(() => {
+    scanTimer = undefined
+    if (scanRunning)
+      return
+    scanRunning = true
+    runScan(options)
+      .catch((err) => {
+        console.error(`[${PLUGIN_NAME}] background scan failed:`, err)
+      })
+      .finally(() => {
+        scanRunning = false
+      })
+  }, 250)
+}
+
+/**
+ * Resolve + run an Unlighthouse scan via the v1 host API. Exported so
+ * the CLI entry (`./cli.ts`) can re-use it without duplicating the
+ * dynamic-import contract.
+ *
+ * @internal
+ */
+export async function runScan(options: UnlighthouseNextOptions): Promise<void> {
+  const {
+    site = process.env.UNLIGHTHOUSE_SITE ?? 'http://localhost:3000',
+    outputPath,
+    unlighthouse: userOpts,
+  } = options
+
+  // Dynamic import of `unlighthouse` keeps it out of the plugin bundle so
+  // the host project's installed copy wins. Variable specifier prevents
+  // TypeScript from chasing the workspace source at type-check time and
+  // dragging in unrelated transitive-dep type errors.
+  interface UnlighthouseModule {
+    createUnlighthouseHost: (opts: { userConfig: Record<string, unknown> }) => Promise<{
+      start: () => Promise<{ scanId: string }>
+    }>
+  }
+  const specifier = 'unlighthouse'
+  const mod = (await import(specifier)) as UnlighthouseModule
+  if (typeof mod.createUnlighthouseHost !== 'function')
+    throw new TypeError('unlighthouse: createUnlighthouseHost not exported (need v1)')
+
+  const userConfig: Record<string, unknown> = {
+    ...(userOpts || {}),
+    // Top-level wins over keys nested inside `unlighthouse: {...}`.
+    site,
+    ...(outputPath ? { outputPath } : {}),
+  }
+
+  const host = await mod.createUnlighthouseHost({ userConfig })
+  const { scanId } = await host.start()
+  // eslint-disable-next-line no-console
+  console.log(`[${PLUGIN_NAME}] scan started: ${scanId} (site=${site})`)
+}
+
+export default withUnlighthouse

--- a/packages/next/test/hoc-shape.test.ts
+++ b/packages/next/test/hoc-shape.test.ts
@@ -1,0 +1,116 @@
+// Shape-only tests — no real Next build, no real Unlighthouse scan.
+// Verifies the HOC factory returns a NextConfig-shaped object, preserves
+// user fields, chains the user's webpack hook, and only attaches the
+// `done` tap under the right conditions.
+
+import process from 'node:process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withUnlighthouse } from '../src/index'
+
+interface FakeHook { tap: ReturnType<typeof vi.fn> }
+interface FakeCompiler { hooks: { done: FakeHook } }
+
+function makeFakeCompiler(): FakeCompiler {
+  return { hooks: { done: { tap: vi.fn() } } }
+}
+
+describe('@unlighthouse/next — withUnlighthouse HOC shape', () => {
+  const originalEnv = process.env.NODE_ENV
+  const originalSkip = process.env.UNLIGHTHOUSE_SKIP
+
+  beforeEach(() => {
+    // Vitest types NODE_ENV as readonly; the cast is local-only.
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    delete process.env.UNLIGHTHOUSE_SKIP
+  })
+
+  afterEach(() => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = originalEnv
+    if (originalSkip === undefined)
+      delete process.env.UNLIGHTHOUSE_SKIP
+    else
+      process.env.UNLIGHTHOUSE_SKIP = originalSkip
+  })
+
+  it('returns a NextConfig with a webpack hook attached', () => {
+    const wrapped = withUnlighthouse({ reactStrictMode: true })
+    expect(wrapped.reactStrictMode).toBe(true)
+    expect(wrapped.webpack).toBeTypeOf('function')
+  })
+
+  it('preserves arbitrary user config fields', () => {
+    const wrapped = withUnlighthouse({
+      reactStrictMode: true,
+      images: { domains: ['example.com'] },
+      experimental: { typedRoutes: true },
+    } as Record<string, unknown>)
+    expect((wrapped as Record<string, unknown>).reactStrictMode).toBe(true)
+    expect((wrapped as Record<string, unknown>).images).toEqual({ domains: ['example.com'] })
+    expect((wrapped as Record<string, unknown>).experimental).toEqual({ typedRoutes: true })
+  })
+
+  it('chains an existing user webpack hook (user runs first, result passed through)', () => {
+    const userWebpack = vi.fn((config: unknown) => ({ ...(config as object), userMark: true }))
+    const wrapped = withUnlighthouse({ webpack: userWebpack })
+    const compiler = makeFakeCompiler()
+    // dev: true means the unlighthouse tap is skipped — but the user
+    // hook should still run and its return value must be propagated.
+    const result = wrapped.webpack(compiler, { isServer: false, dev: true }) as Record<string, unknown>
+    expect(userWebpack).toHaveBeenCalledTimes(1)
+    expect(result.userMark).toBe(true)
+  })
+
+  it('attaches done.tap only for client production builds', () => {
+    const wrapped = withUnlighthouse({})
+
+    const clientProd = makeFakeCompiler()
+    wrapped.webpack(clientProd, { isServer: false, dev: false, buildId: 'a' })
+    expect(clientProd.hooks.done.tap).toHaveBeenCalledTimes(1)
+
+    const serverProd = makeFakeCompiler()
+    wrapped.webpack(serverProd, { isServer: true, dev: false, buildId: 'b' })
+    expect(serverProd.hooks.done.tap).not.toHaveBeenCalled()
+
+    const clientDev = makeFakeCompiler()
+    wrapped.webpack(clientDev, { isServer: false, dev: true, buildId: 'c' })
+    expect(clientDev.hooks.done.tap).not.toHaveBeenCalled()
+  })
+
+  it('skips the tap when UNLIGHTHOUSE_SKIP=true', () => {
+    process.env.UNLIGHTHOUSE_SKIP = 'true'
+    const wrapped = withUnlighthouse({})
+    const compiler = makeFakeCompiler()
+    wrapped.webpack(compiler, { isServer: false, dev: false, buildId: 'skip' })
+    expect(compiler.hooks.done.tap).not.toHaveBeenCalled()
+  })
+
+  it('skips the tap when NODE_ENV is not production', () => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'test'
+    const wrapped = withUnlighthouse({})
+    const compiler = makeFakeCompiler()
+    wrapped.webpack(compiler, { isServer: false, dev: false, buildId: 'nonprod' })
+    expect(compiler.hooks.done.tap).not.toHaveBeenCalled()
+  })
+
+  it('honours enableOnBuild: false', () => {
+    const wrapped = withUnlighthouse({}, { enableOnBuild: false })
+    const compiler = makeFakeCompiler()
+    wrapped.webpack(compiler, { isServer: false, dev: false, buildId: 'disabled' })
+    expect(compiler.hooks.done.tap).not.toHaveBeenCalled()
+  })
+
+  it('dedupes repeated webpack(config) calls for the same buildId', () => {
+    const wrapped = withUnlighthouse({})
+    const compilerA = makeFakeCompiler()
+    const compilerB = makeFakeCompiler()
+    wrapped.webpack(compilerA, { isServer: false, dev: false, buildId: 'dup' })
+    wrapped.webpack(compilerB, { isServer: false, dev: false, buildId: 'dup' })
+    expect(compilerA.hooks.done.tap).toHaveBeenCalledTimes(1)
+    expect(compilerB.hooks.done.tap).not.toHaveBeenCalled()
+  })
+
+  it('default export matches the named export', async () => {
+    const mod = await import('../src/index')
+    expect(mod.default).toBe(mod.withUnlighthouse)
+  })
+})

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// Local config so `pnpm --filter @unlighthouse/next test` works without
+// pulling in the root workspace aliases. Mirrors the @unlighthouse/vite
+// sibling scaffold.
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,22 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  packages/next:
+    dependencies:
+      next:
+        specifier: ^13.0.0 || ^14.0.0 || ^15.0.0
+        version: 15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      unlighthouse:
+        specifier: workspace:*
+        version: link:../unlighthouse
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.7.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.7.0)(jsdom@26.1.0)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/ui:
     dependencies:
       '@internationalized/date':
@@ -584,7 +600,7 @@ importers:
         version: 3.12.1
       '@nuxt/ui':
         specifier: catalog:dependencies
-        version: 4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(axios@1.16.0)(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(embla-carousel@8.6.0)(ioredis@5.8.2)(magicast@0.5.1)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-router@4.5.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))(yjs@13.6.29)(zod@4.4.3)
+        version: 4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(axios@1.16.0)(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(embla-carousel@8.6.0)(ioredis@5.8.2)(magicast@0.5.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-router@4.5.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))(yjs@13.6.29)(zod@4.4.3)
       '@tanstack/table-core':
         specifier: catalog:dependencies
         version: 8.21.3
@@ -611,7 +627,7 @@ importers:
         version: 4.18.1
       motion-v:
         specifier: 'catalog:'
-        version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))
+        version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.25(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.25(typescript@6.0.3))
       nuxt:
         specifier: 4.2.2
         version: 4.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@25.7.0)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.4)(rolldown@1.0.0)(rollup@4.53.5)(terser@5.44.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
@@ -2502,6 +2518,61 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@next/env@15.5.18':
+    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
+
+  '@next/swc-darwin-arm64@15.5.18':
+    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.18':
+    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.18':
+    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.18':
+    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.18':
+    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.18':
+    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.18':
+    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.18':
+    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@nodable/entities@1.1.0':
     resolution: {integrity: sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==}
 
@@ -3711,6 +3782,9 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
@@ -5225,6 +5299,9 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -7858,6 +7935,27 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
+  next@15.5.18:
+    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   nitropack@2.12.9:
     resolution: {integrity: sha512-t6qqNBn2UDGMWogQuORjbL2UPevB8PvIPsPHmqvWpeGOlPr4P8Oc5oA8t3wFwGmaolM2M/s2SwT23nx9yARmOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8430,6 +8528,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8617,6 +8719,15 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -8845,6 +8956,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
@@ -9131,6 +9245,19 @@ packages:
 
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   stylehacks@7.0.7:
     resolution: {integrity: sha512-bJkD0JkEtbRrMFtwgpJyBbFIwfDDONQ1Ov3sDLZQP8HuJ73kBOyx66H4bOcAbVWmnfLdvQ0AJwXxOMkpujcO6g==}
@@ -11669,6 +11796,32 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/env@15.5.18': {}
+
+  '@next/swc-darwin-arm64@15.5.18':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.18':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.18':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.18':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.18':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.18':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.18':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.18':
+    optional: true
+
   '@nodable/entities@1.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -11971,7 +12124,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/ui@4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(axios@1.16.0)(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(embla-carousel@8.6.0)(ioredis@5.8.2)(magicast@0.5.1)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-router@4.5.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))(yjs@13.6.29)(zod@4.4.3)':
+  '@nuxt/ui@4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@tiptap/extensions@3.23.1(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))(@tiptap/pm@3.23.1))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(axios@1.16.0)(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(embla-carousel@8.6.0)(ioredis@5.8.2)(magicast@0.5.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-router@4.5.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))(yjs@13.6.29)(zod@4.4.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.0(vue@3.5.25(typescript@6.0.3))
@@ -12021,7 +12174,7 @@ snapshots:
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3))
+      motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.25(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.25(typescript@6.0.3))
       ohash: 2.0.11
       pathe: 2.0.3
       reka-ui: 2.9.6(vue@3.5.25(typescript@6.0.3))
@@ -13009,6 +13162,10 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.4
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc/helpers@0.5.17':
     dependencies:
@@ -14803,6 +14960,8 @@ snapshots:
 
   cli-width@4.1.0: {}
 
+  client-only@0.0.1: {}
+
   cliui@7.0.4:
     dependencies:
       string-width: 4.2.3
@@ -16257,11 +16416,14 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.38.0:
+  framer-motion@12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       motion-dom: 12.38.0
       motion-utils: 12.36.0
       tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   fresh@2.0.0: {}
 
@@ -17705,10 +17867,10 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  motion-v@2.2.1(@vueuse/core@14.2.1(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3)):
+  motion-v@2.2.1(@vueuse/core@14.2.1(vue@3.5.25(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.25(typescript@6.0.3)):
     dependencies:
       '@vueuse/core': 14.2.1(vue@3.5.25(typescript@6.0.3))
-      framer-motion: 12.38.0
+      framer-motion: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       hey-listen: 1.0.8
       motion-dom: 12.38.0
       motion-utils: 12.36.0
@@ -17718,10 +17880,10 @@ snapshots:
       - react
       - react-dom
 
-  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.25(typescript@6.0.3)))(vue@3.5.25(typescript@6.0.3)):
+  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.25(typescript@6.0.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.25(typescript@6.0.3)):
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.5.25(typescript@6.0.3))
-      framer-motion: 12.38.0
+      framer-motion: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       hey-listen: 1.0.8
       motion-dom: 12.38.0
       motion-utils: 12.36.0
@@ -17770,6 +17932,30 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 15.5.18
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001760
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.18
+      '@next/swc-darwin-x64': 15.5.18
+      '@next/swc-linux-arm64-gnu': 15.5.18
+      '@next/swc-linux-arm64-musl': 15.5.18
+      '@next/swc-linux-x64-gnu': 15.5.18
+      '@next/swc-linux-x64-musl': 15.5.18
+      '@next/swc-win32-arm64-msvc': 15.5.18
+      '@next/swc-win32-x64-msvc': 15.5.18
+      '@opentelemetry/api': 1.9.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   nitropack@2.12.9(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0))(rolldown@1.0.0):
     dependencies:
@@ -18593,6 +18779,12 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
@@ -18838,6 +19030,13 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react@19.2.6: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -19112,6 +19311,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   scslre@0.3.0:
     dependencies:
@@ -19435,6 +19636,11 @@ snapshots:
       stubborn-utils: 1.0.2
 
   stubborn-utils@1.0.2: {}
+
+  styled-jsx@5.1.6(react@19.2.6):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.6
 
   stylehacks@7.0.7(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
## Summary

First-iteration Next.js integration for Unlighthouse, sibling to the [@unlighthouse/vite plugin (#359)](https://github.com/harlan-zw/unlighthouse/pull/359). Tackles the Next.js plugin bullet from [Phase 15 of #349](https://github.com/harlan-zw/unlighthouse/issues/349).

- `withUnlighthouse(nextConfig, options)` HOC wraps `next.config.js`, attaching a webpack `done` hook on the client compiler so a scan kicks off after `next build`.
- Companion `unlighthouse-next` bin for users who'd rather not touch their config.
- Honours `UNLIGHTHOUSE_SKIP=true`, only fires under `NODE_ENV=production`, dedupes via per-`buildId` latch + 250ms debounce against webpack's chatty `done` events.
- Matches the `@unlighthouse/vite` scaffold conventions: `unlighthouse` as a dynamic import (host install wins), `next` as a peer dep, obuild + publint + attw clean.

## Deferred follow-ups (noted in source + README)

- Middleware that scans on preview deploys (Vercel / Netlify hooks).
- PR-comment diff posting via GitHub API.
- Dev-mode HUD with live per-page Lighthouse scores.

## Test plan

- [x] `pnpm --filter @unlighthouse/next test` — 9 shape-only tests passing (HOC merge, webpack chain, env-gating, dedupe, default export).
- [x] `pnpm --filter @unlighthouse/next typecheck` — clean.
- [x] `pnpm --filter @unlighthouse/next build` — obuild emits both `index.mjs` + `cli.mjs` + d.mts.
- [x] `pnpm --filter @unlighthouse/next test:publint` — clean.
- [x] `pnpm --filter @unlighthouse/next test:attw` — clean (esm-only profile).
- [ ] Manual smoke against a real Next 15 app (out of scope for the scaffold PR — leaving for reviewer).

Refs #349.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>