### PR TITLE
feat(ui): multi-site dashboard (closes #227)

### DIFF
--- a/packages/ui/components/Site/ScannedSiteCard.vue
+++ b/packages/ui/components/Site/ScannedSiteCard.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import type { ScannedSite } from '~/composables/useScannedSites'
+import { getScoreBg, getScoreColor } from '~/utils'
+
+const { site } = defineProps<{ site: ScannedSite }>()
+
+// Prefer drilling into the registered-site view (history table, settings) when
+// we have a registry match. Otherwise route to a host-keyed scan history view.
+const to = computed(() =>
+  site.registry
+    ? `/sites/${site.registry.id}`
+    : `/sites/scanned/${encodeURIComponent(site.host)}`,
+)
+
+function fmtRelative(iso: string | undefined) {
+  if (!iso)
+    return '—'
+  const then = new Date(iso).getTime()
+  const diff = Date.now() - then
+  const m = Math.floor(diff / 60_000)
+  if (m < 1)
+    return 'just now'
+  if (m < 60)
+    return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24)
+    return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 30)
+    return `${d}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+const latest = computed(() => site.latest)
+const summary = computed(() => site.latestComplete?.summary ?? null)
+</script>
+
+<template>
+  <NuxtLink
+    :to="to"
+    class="block group rounded-sm ring-1 ring-default bg-elevated/40 hover:bg-elevated/70 transition-colors p-4"
+  >
+    <div class="flex items-start gap-3 mb-4">
+      <SiteFavicon :url="site.url" :sz="64" :alt="site.host" class="size-8" />
+      <div class="flex-1 min-w-0">
+        <div class="font-medium text-highlighted truncate">
+          {{ site.registry?.name || site.host }}
+        </div>
+        <div class="text-xs text-dimmed font-mono truncate">
+          {{ site.host }}
+        </div>
+      </div>
+      <span
+        v-if="!site.registry"
+        class="text-[10px] uppercase tracking-wider text-dimmed px-1.5 py-0.5 rounded ring-1 ring-default"
+        title="No matching site in the registry — scanned via override"
+      >
+        ad-hoc
+      </span>
+    </div>
+
+    <div class="flex items-center gap-1.5 mb-4">
+      <TableScoreTile
+        v-for="(score, key) in {
+          P: site.scores.performance,
+          A: site.scores.accessibility,
+          B: site.scores.bestPractices,
+          S: site.scores.seo,
+        }"
+        :key="key"
+        :score="score"
+        :label="key"
+        :bg-class="[getScoreBg(score), getScoreColor(score)]"
+      />
+      <div class="ml-auto">
+        <SiteScoreSparkline :values="site.trend" />
+      </div>
+    </div>
+
+    <div class="pt-3 border-t border-default flex items-center justify-between text-[11px] text-dimmed">
+      <span>
+        {{ site.scanCount }} scan{{ site.scanCount === 1 ? '' : 's' }}
+        <span v-if="summary?.routes != null" class="ml-1">· {{ summary.routes }} routes</span>
+      </span>
+      <span>
+        Last {{ fmtRelative(latest?.startedAt) }}
+      </span>
+    </div>
+  </NuxtLink>
+</template>

--- a/packages/ui/components/Site/SiteScoreSparkline.vue
+++ b/packages/ui/components/Site/SiteScoreSparkline.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+// Tiny inline SVG sparkline for a sequence of 0..100 scores. Renders nothing
+// when there are fewer than 2 points (a single dot would be misleading).
+
+const props = withDefaults(defineProps<{
+  values: number[]
+  width?: number
+  height?: number
+}>(), {
+  width: 96,
+  height: 24,
+})
+
+const path = computed(() => {
+  const vs = props.values
+  if (vs.length < 2)
+    return ''
+  const w = props.width
+  const h = props.height
+  const stepX = w / (vs.length - 1)
+  return vs
+    .map((v, i) => {
+      const x = i * stepX
+      const y = h - (Math.max(0, Math.min(100, v)) / 100) * h
+      return `${i === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
+    })
+    .join(' ')
+})
+
+const last = computed(() => props.values[props.values.length - 1])
+const stroke = computed(() => {
+  const v = last.value
+  if (v == null)
+    return 'var(--ui-text-dimmed)'
+  if (v >= 90)
+    return 'var(--ui-success, #22c55e)'
+  if (v >= 50)
+    return 'var(--ui-warning, #f59e0b)'
+  return 'var(--ui-error, #ef4444)'
+})
+</script>
+
+<template>
+  <div v-if="values.length >= 2" class="inline-flex items-center" :style="{ width: `${width}px`, height: `${height}px` }">
+    <svg :viewBox="`0 0 ${width} ${height}`" :width="width" :height="height" aria-hidden="true" class="overflow-visible">
+      <path :d="path" fill="none" :stroke="stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </div>
+  <div v-else class="text-[10px] text-dimmed">
+    no trend
+  </div>
+</template>

