### PR TITLE
feat(ui): report filtering — device, score threshold, regression status (closes #24)

### DIFF
--- a/packages/ui/composables/search.ts
+++ b/packages/ui/composables/search.ts
@@ -11,10 +11,49 @@ export interface Sorting {
 
 export const perPage = 10
 
+// Filter atoms for the routes table on results/[scanId]/index.vue.
+// Persisted via useState so they survive layout re-mounts; the page
+// keeps URL ?query in sync by watching these refs.
+export type DeviceFilter = 'all' | 'mobile' | 'desktop'
+export type RegressionStatus = 'all' | 'worse' | 'better' | 'same'
+export type ScoreCategoryFilter
+  = | 'overall'
+    | 'performance'
+    | 'accessibility'
+    | 'best-practices'
+    | 'seo'
+export type ScoreOp = '>=' | '<='
+
 export function useResultsSearch() {
   const searchText = useState<string>('search:text', () => '')
   const sorting = useState<Sorting>('search:sorting', () => ({}))
   const page = useState<number>('search:page', () => 1)
+  // Toolbar filters — see `pages/results/[scanId]/index.vue` for wiring.
+  const deviceFilter = useState<DeviceFilter>('search:device', () => 'all')
+  const scoreCategory = useState<ScoreCategoryFilter>('search:scoreCategory', () => 'overall')
+  const scoreOp = useState<ScoreOp>('search:scoreOp', () => '>=')
+  // `null` means "no threshold" — display as a blank input.
+  const scoreValue = useState<number | null>('search:scoreValue', () => null)
+  const regressionStatus = useState<RegressionStatus>('search:regression', () => 'all')
+
+  function resetFilters() {
+    searchText.value = ''
+    deviceFilter.value = 'all'
+    scoreCategory.value = 'overall'
+    scoreOp.value = '>='
+    scoreValue.value = null
+    regressionStatus.value = 'all'
+    page.value = 1
+  }
+
+  // True when any non-default filter is active. Lets the page render a
+  // "Reset filters" affordance only when there's something to reset.
+  const hasActiveFilters = computed(() =>
+    !!searchText.value
+    || deviceFilter.value !== 'all'
+    || scoreValue.value !== null
+    || regressionStatus.value !== 'all',
+  )
 
   const { reports } = useReports()
   const { configColumns, groupRoutesKey } = useUnlighthouseConfig()
@@ -117,5 +156,13 @@ export function useResultsSearch() {
     incrementSort,
     searchResults,
     paginatedResults,
+    // toolbar filters
+    deviceFilter,
+    scoreCategory,
+    scoreOp,
+    scoreValue,
+    regressionStatus,
+    hasActiveFilters,
+    resetFilters,
   }
 }

--- a/packages/ui/composables/usePreviousScan.ts
+++ b/packages/ui/composables/usePreviousScan.ts
@@ -1,0 +1,52 @@
+// Fetches the scan immediately preceding `scanId` for the same site so the
+// results page can surface per-route regression status. We resolve by:
+//   1. history.get the current scan (to know its site + startedAt)
+//   2. history.list that site (sorted desc) and take the first scan whose
+//      startedAt < current.startedAt
+//   3. history.get that previous scan to pull its routes (= per-(url,device)
+//      score atoms)
+//
+// All requests are .catch'd to null — a missing previous scan just disables
+// the regression filter, never breaks the page.
+
+import type { ScanId, ScanRoute } from '@unlighthouse/contracts'
+import { useApiClient } from './useApiClient'
+
+export interface PreviousScanResult {
+  scanId: string
+  routes: ScanRoute[]
+}
+
+export function usePreviousScan(scanId: MaybeRef<string | undefined>) {
+  const apiClient = useApiClient()
+  const id = computed(() => unref(scanId))
+
+  return useAsyncData<PreviousScanResult | null>(
+    () => `prev-scan:${id.value ?? ''}`,
+    async () => {
+      if (!id.value)
+        return null
+      const current = await apiClient['history.get']({ scanId: id.value as ScanId }).catch(() => null)
+      if (!current)
+        return null
+      const list = await apiClient['history.list']({
+        site: current.site,
+        page: 1,
+        pageSize: 50,
+      }).catch(() => null)
+      if (!list?.items?.length)
+        return null
+      // history.list isn't documented as sorted, so sort defensively. Most
+      // recent first, then find the first scan strictly older than ours.
+      const sorted = [...list.items].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+      const prev = sorted.find(s => s.scanId !== current.scanId && s.startedAt < current.startedAt)
+      if (!prev)
+        return null
+      const full = await apiClient['history.get']({ scanId: prev.scanId }).catch(() => null)
+      if (!full)
+        return null
+      return { scanId: String(prev.scanId), routes: full.routes ?? [] }
+    },
+    { watch: [id], default: () => null },
+  )
+}

--- a/packages/ui/pages/results/[scanId]/index.vue
+++ b/packages/ui/pages/results/[scanId]/index.vue
@@ -3,12 +3,24 @@ import Fuse from 'fuse.js'
 import { useResultsSearch } from '~/composables/search'
 import { useHistoricalScan } from '~/composables/useHistoricalScan'
 import { useLighthouseReportModal } from '~/composables/useLighthouseReportModal'
+import { usePreviousScan } from '~/composables/usePreviousScan'
 import { useReports } from '~/composables/useReports'
 import { useUnlighthouseConfig } from '~/composables/useUnlighthouseConfig'
 
 const { isStatic, resolveArtifactPath } = useUnlighthouseConfig()
 const { reports: liveReports } = useReports()
-const { page, perPage, searchText } = useResultsSearch()
+const {
+  page,
+  perPage,
+  searchText,
+  deviceFilter,
+  scoreCategory,
+  scoreOp,
+  scoreValue,
+  regressionStatus,
+  hasActiveFilters,
+  resetFilters,
+} = useResultsSearch()
 const {
   isOpen: lighthouseReportModalOpen,
   url: iframeModalUrl,
@@ -37,9 +49,82 @@ const modalDeviceTabValue = computed({
 definePageMeta({ layout: 'site' })
 
 const route = useRoute()
+const router = useRouter()
 const scanId = computed(() => route.params.scanId as string | undefined)
 const { data: historicalScan } = useHistoricalScan(scanId)
 const isHistorical = computed(() => !!scanId.value && !!historicalScan.value)
+
+// Previous scan (for the same site) drives the "regression" filter. The
+// dropdown is disabled when no prior scan exists, so a fresh site looks
+// identical to the pre-filter UI.
+const { data: previousScan } = usePreviousScan(scanId)
+const hasComparison = computed(() => !!previousScan.value?.routes?.length)
+
+// Prev-scan per-route lookup: key by `${path}|${device}` so matrix scans
+// compare mobile-to-mobile and desktop-to-desktop instead of muddling them.
+const prevByRouteDevice = computed(() => {
+  const map = new Map<string, any>()
+  for (const r of previousScan.value?.routes ?? []) {
+    map.set(`${r.path}|${r.device}`, r)
+  }
+  return map
+})
+
+// ── Hydrate filter state from URL query on mount ───────────────────────────
+// We hydrate once (not as a deep watch on route.query) so the page is
+// shareable but typing into a filter doesn't trigger a router round-trip
+// for every keystroke before the URL push below runs.
+onMounted(() => {
+  const q = route.query
+  if (typeof q.search === 'string')
+    searchText.value = q.search
+  if (q.device === 'mobile' || q.device === 'desktop' || q.device === 'all')
+    deviceFilter.value = q.device
+  if (q.cat === 'overall' || q.cat === 'performance' || q.cat === 'accessibility' || q.cat === 'best-practices' || q.cat === 'seo')
+    scoreCategory.value = q.cat
+  if (q.scoreOp === '>=' || q.scoreOp === '<=')
+    scoreOp.value = q.scoreOp
+  if (typeof q.score === 'string') {
+    const n = Number.parseInt(q.score, 10)
+    if (Number.isFinite(n) && n >= 0 && n <= 100)
+      scoreValue.value = n
+  }
+  if (q.regression === 'worse' || q.regression === 'better' || q.regression === 'same' || q.regression === 'all')
+    regressionStatus.value = q.regression
+})
+
+// Push filter state back into URL query string. `replace` so we don't
+// pollute history with every keystroke; default values are stripped to
+// keep clean URLs.
+watch(
+  [searchText, deviceFilter, scoreCategory, scoreOp, scoreValue, regressionStatus],
+  () => {
+    const next: Record<string, string> = {}
+    if (searchText.value)
+      next.search = searchText.value
+    if (deviceFilter.value !== 'all')
+      next.device = deviceFilter.value
+    if (scoreValue.value != null) {
+      next.score = String(scoreValue.value)
+      next.cat = scoreCategory.value
+      next.scoreOp = scoreOp.value
+    }
+    if (regressionStatus.value !== 'all')
+      next.regression = regressionStatus.value
+    // Preserve any non-filter query keys (none today, but future-proof).
+    const merged = { ...route.query, ...next }
+    // Strip stale filter keys when reverting to default.
+    for (const k of ['search', 'device', 'score', 'cat', 'scoreOp', 'regression']) {
+      if (!(k in next))
+        delete (merged as any)[k]
+    }
+    router.replace({ query: merged })
+    // Any filter change resets pagination to page 1 — page N may not exist
+    // in the filtered result set.
+    page.value = 1
+  },
+  { flush: 'post' },
+)
 
 // Sort & filter state
 const sortBy = ref<'score' | 'performance' | 'accessibility' | 'best-practices' | 'seo' | 'path'>('path')
@@ -176,6 +261,110 @@ const summaryStats = computed(() => {
   ]
 })
 
+// Per-device score lookup: pulls the chosen category from a report row,
+// returning 0..100 ints (or null when the row has no scored report). Used by
+// the toolbar threshold / regression filters.
+function deviceScore(row: any, cat: string): number | null {
+  if (!row?.report?.categories)
+    return null
+  if (cat === 'overall')
+    return getOverallScore(row)
+  return getCategoryScore(row, cat)
+}
+
+// Prev-scan score atom (0..100). Reads the per-category fields straight off
+// the persisted ScanRoute — `scorePerformance`, `scoreAccessibility`, ….
+function prevDeviceScore(path: string, device: 'mobile' | 'desktop', cat: string): number | null {
+  const r = prevByRouteDevice.value.get(`${path}|${device}`)
+  if (!r)
+    return null
+  const get = (s: number | null | undefined) => (s == null ? null : Math.round(s * 100))
+  if (cat === 'performance')
+    return get(r.scorePerformance)
+  if (cat === 'accessibility')
+    return get(r.scoreAccessibility)
+  if (cat === 'best-practices')
+    return get(r.scoreBestPractices)
+  if (cat === 'seo')
+    return get(r.scoreSeo)
+  // overall — average present categories on the prev row.
+  const present = [r.scorePerformance, r.scoreAccessibility, r.scoreBestPractices, r.scoreSeo]
+    .filter((s): s is number => s != null)
+    .map(s => s * 100)
+  if (!present.length)
+    return null
+  return Math.round(present.reduce((a, b) => a + b, 0) / present.length)
+}
+
+// Bucket a (current, prev) score pair into a regression status. ±2 points
+// of jitter rounds to "same" so noise from one warm-up doesn't paint every
+// route as worse/better.
+function regressionFor(group: RouteGroup, device: 'mobile' | 'desktop', cat: string): 'worse' | 'better' | 'same' | null {
+  const row = device === 'mobile' ? group.mobile : group.desktop
+  if (!row)
+    return null
+  const cur = deviceScore(row, cat)
+  const prev = prevDeviceScore(group.path, device, cat)
+  if (cur == null || prev == null)
+    return null
+  const delta = cur - prev
+  if (delta <= -3)
+    return 'worse'
+  if (delta >= 3)
+    return 'better'
+  return 'same'
+}
+
+// Returns the devices on a group that the current device filter selects.
+// `all` keeps mobile + desktop; `mobile` / `desktop` narrow to one form-factor.
+function selectedDevicesFor(g: RouteGroup): ('mobile' | 'desktop')[] {
+  if (deviceFilter.value === 'mobile')
+    return g.mobile ? ['mobile'] : []
+  if (deviceFilter.value === 'desktop')
+    return g.desktop ? ['desktop'] : []
+  // 'all'
+  const out: ('mobile' | 'desktop')[] = []
+  if (g.mobile)
+    out.push('mobile')
+  if (g.desktop)
+    out.push('desktop')
+  return out
+}
+
+// A group matches the threshold/regression filters iff *any* of its selected
+// devices satisfies them — i.e. one mobile row scoring ≥80 keeps the group
+// even if desktop scores 50. Matches the user's mental model (search by
+// route, scoped to a device).
+function groupMatchesScoreAndRegression(g: RouteGroup): boolean {
+  const devices = selectedDevicesFor(g)
+  if (!devices.length)
+    return false
+  return devices.some((dev) => {
+    const row = dev === 'mobile' ? g.mobile : g.desktop
+    if (!row)
+      return false
+    // Score threshold.
+    if (scoreValue.value != null) {
+      const s = deviceScore(row, scoreCategory.value)
+      if (s == null)
+        return false
+      if (scoreOp.value === '>=' && s < scoreValue.value)
+        return false
+      if (scoreOp.value === '<=' && s > scoreValue.value)
+        return false
+    }
+    // Regression status.
+    if (regressionStatus.value !== 'all' && hasComparison.value) {
+      const r = regressionFor(g, dev, scoreCategory.value)
+      if (r == null)
+        return false
+      if (r !== regressionStatus.value)
+        return false
+    }
+    return true
+  })
+}
+
 // Fuzzy search + sort + filter — operates on grouped rows so paginate/sort
 // reflect logical routes, not (route, device) pairs.
 const searchResults = computed((): RouteGroup[] => {
@@ -188,6 +377,16 @@ const searchResults = computed((): RouteGroup[] => {
       keys: ['path', 'url'],
     })
     data = fuse.search(searchText.value).map(i => i.item)
+  }
+
+  // Toolbar filters: device + score threshold + regression status. Applied
+  // before the quick filter so worst5/best5 reflects the filtered set.
+  if (
+    deviceFilter.value !== 'all'
+    || scoreValue.value != null
+    || (regressionStatus.value !== 'all' && hasComparison.value)
+  ) {
+    data = data.filter(groupMatchesScoreAndRegression)
   }
 
   // Quick filter: scores come from the primary report (mobile when present).
@@ -264,6 +463,32 @@ const filterOptions = [
   { label: 'Below 50', value: 'below50' },
 ]
 
+const deviceOptions = [
+  { label: 'All', value: 'all' },
+  { label: 'Mobile', value: 'mobile' },
+  { label: 'Desktop', value: 'desktop' },
+]
+
+const scoreCategoryOptions = [
+  { label: 'Overall', value: 'overall' },
+  { label: 'Performance', value: 'performance' },
+  { label: 'Accessibility', value: 'accessibility' },
+  { label: 'Best Practices', value: 'best-practices' },
+  { label: 'SEO', value: 'seo' },
+]
+
+const scoreOpOptions: { label: string, value: '>=' | '<=' }[] = [
+  { label: '≥', value: '>=' },
+  { label: '≤', value: '<=' },
+]
+
+const regressionOptions = [
+  { label: 'Any', value: 'all' },
+  { label: 'Worse', value: 'worse' },
+  { label: 'Better', value: 'better' },
+  { label: 'Same', value: 'same' },
+]
+
 </script>
 
 <template>
@@ -307,6 +532,64 @@ const filterOptions = [
       <div class="flex items-center gap-2">
         <span class="text-xs text-dimmed">Filter:</span>
         <UiPillSelect v-model="quickFilter" :options="filterOptions" />
+      </div>
+
+      <div v-if="hasActiveFilters" class="ml-auto">
+        <UiMotionButton
+          variant="ghost"
+          size="xs"
+          icon="i-heroicons-x-mark"
+          @click="resetFilters"
+        >
+          <span class="hidden sm:inline">Reset filters</span>
+        </UiMotionButton>
+      </div>
+    </div>
+
+    <!-- Advanced filter toolbar — collapses to a single wrapping row on
+         narrow viewports. Score threshold + regression status only act on
+         their respective category (Overall / Performance / …). -->
+    <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mb-6 text-xs">
+      <div class="flex items-center gap-2">
+        <span class="text-dimmed">Device:</span>
+        <UiPillSelect v-model="deviceFilter" :options="deviceOptions" />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span class="text-dimmed">Score:</span>
+        <USelectMenu
+          v-model="scoreCategory"
+          :items="scoreCategoryOptions"
+          value-key="value"
+          size="xs"
+          class="w-32"
+        />
+        <UiPillSelect v-model="scoreOp" :options="scoreOpOptions" />
+        <UInput
+          v-model.number="scoreValue"
+          type="number"
+          min="0"
+          max="100"
+          placeholder="–"
+          size="xs"
+          class="w-16"
+          :ui="{ base: 'bg-elevated/60 border-default focus-visible:border-accented focus-visible:ring-accented text-right' }"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span class="text-dimmed">Regression:</span>
+        <USelectMenu
+          v-model="regressionStatus"
+          :items="regressionOptions"
+          value-key="value"
+          size="xs"
+          class="w-24"
+          :disabled="!hasComparison"
+        />
+        <span v-if="!hasComparison" class="text-dimmed/70 italic">
+          (no prev scan)
+        </span>
       </div>
     </div>
 


### PR DESCRIPTION
Part of #349 (Phase 17 — UI polish). Closes #24 (open since 2019).

## Summary

Adds a filter toolbar above the routes table on `results/[scanId]/index.vue`. Composes with the existing fuzzy search + quick-filter pills:

- **Device** (all / mobile / desktop) — narrows the form-factors a route group is judged by. A group matches if *any* selected device row satisfies the remaining filters
- **Score threshold** — pick a category (Overall / Performance / Accessibility / Best Practices / SEO), op (≥ / ≤), and a 0..100 value
- **Regression status** (worse / better / same / any) — compares each route to the same `(route, device)` in the previous scan for this site; ±2 points rounds to "same" to ignore warm-up jitter. **Disabled** when no prior scan exists, so a fresh site renders identically to before this PR

Filter state lives in `useResultsSearch()` (so it survives navigation) and round-trips through the URL query string — `?device=mobile&score=80&cat=performance&scoreOp=>=&regression=worse` — for shareable filtered views. A "Reset filters" affordance appears when any non-default filter is active.

A new `usePreviousScan(scanId)` composable resolves the prior scan via `history.list` (sorted by `startedAt`) + `history.get`. All requests are `.catch(() => null)` — a missing prev scan just disables the regression filter, never breaks the page.

## What changed

- `packages/ui/composables/search.ts` — extended `useResultsSearch()` with `deviceFilter`, `scoreCategory`, `scoreOp`, `scoreValue`, `regressionStatus`, `hasActiveFilters`, `resetFilters`
- `packages/ui/composables/usePreviousScan.ts` — new
- `packages/ui/pages/results/[scanId]/index.vue` — toolbar UI (UInput / USelectMenu / UiPillSelect), URL ↔ state sync, filter logic wired into the existing `RouteGroup` grouping from #360

Backwards-compatible: with all filters default + no prev scan, the page renders identically to today.

## Test plan

- [x] `pnpm --filter @unlighthouse/ui typecheck` — clean for new files
- [x] `pnpm build` — succeeds end-to-end
- [x] `pnpm lint` — clean
- [x] `pnpm --filter @unlighthouse/ui dev` — `/` and `/results/<id>?device=mobile&score=80&cat=performance&scoreOp=>=` both serve 200 with no console errors
- [ ] Manual: run a scan, verify search + device + score threshold + reset all behave
- [ ] Manual: run a second scan against the same site, verify the regression dropdown activates and Worse / Better / Same buckets respect ±2 jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)