### PR TITLE
fix(ui): column sorting handles nulls + RouteGroup correctly (closes #101)

### DIFF
--- a/packages/ui/pages/results/[scanId]/index.vue
+++ b/packages/ui/pages/results/[scanId]/index.vue
@@ -6,6 +6,7 @@ import { useLighthouseReportModal } from '~/composables/useLighthouseReportModal
 import { usePreviousScan } from '~/composables/usePreviousScan'
 import { useReports } from '~/composables/useReports'
 import { useUnlighthouseConfig } from '~/composables/useUnlighthouseConfig'
+import { makeRouteGroupComparator } from '~/utils/sortRoutes'
 
 const { isStatic, resolveArtifactPath } = useUnlighthouseConfig()
 const { reports: liveReports } = useReports()
@@ -403,25 +404,12 @@ const searchResults = computed((): RouteGroup[] => {
     }
   }
 
-  // Sort by group key — same comparators as before, just reading from primary.
-  if (sortBy.value === 'path') {
-    data = [...data].sort((a, b) => {
-      const cmp = (a.path || '').localeCompare(b.path || '')
-      return sortDir.value === 'asc' ? cmp : -cmp
-    })
-  }
-  else if (sortBy.value === 'score') {
-    data = [...data].sort((a, b) => {
-      const diff = (getOverallScore(a.primary) ?? -1) - (getOverallScore(b.primary) ?? -1)
-      return sortDir.value === 'asc' ? diff : -diff
-    })
-  }
-  else {
-    data = [...data].sort((a, b) => {
-      const diff = (getCategoryScore(a.primary, sortBy.value) ?? -1) - (getCategoryScore(b.primary, sortBy.value) ?? -1)
-      return sortDir.value === 'asc' ? diff : -diff
-    })
-  }
+  // Sort at the RouteGroup level: nulls always sink, multi-device rows use
+  // the max(mobile, desktop) score per category so a row still scanning on
+  // desktop isn't penalised. Closes #101 — the old comparator used `-1` as a
+  // sentinel for null which placed scanning rows at the *top* in ascending
+  // order. See `utils/sortRoutes.ts` for the pure helpers + tests.
+  data = [...data].sort(makeRouteGroupComparator(sortBy.value, sortDir.value))
 
   return data
 })