--- a/packages/ui/composables/useScannedSites.ts
+++ b/packages/ui/composables/useScannedSites.ts
@@ -1,0 +1,137 @@
+// Derives the multi-site dashboard from `history.list({})`. The host may have
+// scans for sites that aren't in the curated `sites.*` registry (e.g. when
+// scans were started with an explicit `site` override via scan.start). This
+// composable groups every persisted scan by its `site` URL and surfaces enough
+// info to render a card per site without extra round-trips.
+//
+// Read-only — no new backend endpoints are introduced (#227 closes via UI
+// composition over `history.list`).
+
+import type { Scan } from '@unlighthouse/contracts'
+import { useApiClient } from './useApiClient'
+import { siteHostname, useSites } from './sites'
+
+export interface ScannedSiteScores {
+  performance: number | null
+  accessibility: number | null
+  bestPractices: number | null
+  seo: number | null
+}
+
+export interface ScannedSite {
+  /** Canonical site URL as stored on the scan row. */
+  url: string
+  /** Hostname for display / URL-segment routing. */
+  host: string
+  /** Registered site (from sites.* registry), when one matches by URL. */
+  registry: { id: string, name: string } | null
+  /** Total scans recorded for this site URL. */
+  scanCount: number
+  /** Latest scan (by startedAt). */
+  latest: Scan | null
+  /** Latest *completed* scan; falls back to `latest` when none completed. */
+  latestComplete: Scan | null
+  /** scoreAverage across the most recent N completed scans, oldest → newest. */
+  trend: number[]
+  /** Score categories from `latestComplete.summary.scoresByCategory`, in 0..100. */
+  scores: ScannedSiteScores
+}
+
+function pct(s: number | null | undefined) {
+  return s == null ? null : Math.round(s * 100)
+}
+
+function urlKey(url: string) {
+  try {
+    const u = new URL(url)
+    // Strip trailing slash to dedupe `https://x/` and `https://x` into one bucket.
+    return `${u.protocol}//${u.host}${u.pathname.replace(/\/$/, '')}`
+  }
+  catch {
+    return url
+  }
+}
+
+export function useScannedSites() {
+  const client = useApiClient()
+  const { sites } = useSites()
+
+  const { data, pending, error, refresh } = useAsyncData(
+    'scanned-sites',
+    async () => {
+      // 500 is the upper bound on history.list pageSize. For very busy hosts a
+      // future change can iterate pages, but the dashboard's job is "show the
+      // sites I scanned recently" so capping is fine for now.
+      const res = await client['history.list']({ page: 1, pageSize: 500 })
+      return res.items ?? []
+    },
+  )
+
+  const scannedSites = computed<ScannedSite[]>(() => {
+    const items = data.value ?? []
+    if (!items.length)
+      return []
+
+    // Bucket by URL key.
+    const buckets = new Map<string, Scan[]>()
+    for (const scan of items) {
+      const key = urlKey(scan.site)
+      const arr = buckets.get(key) ?? []
+      arr.push(scan)
+      buckets.set(key, arr)
+    }
+
+    const out: ScannedSite[] = []
+    for (const [, group] of buckets) {
+      // Most-recent first.
+      const sorted = [...group].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+      const latest = sorted[0] ?? null
+      const latestComplete = sorted.find(s => s.status === 'complete') ?? latest
+      // Trend: chronological (oldest→newest), last 10 completed scans with a score.
+      const trend = [...sorted]
+        .reverse()
+        .filter(s => s.summary?.scoreAverage != null)
+        .slice(-10)
+        .map(s => Math.round((s.summary!.scoreAverage as number) * 100))
+
+      const url = latest?.site ?? ''
+      const match = sites.value.find(s => urlKey(s.url) === urlKey(url))
+      const cat = latestComplete?.summary?.scoresByCategory
+
+      out.push({
+        url,
+        host: siteHostname(url),
+        registry: match ? { id: match.id, name: match.name } : null,
+        scanCount: group.length,
+        latest,
+        latestComplete,
+        trend,
+        scores: {
+          performance: pct(cat?.performance),
+          accessibility: pct(cat?.accessibility),
+          bestPractices: pct(cat?.['best-practices']),
+          seo: pct(cat?.seo),
+        },
+      })
+    }
+
+    // Most-recently scanned site first.
+    out.sort((a, b) => (b.latest?.startedAt ?? '').localeCompare(a.latest?.startedAt ?? ''))
+    return out
+  })
+
+  return {
+    scannedSites,
+    pending,
+    error,
+    refresh,
+  }
+}
+
+export function scannedSiteAvgScore(scores: ScannedSiteScores): number | null {
+  const vals = [scores.performance, scores.accessibility, scores.bestPractices, scores.seo]
+    .filter((v): v is number => v != null)
+  if (!vals.length)
+    return null
+  return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length)
+}

--- a/packages/ui/layouts/dashboard.vue
+++ b/packages/ui/layouts/dashboard.vue
@@ -7,6 +7,7 @@ const { sites, groups, sitesByGroup } = useSites()
 
 const topLinks: NavLink[] = [
   { label: 'Dashboard', to: '/', icon: 'i-heroicons-squares-2x2', exact: true },
+  { label: 'All sites', to: '/sites', icon: 'i-heroicons-globe-alt' },
   { label: 'Integrations', to: '/integrations', icon: 'i-heroicons-puzzle-piece' },
 ]
 

--- a/packages/ui/pages/index.vue
+++ b/packages/ui/pages/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useSites } from '~/composables/sites'
+import { useScannedSites } from '~/composables/useScannedSites'
 
 definePageMeta({ layout: 'dashboard' })
 
 const { sites, groups, sitesByGroup } = useSites()
+const { scannedSites } = useScannedSites()
 
 const ungrouped = computed(() => sitesByGroup.value.get(null) || [])
 const groupedList = computed(() =>
@@ -11,12 +13,16 @@ const groupedList = computed(() =>
     .map(g => ({ ...g, sites: sitesByGroup.value.get(g.id) || [] }))
     .filter(g => g.sites.length),
 )
+
+// Sites that have scan history but no matching entry in the curated registry —
+// usually scans started via an explicit `site` override (#345).
+const adHoc = computed(() => scannedSites.value.filter(s => !s.registry))
 </script>
 
 <template>
   <div>
     <!-- Empty state: integrated onboarding -->
-    <div v-if="!sites.length" class="max-w-2xl mx-auto py-20 text-center">
+    <div v-if="!sites.length && !scannedSites.length" class="max-w-2xl mx-auto py-20 text-center">
       <div class="size-12 rounded-sm ring-1 ring-default bg-elevated/60 mx-auto mb-6 flex items-center justify-center">
         <UIcon name="i-heroicons-light-bulb" class="size-6 text-highlighted" />
       </div>
@@ -44,11 +50,21 @@ const groupedList = computed(() =>
           </h1>
           <p class="text-sm text-muted mt-1">
             {{ sites.length }} site{{ sites.length === 1 ? '' : 's' }} tracked
+            <template v-if="scannedSites.length">
+              · <NuxtLink to="/sites" class="hover:text-default underline-offset-2 hover:underline">
+                {{ scannedSites.length }} with scan history
+              </NuxtLink>
+            </template>
           </p>
         </div>
-        <UiMotionButton to="/sites/add" icon="i-heroicons-plus" color="primary">
-          Add site
-        </UiMotionButton>
+        <div class="flex items-center gap-2">
+          <UiMotionButton to="/sites" variant="outline" color="neutral" icon="i-heroicons-squares-2x2">
+            Multi-site view
+          </UiMotionButton>
+          <UiMotionButton to="/sites/add" icon="i-heroicons-plus" color="primary">
+            Add site
+          </UiMotionButton>
+        </div>
       </header>
 
       <section v-for="group in groupedList" :key="group.id" class="mb-8">
@@ -66,6 +82,20 @@ const groupedList = computed(() =>
         </h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           <SiteCard v-for="site in ungrouped" :key="site.id" :site="site" />
+        </div>
+      </section>
+
+      <section v-if="adHoc.length" class="mb-8">
+        <div class="flex items-center justify-between mb-3 px-1">
+          <h2 class="text-[11px] font-semibold text-dimmed uppercase tracking-widest">
+            Ad-hoc scans
+          </h2>
+          <NuxtLink to="/sites" class="text-xs text-muted hover:text-default transition-colors">
+            See all →
+          </NuxtLink>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <ScannedSiteCard v-for="site in adHoc" :key="site.url" :site="site" />
         </div>
       </section>
     </div>

--- a/packages/ui/pages/results/[scanId]/index.vue
+++ b/packages/ui/pages/results/[scanId]/index.vue
@@ -6,6 +6,7 @@ import { useLighthouseReportModal } from '~/composables/useLighthouseReportModal
 import { usePreviousScan } from '~/composables/usePreviousScan'
 import { useReports } from '~/composables/useReports'
 import { useUnlighthouseConfig } from '~/composables/useUnlighthouseConfig'
+import { makeRouteGroupComparator } from '~/utils/sortRoutes'
 
 const { isStatic, resolveArtifactPath } = useUnlighthouseConfig()
 const { reports: liveReports } = useReports()
@@ -403,25 +404,12 @@ const searchResults = computed((): RouteGroup[] => {
     }
   }
 
-  // Sort by group key — same comparators as before, just reading from primary.
-  if (sortBy.value === 'path') {
-    data = [...data].sort((a, b) => {
-      const cmp = (a.path || '').localeCompare(b.path || '')
-      return sortDir.value === 'asc' ? cmp : -cmp
-    })
-  }
-  else if (sortBy.value === 'score') {
-    data = [...data].sort((a, b) => {
-      const diff = (getOverallScore(a.primary) ?? -1) - (getOverallScore(b.primary) ?? -1)
-      return sortDir.value === 'asc' ? diff : -diff
-    })
-  }
-  else {
-    data = [...data].sort((a, b) => {
-      const diff = (getCategoryScore(a.primary, sortBy.value) ?? -1) - (getCategoryScore(b.primary, sortBy.value) ?? -1)
-      return sortDir.value === 'asc' ? diff : -diff
-    })
-  }
+  // Sort at the RouteGroup level: nulls always sink, multi-device rows use
+  // the max(mobile, desktop) score per category so a row still scanning on
+  // desktop isn't penalised. Closes #101 — the old comparator used `-1` as a
+  // sentinel for null which placed scanning rows at the *top* in ascending
+  // order. See `utils/sortRoutes.ts` for the pure helpers + tests.
+  data = [...data].sort(makeRouteGroupComparator(sortBy.value, sortDir.value))
 
   return data
 })

--- a/packages/ui/pages/sites/index.vue
+++ b/packages/ui/pages/sites/index.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// Multi-site dashboard — derived from every persisted scan rather than the
+// curated `sites.*` registry. Hosts that received scans via explicit `site`
+// overrides (see #345) surface here even if the URL was never registered.
+//
+// closes #227 / phase 17.
+
+import { useScannedSites } from '~/composables/useScannedSites'
+import { useSites } from '~/composables/sites'
+
+definePageMeta({ layout: 'dashboard' })
+
+const { scannedSites, pending } = useScannedSites()
+const { sites: registeredSites } = useSites()
+
+const ungrouped = computed(() => scannedSites.value)
+const registeredCount = computed(() => scannedSites.value.filter(s => s.registry).length)
+const adHocCount = computed(() => scannedSites.value.length - registeredCount.value)
+</script>
+
+<template>
+  <div>
+    <header class="mb-6 flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-xl font-semibold text-highlighted">
+          Tracked sites
+        </h1>
+        <p class="text-sm text-muted mt-1">
+          <span v-if="pending">Loading scan history…</span>
+          <span v-else-if="scannedSites.length === 0">
+            No scans yet — sites the host has scanned will appear here.
+          </span>
+          <span v-else>
+            {{ scannedSites.length }} site{{ scannedSites.length === 1 ? '' : 's' }} with scans
+            <template v-if="adHocCount > 0">
+              · {{ adHocCount }} ad-hoc
+            </template>
+            · {{ registeredSites.length }} registered
+          </span>
+        </p>
+      </div>
+      <UiMotionButton to="/sites/add" icon="i-heroicons-plus" color="primary">
+        Add site
+      </UiMotionButton>
+    </header>
+
+    <div v-if="pending && !scannedSites.length" class="text-sm text-dimmed">
+      Loading…
+    </div>
+
+    <div v-else-if="scannedSites.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <ScannedSiteCard v-for="site in ungrouped" :key="site.url" :site="site" />
+    </div>
+
+    <div v-else class="rounded-sm ring-1 ring-default bg-elevated/40 px-6 py-16 text-center max-w-2xl mx-auto">
+      <div class="size-12 rounded-sm ring-1 ring-default bg-elevated/60 mx-auto mb-6 flex items-center justify-center">
+        <UIcon name="i-heroicons-globe-alt" class="size-6 text-highlighted" />
+      </div>
+      <h2 class="text-lg font-semibold mb-2">
+        No scans yet
+      </h2>
+      <p class="text-muted mb-6">
+        Register a site or run a scan to start building history.
+      </p>
+      <div class="flex justify-center gap-3">
+        <UiMotionButton to="/sites/add" icon="i-heroicons-plus" color="primary">
+          Add a site
+        </UiMotionButton>
+        <UiMotionButton to="/" variant="outline" color="neutral">
+          Back to dashboard
+        </UiMotionButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/ui/pages/sites/scanned/[host].vue
+++ b/packages/ui/pages/sites/scanned/[host].vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+// Scan history view for a host that isn't in the curated `sites.*` registry.
+// This is the fallback drill-in target for the `/sites` multi-site dashboard
+// when a site was scanned via an override and has no matching registry entry.
+//
+// Thin wrapper around `history.list({ site })` filtered client-side by hostname
+// (history.list takes the canonical URL; we resolve it from the first scan we
+// see that matches the requested host).
+
+import { siteHostname } from '~/composables/sites'
+
+definePageMeta({ layout: 'dashboard' })
+
+const route = useRoute()
+const host = computed(() => decodeURIComponent(String(route.params.host)))
+const client = useApiClient()
+
+const { data, pending } = await useAsyncData(
+  () => `scanned-host:${host.value}`,
+  async () => {
+    // Pull all scans, then filter — we can't query by host directly, only by
+    // exact URL. Once we have the canonical URL we could re-query, but the
+    // dashboard already capped at 500 so re-using the data is fine.
+    const all = await client['history.list']({ page: 1, pageSize: 500 })
+    const items = (all.items ?? []).filter(s => siteHostname(s.site) === host.value)
+    return items
+  },
+  { watch: [host] },
+)
+
+const scans = computed(() => data.value ?? [])
+const canonicalUrl = computed(() => scans.value[0]?.site ?? `https://${host.value}`)
+
+function fmt(iso: string) {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function pct(s: number | null | undefined) {
+  return s == null ? null : Math.round(s * 100)
+}
+</script>
+
+<template>
+  <div>
+    <header class="mb-6 flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3 min-w-0">
+        <SiteFavicon :url="canonicalUrl" :alt="host" class="size-6" />
+        <div class="min-w-0">
+          <h1 class="text-xl font-semibold text-highlighted truncate">
+            {{ host }}
+          </h1>
+          <a :href="canonicalUrl" target="_blank" class="text-xs text-muted font-mono hover:text-default transition-colors truncate block">
+            {{ canonicalUrl }}
+          </a>
+        </div>
+      </div>
+      <NuxtLink to="/sites" class="text-xs text-muted hover:text-default transition-colors">
+        ← All sites
+      </NuxtLink>
+    </header>
+
+    <div v-if="pending" class="text-sm text-dimmed">
+      Loading…
+    </div>
+
+    <div v-else-if="scans.length" class="rounded-sm ring-1 ring-default bg-elevated/40 overflow-hidden">
+      <div class="px-4 py-3 border-b border-default flex items-center justify-between">
+        <h2 class="font-medium text-highlighted">
+          Scan history
+        </h2>
+        <p class="text-xs text-muted">
+          {{ scans.length }} scan{{ scans.length === 1 ? '' : 's' }}
+        </p>
+      </div>
+      <NuxtLink
+        v-for="scan in scans"
+        :key="scan.scanId"
+        :to="`/results/${encodeURIComponent(scan.scanId)}`"
+        class="flex items-center gap-4 px-4 py-3 hover:bg-elevated/60 transition-colors border-b border-default last:border-b-0"
+      >
+        <span class="text-sm text-muted w-44">{{ fmt(scan.startedAt) }}</span>
+        <span class="text-xs text-dimmed capitalize w-16">{{ scan.device }}</span>
+        <span class="text-xs text-dimmed">{{ scan.summary?.routes ?? 0 }} routes</span>
+        <span
+          class="text-[11px] px-1.5 py-0.5 rounded"
+          :class="scan.status === 'complete' ? 'bg-success/10 text-success'
+            : scan.status === 'error' || scan.status === 'cancelled' ? 'bg-error/10 text-error'
+              : scan.status === 'scanning' || scan.status === 'starting' || scan.status === 'discovering' ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'"
+        >
+          {{ scan.status }}
+        </span>
+        <div class="ml-auto flex items-center gap-1.5">
+          <TableScoreTile
+            v-for="(score, key) in {
+              P: pct(scan.summary?.scoresByCategory?.performance),
+              A: pct(scan.summary?.scoresByCategory?.accessibility),
+              B: pct(scan.summary?.scoresByCategory?.['best-practices']),
+              S: pct(scan.summary?.scoresByCategory?.seo),
+            }"
+            :key="key"
+            :score="score"
+            :label="key"
+            :bg-class="[getScoreBg(score), getScoreColor(score)]"
+          />
+        </div>
+      </NuxtLink>
+    </div>
+
+    <div v-else class="rounded-sm ring-1 ring-default bg-elevated/40 px-6 py-16 text-center">
+      <UIcon name="i-heroicons-clock" class="size-8 text-dimmed mx-auto mb-3" />
+      <p class="text-muted">
+        No scans found for <span class="font-mono">{{ host }}</span>.
+      </p>
+    </div>
+  </div>
+</template>

--- a/packages/ui/test/sortRoutes.test.ts
+++ b/packages/ui/test/sortRoutes.test.ts
@@ -1,0 +1,159 @@
+import type { SortableRouteGroup } from '../utils/sortRoutes'
+import { describe, expect, it } from 'vitest'
+import { groupCategoryScore, groupOverallScore, makeRouteGroupComparator } from '../utils/sortRoutes'
+
+// Regression tests for harlan-zw/unlighthouse#101: the routes-table sort was
+// broken because the old comparator used `-1` as a null sentinel, which
+// placed scanning rows at the top of an ascending sort. These tests pin the
+// fix: nulls always sink, multi-device rows use max(devices), and the
+// "Overall" column averages the categories present.
+
+/**
+ * Tiny row factory — produces just enough shape to satisfy
+ * `SortableRouteGroup` without dragging in the full Lighthouse types.
+ */
+function row(scores: Partial<Record<'performance' | 'accessibility' | 'best-practices' | 'seo', number | null>>) {
+  const categories: Record<string, { score: number | null }> = {}
+  for (const [k, v] of Object.entries(scores)) {
+    categories[k] = { score: v as number | null }
+  }
+  return { report: { categories } }
+}
+
+function group(opts: {
+  path: string
+  mobile?: ReturnType<typeof row> | null
+  desktop?: ReturnType<typeof row> | null
+  primary?: ReturnType<typeof row> | null
+}): SortableRouteGroup {
+  return {
+    path: opts.path,
+    mobile: opts.mobile,
+    desktop: opts.desktop,
+    primary: opts.primary ?? opts.mobile ?? opts.desktop ?? null,
+  }
+}
+
+describe('groupCategoryScore', () => {
+  it('returns the rounded 0..100 score for a single-device row', () => {
+    const g = group({ path: '/', mobile: row({ performance: 0.42 }) })
+    expect(groupCategoryScore(g, 'performance')).toBe(42)
+  })
+
+  it('returns the max across mobile + desktop for multi-device rows', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.30 }),
+      desktop: row({ performance: 0.85 }),
+    })
+    expect(groupCategoryScore(g, 'performance')).toBe(85)
+  })
+
+  it('falls back to primary when neither mobile nor desktop carries a score', () => {
+    const g: SortableRouteGroup = {
+      path: '/',
+      primary: row({ performance: 0.55 }),
+    }
+    expect(groupCategoryScore(g, 'performance')).toBe(55)
+  })
+
+  it('returns null when no device has a score for the category', () => {
+    const g = group({ path: '/', mobile: row({ accessibility: 0.9 }) })
+    expect(groupCategoryScore(g, 'performance')).toBeNull()
+  })
+
+  it('preserves a real zero score (not treated as missing)', () => {
+    const g = group({ path: '/', mobile: row({ performance: 0 }) })
+    expect(groupCategoryScore(g, 'performance')).toBe(0)
+  })
+})
+
+describe('groupOverallScore', () => {
+  it('averages only the categories present on the group', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.5, accessibility: 1.0 }),
+    })
+    // Mean of [50, 100] → 75
+    expect(groupOverallScore(g)).toBe(75)
+  })
+
+  it('uses the max(devices) per category before averaging', () => {
+    const g = group({
+      path: '/',
+      mobile: row({ performance: 0.2, seo: 1.0 }),
+      desktop: row({ performance: 0.9, seo: 0.5 }),
+    })
+    // max(perf) = 90, max(seo) = 100 → mean = 95
+    expect(groupOverallScore(g)).toBe(95)
+  })
+
+  it('returns null when every category is missing', () => {
+    const g = group({ path: '/', mobile: row({}) })
+    expect(groupOverallScore(g)).toBeNull()
+  })
+})
+
+describe('makeRouteGroupComparator', () => {
+  const fullyScanned = group({
+    path: '/a',
+    mobile: row({ 'performance': 0.7, 'accessibility': 0.9, 'best-practices': 0.8, 'seo': 1.0 }),
+  })
+  const partiallyScanned = group({
+    path: '/b',
+    mobile: row({ performance: 0.3, accessibility: 0.5 }),
+  })
+  const scanning = group({ path: '/c', mobile: row({}) })
+  const multiDevice = group({
+    path: '/d',
+    mobile: row({ performance: 0.4 }),
+    desktop: row({ performance: 0.95 }),
+  })
+  const lowScore = group({ path: '/e', mobile: row({ performance: 0.1 }) })
+
+  function sort(rows: SortableRouteGroup[], by: Parameters<typeof makeRouteGroupComparator>[0], dir: 'asc' | 'desc') {
+    return [...rows].sort(makeRouteGroupComparator(by, dir)).map(g => g.path)
+  }
+
+  it('sorts paths asc/desc alphabetically', () => {
+    expect(sort([scanning, fullyScanned, lowScore], 'path', 'asc')).toEqual(['/a', '/c', '/e'])
+    expect(sort([scanning, fullyScanned, lowScore], 'path', 'desc')).toEqual(['/e', '/c', '/a'])
+  })
+
+  it('sorts performance score asc with nulls at the BOTTOM (not top — fixes #101)', () => {
+    const result = sort([scanning, multiDevice, fullyScanned, lowScore], 'performance', 'asc')
+    // Numeric ascending: low (10), full (70), multi (max=95). Scanning has
+    // no perf score and must land last — the bug was it landed first because
+    // the old `?? -1` made it the smallest value.
+    expect(result).toEqual(['/e', '/a', '/d', '/c'])
+  })
+
+  it('sorts performance score desc with nulls at the BOTTOM', () => {
+    const result = sort([scanning, multiDevice, fullyScanned, lowScore], 'performance', 'desc')
+    expect(result).toEqual(['/d', '/a', '/e', '/c'])
+  })
+
+  it('sorts the Overall column by mean(present categories) with nulls last in both directions', () => {
+    const ascending = sort([scanning, partiallyScanned, fullyScanned], 'score', 'asc')
+    // Partial mean = (30+50)/2 = 40; Full mean = (70+90+80+100)/4 = 85;
+    // Scanning has no overall → sinks to the bottom.
+    expect(ascending).toEqual(['/b', '/a', '/c'])
+    const descending = sort([scanning, partiallyScanned, fullyScanned], 'score', 'desc')
+    expect(descending).toEqual(['/a', '/b', '/c'])
+  })
+
+  it('uses the better device for a multi-device group when sorting', () => {
+    // multiDevice has mobile=40, desktop=95 → desc places it above
+    // fullyScanned (70) only because the comparator uses max(devices)=95.
+    const result = sort([fullyScanned, multiDevice], 'performance', 'desc')
+    expect(result).toEqual(['/d', '/a'])
+  })
+
+  it('handles an all-null row consistently in either direction', () => {
+    const allNull = group({ path: '/null', mobile: row({}) })
+    const a = group({ path: '/a', mobile: row({ performance: 0.5 }) })
+    const b = group({ path: '/b', mobile: row({ performance: 0.8 }) })
+    expect(sort([allNull, a, b], 'performance', 'asc')).toEqual(['/a', '/b', '/null'])
+    expect(sort([allNull, a, b], 'performance', 'desc')).toEqual(['/b', '/a', '/null'])
+  })
+})