--- a/packages/ui/test/sortRoutes.test.ts
+++ b/packages/ui/test/sortRoutes.test.ts
@@ -1,0 +1,159 @@
+import type { SortableRouteGroup } from '../utils/sortRoutes'
+import { describe, expect, it } from 'vitest'
+import { groupCategoryScore, groupOverallScore, makeRouteGroupComparator } from '../utils/sortRoutes'
+
+// Regression tests for harlan-zw/unlighthouse#101: the routes-table sort was
+// broken because the old comparator used `-1` as a null sentinel, which
+// placed scanning rows at the top of an ascending sort. These tests pin the
+// fix: nulls always sink, multi-device rows use max(devices), and the
+// "Overall" column averages the categories present.
+
+/**
+ * Tiny row factory — produces just enough shape to satisfy
+ * `SortableRouteGroup` without dragging in the full Lighthouse types.
+ */
+function row(scores: Partial<Record<'performance' | 'accessibility' | 'best-practices' | 'seo', number | null>>) {
+  const categories: Record<string, { score: number | null }> = {}
+  for (const [k, v] of Object.entries(scores)) {
+    categories[k] = { score: v as number | null }
+  }
+  return { report: { categories } }
+}
+
+function group(opts: {
+  path: string
+  mobile?: ReturnType<typeof row> | null
+  desktop?: ReturnType<typeof row> | null
+  primary?: ReturnType<typeof row> | null
+}): SortableRouteGroup {
+  return {
+    path: opts.path,
+    mobile: opts.mobile,
+    desktop: opts.desktop,
+    primary: opts.primary ?? opts.mobile ?? opts.desktop ?? null,
+  }
+}
+
+describe('groupCategoryScore', () => {
+  it('returns the rounded 0..100 score for a single-device row', () => {
+    const g = group({ path: '/', mobile: row({ performance: 0.42 }) })
+    expect(groupCategoryScore(g, 'performance')).toBe(42)
+  })
+
+  it('returns the max across mobile + desktop for multi-device rows', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.30 }),
+      desktop: row({ performance: 0.85 }),
+    })
+    expect(groupCategoryScore(g, 'performance')).toBe(85)
+  })
+
+  it('falls back to primary when neither mobile nor desktop carries a score', () => {
+    const g: SortableRouteGroup = {
+      path: '/',
+      primary: row({ performance: 0.55 }),
+    }
+    expect(groupCategoryScore(g, 'performance')).toBe(55)
+  })
+
+  it('returns null when no device has a score for the category', () => {
+    const g = group({ path: '/', mobile: row({ accessibility: 0.9 }) })
+    expect(groupCategoryScore(g, 'performance')).toBeNull()
+  })
+
+  it('preserves a real zero score (not treated as missing)', () => {
+    const g = group({ path: '/', mobile: row({ performance: 0 }) })
+    expect(groupCategoryScore(g, 'performance')).toBe(0)
+  })
+})
+
+describe('groupOverallScore', () => {
+  it('averages only the categories present on the group', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.5, accessibility: 1.0 }),
+    })
+    // Mean of [50, 100] → 75
+    expect(groupOverallScore(g)).toBe(75)
+  })
+
+  it('uses the max(devices) per category before averaging', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.2, seo: 1.0 }),
+      desktop: row({ performance: 0.9, seo: 0.5 }),
+    })
+    // max(perf) = 90, max(seo) = 100 → mean = 95
+    expect(groupOverallScore(g)).toBe(95)
+  })
+
+  it('returns null when every category is missing', () => {
+    const g = group({ path: '/', mobile: row({}) })
+    expect(groupOverallScore(g)).toBeNull()
+  })
+})
+
+describe('makeRouteGroupComparator', () => {
+  const fullyScanned = group({
+    path: '/a',
+    mobile: row({ 'performance': 0.7, 'accessibility': 0.9, 'best-practices': 0.8, 'seo': 1.0 }),
+  })
+  const partiallyScanned = group({
+    path: '/b',
+    mobile: row({ performance: 0.3, accessibility: 0.5 }),
+  })
+  const scanning = group({ path: '/c', mobile: row({}) })
+  const multiDevice = group({
+    path: '/d',
+    mobile: row({ performance: 0.4 }),
+    desktop: row({ performance: 0.95 }),
+  })
+  const lowScore = group({ path: '/e', mobile: row({ performance: 0.1 }) })
+
+  function sort(rows: SortableRouteGroup[], by: Parameters<typeof makeRouteGroupComparator>[0], dir: 'asc' | 'desc') {
+    return [...rows].sort(makeRouteGroupComparator(by, dir)).map(g => g.path)
+  }
+
+  it('sorts paths asc/desc alphabetically', () => {
+    expect(sort([scanning, fullyScanned, lowScore], 'path', 'asc')).toEqual(['/a', '/c', '/e'])
+    expect(sort([scanning, fullyScanned, lowScore], 'path', 'desc')).toEqual(['/e', '/c', '/a'])
+  })
+
+  it('sorts performance score asc with nulls at the BOTTOM (not top — fixes #101)', () => {
+    const result = sort([scanning, multiDevice, fullyScanned, lowScore], 'performance', 'asc')
+    // Numeric ascending: low (10), full (70), multi (max=95). Scanning has
+    // no perf score and must land last — the bug was it landed first because
+    // the old `?? -1` made it the smallest value.
+    expect(result).toEqual(['/e', '/a', '/d', '/c'])
+  })
+
+  it('sorts performance score desc with nulls at the BOTTOM', () => {
+    const result = sort([scanning, multiDevice, fullyScanned, lowScore], 'performance', 'desc')
+    expect(result).toEqual(['/d', '/a', '/e', '/c'])
+  })
+
+  it('sorts the Overall column by mean(present categories) with nulls last in both directions', () => {
+    const ascending = sort([scanning, partiallyScanned, fullyScanned], 'score', 'asc')
+    // Partial mean = (30+50)/2 = 40; Full mean = (70+90+80+100)/4 = 85;
+    // Scanning has no overall → sinks to the bottom.
+    expect(ascending).toEqual(['/b', '/a', '/c'])
+    const descending = sort([scanning, partiallyScanned, fullyScanned], 'score', 'desc')
+    expect(descending).toEqual(['/a', '/b', '/c'])
+  })
+
+  it('uses the better device for a multi-device group when sorting', () => {
+    // multiDevice has mobile=40, desktop=95 → desc places it above
+    // fullyScanned (70) only because the comparator uses max(devices)=95.
+    const result = sort([fullyScanned, multiDevice], 'performance', 'desc')
+    expect(result).toEqual(['/d', '/a'])
+  })
+
+  it('handles an all-null row consistently in either direction', () => {
+    const allNull = group({ path: '/null', mobile: row({}) })
+    const a = group({ path: '/a', mobile: row({ performance: 0.5 }) })
+    const b = group({ path: '/b', mobile: row({ performance: 0.8 }) })
+    expect(sort([allNull, a, b], 'performance', 'asc')).toEqual(['/a', '/b', '/null'])
+    expect(sort([allNull, a, b], 'performance', 'desc')).toEqual(['/b', '/a', '/null'])
+  })
+})