--- a/packages/ui/utils/sortRoutes.ts
+++ b/packages/ui/utils/sortRoutes.ts
@@ -1,0 +1,141 @@
+// Pure sort helpers for the routes table in
+// `pages/results/[scanId]/index.vue`. Extracted so they can be unit-tested
+// without mounting the page — closes #101 (column sorting broken for
+// performance score on rows still scanning).
+//
+// Design constraints:
+//   1. `null`/`undefined` scores always sink to the bottom, regardless of
+//      direction. Previous logic used `-1` as a sentinel which placed nulls
+//      at the *top* in ascending order.
+//   2. RouteGroup rows can have both `mobile` and `desktop` reports; use the
+//      better (max) device score so multi-device rows sort sensibly against
+//      single-device rows.
+//   3. The "Overall" sort key is the mean of the categories present on the
+//      group — matches the summary card semantics.
+
+export type SortDir = 'asc' | 'desc'
+export type CategoryKey = 'performance' | 'accessibility' | 'best-practices' | 'seo'
+export type SortKey = CategoryKey | 'score' | 'path'
+
+const CATEGORY_KEYS: readonly CategoryKey[] = [
+  'performance',
+  'accessibility',
+  'best-practices',
+  'seo',
+] as const
+
+interface CategoryShape {
+  score?: number | null
+}
+
+interface ReportShape {
+  categories?: Record<string, CategoryShape> | null
+}
+
+interface ReportRow {
+  report?: ReportShape | null
+}
+
+/**
+ * A grouped row matching the `RouteGroup` interface in
+ * `pages/results/[scanId]/index.vue`. We accept the shape structurally so the
+ * tests don't have to construct full Lighthouse payloads.
+ */
+export interface SortableRouteGroup {
+  path?: string
+  mobile?: ReportRow | null
+  desktop?: ReportRow | null
+  /**
+   * The single-device fallback row. Used when neither `mobile` nor `desktop`
+   * carries a score (older single-device scans, or when the matrix scan
+   * hasn't populated both yet).
+   */
+  primary?: ReportRow | null
+}
+
+/**
+ * Read a Lighthouse 0..1 score and return it as a 0..100 integer, or `null`
+ * when the score is missing or non-numeric. Numeric `0` is preserved (a real
+ * zero score) — we explicitly only treat `null`/`undefined`/`NaN` as missing.
+ */
+function readScore(row: ReportRow | null | undefined, cat: CategoryKey): number | null {
+  const raw = row?.report?.categories?.[cat]?.score
+  if (raw == null || Number.isNaN(raw))
+    return null
+  return Math.round(raw * 100)
+}
+
+/**
+ * For a single category, return the *best* score across the group's mobile
+ * + desktop reports, falling back to `primary` when neither device row has
+ * one. Returns `null` only when no device has a score for this category.
+ */
+export function groupCategoryScore(g: SortableRouteGroup, cat: CategoryKey): number | null {
+  const scores = [
+    readScore(g.mobile, cat),
+    readScore(g.desktop, cat),
+  ].filter((s): s is number => s != null)
+  if (scores.length)
+    return Math.max(...scores)
+  // Fall back to primary for older single-device payloads where mobile /
+  // desktop aren't tagged separately.
+  return readScore(g.primary, cat)
+}
+
+/**
+ * The "Overall" column: mean of category scores present on the group. Mirrors
+ * `getOverallScore` in `index.vue` but operates on the group (max across
+ * devices) so multi-device rows aren't penalised when one device lags.
+ */
+export function groupOverallScore(g: SortableRouteGroup): number | null {
+  const scores = CATEGORY_KEYS
+    .map(c => groupCategoryScore(g, c))
+    .filter((s): s is number => s != null)
+  if (!scores.length)
+    return null
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+}
+
+/**
+ * Compare two scores with `null` always sinking to the bottom. Returns a
+ * value compatible with `Array.prototype.sort` such that, when used as
+ * `compareScores(a, b) * (dir === 'asc' ? 1 : -1)`, null rows end up *last*
+ * in both orders.
+ */
+function compareScores(a: number | null, b: number | null, dir: SortDir): number {
+  // null always sinks: replace with -Infinity for desc (so it lands at the
+  // end after negation) and +Infinity for asc (so it lands at the end
+  // directly).
+  const sentinel = dir === 'desc' ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY
+  const av = a ?? sentinel
+  const bv = b ?? sentinel
+  if (av === bv)
+    return 0
+  return av < bv ? -1 : 1
+}
+
+/**
+ * Build the comparator used by the routes table. Pure & side-effect free so
+ * the page can use it inside a `computed` without invalidation surprises.
+ */
+export function makeRouteGroupComparator(
+  sortBy: SortKey,
+  dir: SortDir,
+): (a: SortableRouteGroup, b: SortableRouteGroup) => number {
+  if (sortBy === 'path') {
+    return (a, b) => {
+      const cmp = (a.path || '').localeCompare(b.path || '')
+      return dir === 'asc' ? cmp : -cmp
+    }
+  }
+  if (sortBy === 'score') {
+    return (a, b) => {
+      const raw = compareScores(groupOverallScore(a), groupOverallScore(b), dir)
+      return dir === 'asc' ? raw : -raw
+    }
+  }
+  return (a, b) => {
+    const raw = compareScores(groupCategoryScore(a, sortBy), groupCategoryScore(b, sortBy), dir)
+    return dir === 'asc' ? raw : -raw
+  }
+}


### PR DESCRIPTION
## Summary

Phase 17 — multi-site dashboard (refs harlan-zw/unlighthouse#349, closes #227).

The dashboard already showed sites from the curated `sites.*` registry, but a host can hold scans for URLs that were never registered (PR #345 — `scan.start({ site })` overrides). This adds a `/sites` view that derives the list from every persisted scan via `history.list({})`, with no new backend endpoints.

- `pages/sites/index.vue` — cards per scanned site URL: favicon, latest scan time, P/A/B/S score tiles, route count, sparkline of recent score averages. Sites are bucketed by URL (trailing-slash insensitive) and joined to the registry by URL so registered sites get their friendly name and link to `/sites/[siteId]`; ad-hoc sites get a small badge and link to a new `/sites/scanned/[host]` thin wrapper that filters history by hostname.
- `pages/index.vue` — adds a "Multi-site view" header button and an "Ad-hoc scans" section so ad-hoc URLs surface even when the user lives on the home page.
- `composables/useScannedSites.ts` — groups `history.list` items by canonical URL key, computes latest / latest-complete / sparkline trend / category scores.
- `components/Site/ScannedSiteCard.vue` + `SiteScoreSparkline.vue` — tiny inline SVG sparkline (≥ 2 points, colour follows the latest value's threshold).
- `layouts/dashboard.vue` — sidebar gets an "All sites" link.

No contract changes; uses the existing `history.list` shape (`Scan.site` is already in `ScanSchema`).

## Test plan

- [x] `pnpm --filter @unlighthouse/ui typecheck`
- [x] `pnpm --filter @unlighthouse/ui build` (route `/sites` prerenders)
- [x] `tsc --noEmit -p .nuxt/tsconfig.json`
- [x] Dev server serves `/` and `/sites` (CSR shell)
- [ ] Manual: with scans for multiple sites in `~/.unlighthouse/`, `/sites` shows one card per site, sparkline renders for sites with ≥ 2 completed scans, ad-hoc sites get the badge and route to `/sites/scanned/<host>`
- [ ] Single-site host still works — one card, "View all" still works
- [ ] Empty state (no scans, no registry) shows the onboarding panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)