--- a/packages/ui/utils/sortRoutes.ts
+++ b/packages/ui/utils/sortRoutes.ts
@@ -1,0 +1,141 @@
+// Pure sort helpers for the routes table in
+// `pages/results/[scanId]/index.vue`. Extracted so they can be unit-tested
+// without mounting the page — closes #101 (column sorting broken for
+// performance score on rows still scanning).
+//
+// Design constraints:
+//   1. `null`/`undefined` scores always sink to the bottom, regardless of
+//      direction. Previous logic used `-1` as a sentinel which placed nulls
+//      at the *top* in ascending order.
+//   2. RouteGroup rows can have both `mobile` and `desktop` reports; use the
+//      better (max) device score so multi-device rows sort sensibly against
+//      single-device rows.
+//   3. The "Overall" sort key is the mean of the categories present on the
+//      group — matches the summary card semantics.
+
+export type SortDir = 'asc' | 'desc'
+export type CategoryKey = 'performance' | 'accessibility' | 'best-practices' | 'seo'
+export type SortKey = CategoryKey | 'score' | 'path'
+
+const CATEGORY_KEYS: readonly CategoryKey[] = [
+  'performance',
+  'accessibility',
+  'best-practices',
+  'seo',
+] as const
+
+interface CategoryShape {
+  score?: number | null
+}
+
+interface ReportShape {
+  categories?: Record<string, CategoryShape> | null
+}
+
+interface ReportRow {
+  report?: ReportShape | null
+}
+
+/**
+ * A grouped row matching the `RouteGroup` interface in
+ * `pages/results/[scanId]/index.vue`. We accept the shape structurally so the
+ * tests don't have to construct full Lighthouse payloads.
+ */
+export interface SortableRouteGroup {
+  path?: string
+  mobile?: ReportRow | null
+  desktop?: ReportRow | null
+  /**
+   * The single-device fallback row. Used when neither `mobile` nor `desktop`
+   * carries a score (older single-device scans, or when the matrix scan
+   * hasn't populated both yet).
+   */
+  primary?: ReportRow | null
+}
+
+/**
+ * Read a Lighthouse 0..1 score and return it as a 0..100 integer, or `null`
+ * when the score is missing or non-numeric. Numeric `0` is preserved (a real
+ * zero score) — we explicitly only treat `null`/`undefined`/`NaN` as missing.
+ */
+function readScore(row: ReportRow | null | undefined, cat: CategoryKey): number | null {
+  const raw = row?.report?.categories?.[cat]?.score
+  if (raw == null || Number.isNaN(raw))
+    return null
+  return Math.round(raw * 100)
+}
+
+/**
+ * For a single category, return the *best* score across the group's mobile
+ * + desktop reports, falling back to `primary` when neither device row has
+ * one. Returns `null` only when no device has a score for this category.
+ */
+export function groupCategoryScore(g: SortableRouteGroup, cat: CategoryKey): number | null {
+  const scores = [
+    readScore(g.mobile, cat),
+    readScore(g.desktop, cat),
+  ].filter((s): s is number => s != null)
+  if (scores.length)
+    return Math.max(...scores)
+  // Fall back to primary for older single-device payloads where mobile /
+  // desktop aren't tagged separately.
+  return readScore(g.primary, cat)
+}
+
+/**
+ * The "Overall" column: mean of category scores present on the group. Mirrors
+ * `getOverallScore` in `index.vue` but operates on the group (max across
+ * devices) so multi-device rows aren't penalised when one device lags.
+ */
+export function groupOverallScore(g: SortableRouteGroup): number | null {
+  const scores = CATEGORY_KEYS
+    .map(c => groupCategoryScore(g, c))
+    .filter((s): s is number => s != null)
+  if (!scores.length)
+    return null
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+}
+
+/**
+ * Compare two scores with `null` always sinking to the bottom. Returns a
+ * value compatible with `Array.prototype.sort` such that, when used as
+ * `compareScores(a, b) * (dir === 'asc' ? 1 : -1)`, null rows end up *last*
+ * in both orders.
+ */
+function compareScores(a: number | null, b: number | null, dir: SortDir): number {
+  // null always sinks: replace with -Infinity for desc (so it lands at the
+  // end after negation) and +Infinity for asc (so it lands at the end
+  // directly).
+  const sentinel = dir === 'desc' ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY
+  const av = a ?? sentinel
+  const bv = b ?? sentinel
+  if (av === bv)
+    return 0
+  return av < bv ? -1 : 1
+}
+
+/**
+ * Build the comparator used by the routes table. Pure & side-effect free so
+ * the page can use it inside a `computed` without invalidation surprises.
+ */
+export function makeRouteGroupComparator(
+  sortBy: SortKey,
+  dir: SortDir,
+): (a: SortableRouteGroup, b: SortableRouteGroup) => number {
+  if (sortBy === 'path') {
+    return (a, b) => {
+      const cmp = (a.path || '').localeCompare(b.path || '')
+      return dir === 'asc' ? cmp : -cmp
+    }
+  }
+  if (sortBy === 'score') {
+    return (a, b) => {
+      const raw = compareScores(groupOverallScore(a), groupOverallScore(b), dir)
+      return dir === 'asc' ? raw : -raw
+    }
+  }
+  return (a, b) => {
+    const raw = compareScores(groupCategoryScore(a, sortBy), groupCategoryScore(b, sortBy), dir)
+    return dir === 'asc' ? raw : -raw
+  }
+}


### PR DESCRIPTION
Closes #101 and ticks the "column sorting that actually works for performance score" item in #349 Phase 17.

## Summary
- The routes-table comparator in `pages/results/[scanId]/index.vue` used `-1` as a null sentinel, which pushed in-progress / partially-scanned rows to the *top* of an ascending sort instead of the bottom. This was particularly visible on the Performance column when a scan was still running.
- Extracted the sort logic into a pure `utils/sortRoutes.ts` helper so it can be unit-tested without mounting the page. It treats null / undefined as a true "sinks to the bottom in both directions" sentinel, uses `max(mobile, desktop)` for the per-category score so multi-device matrix scans aren't penalised when one device lags, and computes the Overall column as the mean of categories present on the group.
- Direction toggle and the Path column behaviour are unchanged.

## Test plan
- [x] `pnpm vitest run packages/ui/test/sortRoutes.test.ts` — 14 cases covering all-null rows, mixed nulls, multi-device groups, real zero scores, and the asc/desc null-sink invariant
- [x] `pnpm --filter @unlighthouse/ui typecheck`
- [x] `pnpm --filter @unlighthouse/ui build`
- [ ] Manual smoke: load a multi-route scan, click Performance — null rows should land last in both asc and desc

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)