### PR TITLE
feat(action): scaffold v1 GitHub Action with device matrix + PR comment

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,61 @@
+name: Test GitHub Action
+
+on:
+  push:
+    branches:
+      - v1
+    paths:
+      - 'packages/github-action/**'
+      - .github/workflows/test-action.yml
+  pull_request:
+    paths:
+      - 'packages/github-action/**'
+      - .github/workflows/test-action.yml
+
+jobs:
+  # Lightweight shape check — verifies the composite action's wiring is valid
+  # and the bundled `dist/main.mjs` entrypoint loads cleanly. We do not run a
+  # real Lighthouse scan (Chrome boot is expensive and adds flake to CI); the
+  # action's pure helpers are covered by `packages/github-action/test/`.
+  shape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+
+      - name: Use Node.js v24
+        uses: actions/setup-node@v5
+        with:
+          node-version: v24
+          cache: pnpm
+
+      - run: pnpm install
+      - run: pnpm --filter @unlighthouse/github-action build
+      - run: pnpm --filter @unlighthouse/github-action test
+
+      - name: Validate composite action metadata
+        run: |
+          node --input-type=module -e "
+            import { readFileSync } from 'node:fs';
+            const yml = readFileSync('packages/github-action/action.yml', 'utf8');
+            if (!yml.includes('using: composite')) throw new Error('action.yml is not a composite action');
+            if (!yml.includes('dist/main.mjs')) throw new Error('action.yml does not invoke dist/main.mjs');
+            console.log('action.yml shape OK');
+          "
+
+      - name: Smoke-load the built entrypoint
+        env:
+          UNLIGHTHOUSE_SITE: ''
+        run: |
+          # No site → entrypoint should exit(1) with a clear error. This
+          # verifies the bundle is well-formed and the input parser runs.
+          set +e
+          node packages/github-action/dist/main.mjs
+          rc=$?
+          if [ "$rc" -ne 1 ]; then
+            echo "expected exit 1 from missing site, got $rc" >&2
+            exit 1
+          fi
+          echo "smoke-load OK (exited 1 on missing site as expected)"

--- a/packages/github-action/README.md
+++ b/packages/github-action/README.md
@@ -1,0 +1,46 @@
+# @unlighthouse/github-action
+
+Composite GitHub Action wrapper around [`unlighthouse-ci`](https://unlighthouse.dev/integrations/ci).
+
+- Runs a multi-device scan via the `--device` matrix flag (mobile, desktop, or both).
+- On `pull_request` events, posts the `compare.markdown` PR-comment summary against a prior scan / branch.
+- Exits non-zero when regressions or budget assertions trip, so the workflow fails the same way local CI does.
+
+## Usage
+
+```yaml
+# .github/workflows/perf.yml
+name: Unlighthouse
+on: pull_request
+permissions: { contents: read, pull-requests: write }
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: harlan-zw/unlighthouse/packages/github-action@v1
+        with:
+          site: https://example.com
+          device: mobile,desktop
+          compare-with: latest
+```
+
+## Inputs
+
+| Input               | Default               | Description                                                                  |
+| ------------------- | --------------------- | ---------------------------------------------------------------------------- |
+| `site`              | —                     | Required. URL to scan.                                                       |
+| `device`            | `mobile`              | `mobile`, `desktop`, or comma-separated list (`mobile,desktop`).             |
+| `budget`            | —                     | Minimum score (1-100); forwarded to `--budget`.                              |
+| `build-static`      | `false`               | Also build a static report (`--build-static`).                               |
+| `compare-with`      | `''`                  | `latest`, `<scanId>`, or `<branch>`. Empty = no comparison.                  |
+| `comment-on-pr`     | `true`                | When the event is `pull_request`, POST the comparison Markdown as a comment. |
+| `working-directory` | `.`                   | Where the scan is executed from.                                             |
+| `github-token`      | `${{ github.token }}` | Token used to post the PR comment. Needs `pull-requests: write`.             |
+
+## Outputs
+
+| Output                  | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `has-regressions`       | `true` when comparison detected regressions (CLI exited non-zero).         |
+| `compare-markdown-path` | Path of the rendered Markdown summary (empty when no comparison ran).      |

--- a/packages/github-action/action.yml
+++ b/packages/github-action/action.yml
@@ -1,0 +1,63 @@
+name: Unlighthouse
+description: Scan a site with Unlighthouse (multi-device matrix) and post the PR-comment-friendly comparison summary on pull requests.
+author: harlan-zw
+branding:
+  icon: zap
+  color: yellow
+
+inputs:
+  site:
+    description: URL to scan. Required.
+    required: true
+  device:
+    description: 'Device(s) to scan. Single value (`mobile` | `desktop`) or comma-separated list (`mobile,desktop`).'
+    required: false
+    default: mobile
+  budget:
+    description: Minimum score (1-100) required for each page to pass. Forwarded to `unlighthouse-ci --budget`.
+    required: false
+  build-static:
+    description: Build a static report alongside the scan.
+    required: false
+    default: 'false'
+  compare-with:
+    description: 'Compare current scan against `latest` (default when set), a `<scanId>`, or a `<branch>` name. Empty disables comparison.'
+    required: false
+    default: ''
+  comment-on-pr:
+    description: 'When the workflow runs on a `pull_request` event, post the comparison Markdown as a PR comment. Requires `pull-requests: write` permission and `GITHUB_TOKEN`.'
+    required: false
+    default: 'true'
+  working-directory:
+    description: Directory the scan is executed from. Defaults to the workspace root.
+    required: false
+    default: .
+  github-token:
+    description: 'Token used to post the PR comment. Defaults to `${{ github.token }}`.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  has-regressions:
+    description: Set to `true` when comparison detected at least one regression.
+    value: ${{ steps.run.outputs.has-regressions }}
+  compare-markdown-path:
+    description: Filesystem path of the rendered comparison Markdown (empty when no comparison ran).
+    value: ${{ steps.run.outputs.compare-markdown-path }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        UNLIGHTHOUSE_SITE: ${{ inputs.site }}
+        UNLIGHTHOUSE_DEVICE: ${{ inputs.device }}
+        UNLIGHTHOUSE_BUDGET: ${{ inputs.budget }}
+        UNLIGHTHOUSE_BUILD_STATIC: ${{ inputs.build-static }}
+        UNLIGHTHOUSE_COMPARE_WITH: ${{ inputs.compare-with }}
+        UNLIGHTHOUSE_COMMENT_ON_PR: ${{ inputs.comment-on-pr }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        node "${{ github.action_path }}/dist/main.mjs"

--- a/packages/github-action/build.config.ts
+++ b/packages/github-action/build.config.ts
@@ -1,0 +1,25 @@
+import { defineBuildConfig } from 'obuild/config'
+
+// `unlighthouse` ships its own CLI bin which we exec at runtime, so keep it
+// external — the action consumer's installed copy resolves it. Node builtins
+// stay external for the same reason as `@unlighthouse/vite`.
+const externals = [
+  'unlighthouse',
+  'node:child_process',
+  'node:fs',
+  'node:fs/promises',
+  'node:path',
+  'node:os',
+  'node:process',
+  'node:url',
+]
+
+export default defineBuildConfig({
+  entries: [
+    {
+      type: 'bundle',
+      input: ['./src/index.ts', './src/main.ts'],
+      rolldown: { external: externals },
+    },
+  ],
+})

--- a/packages/github-action/package.json
+++ b/packages/github-action/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@unlighthouse/github-action",
+  "type": "module",
+  "version": "0.0.0-v1",
+  "private": true,
+  "description": "Composite GitHub Action wrapper around `unlighthouse-ci` — runs a multi-device scan and (optionally) posts the `compare.markdown` summary to the triggering PR.",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "README.md",
+    "action.yml",
+    "dist",
+    "src"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "build": "obuild",
+    "stub": "obuild --stub",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "unlighthouse": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/github-action/src/index.ts
+++ b/packages/github-action/src/index.ts
@@ -1,0 +1,107 @@
+// Public entry — re-exports the pure helpers that the composite-action
+// entrypoint (`src/main.ts`) wires together. Keeping them exported lets us
+// unit-test the shell-command builder and PR-comment payload shape without
+// spawning `unlighthouse-ci`.
+
+export interface ActionInputs {
+  site: string
+  device: string
+  budget?: string
+  buildStatic: boolean
+  compareWith: string
+  commentOnPr: boolean
+  workingDirectory: string
+}
+
+export interface ActionOutputs {
+  hasRegressions: boolean
+  compareMarkdownPath: string
+}
+
+/**
+ * Parse the boolean-ish strings GitHub Actions sends via `env:` (always
+ * strings, even when `default: false`). Treats the empty string and the
+ * literal `'false'` / `'0'` / `'no'` as `false`; everything else truthy.
+ */
+export function parseBooleanInput(raw: string | undefined, fallback: boolean): boolean {
+  if (raw == null)
+    return fallback
+  const v = raw.trim().toLowerCase()
+  if (v === '')
+    return fallback
+  return !(v === 'false' || v === '0' || v === 'no')
+}
+
+/**
+ * Build the argv that should be passed to `unlighthouse-ci`. Returned as a
+ * tuple so the caller can spawn without going through a shell — preserves
+ * arg boundaries even when `site` contains spaces or shell metacharacters.
+ *
+ * `--compare` defaults to `latest` when `compareWith` is non-empty (matches
+ * the CLI's own default). When `compareWith` is set, a `--compare-output`
+ * path is appended so the comparison markdown is written to disk where the
+ * PR-comment poster can pick it up.
+ */
+export function buildCliArgs(inputs: ActionInputs, compareOutputPath: string | null): string[] {
+  const args: string[] = ['--site', inputs.site, '--no-open']
+
+  if (inputs.device && inputs.device.trim() !== '')
+    args.push('--device', inputs.device.trim())
+
+  if (inputs.budget && inputs.budget.trim() !== '')
+    args.push('--budget', inputs.budget.trim())
+
+  if (inputs.buildStatic)
+    args.push('--build-static')
+
+  if (inputs.compareWith && inputs.compareWith.trim() !== '') {
+    args.push('--compare', inputs.compareWith.trim())
+    if (compareOutputPath)
+      args.push('--compare-output', compareOutputPath)
+  }
+
+  return args
+}
+
+/**
+ * Build the request the action makes to `POST /repos/{owner}/{repo}/issues/{n}/comments`.
+ * Kept as a pure function so tests can lock the wire shape without hitting
+ * the live GitHub API.
+ */
+export function buildPrCommentRequest(opts: {
+  repository: string // "owner/repo"
+  prNumber: number
+  body: string
+  token: string
+}): { url: string, init: { method: string, headers: Record<string, string>, body: string } } {
+  const url = `https://api.github.com/repos/${opts.repository}/issues/${opts.prNumber}/comments`
+  return {
+    url,
+    init: {
+      method: 'POST',
+      headers: {
+        'accept': 'application/vnd.github+json',
+        'authorization': `Bearer ${opts.token}`,
+        'content-type': 'application/json',
+        'user-agent': 'unlighthouse-github-action',
+        'x-github-api-version': '2022-11-28',
+      },
+      body: JSON.stringify({ body: opts.body }),
+    },
+  }
+}
+
+/**
+ * Extract the PR number from a GitHub Actions event payload. Supports
+ * `pull_request` and `pull_request_target` shapes. Returns `null` for
+ * unsupported events (the caller logs and skips PR commenting in that case).
+ */
+export function extractPrNumber(eventName: string | undefined, payload: unknown): number | null {
+  if (eventName !== 'pull_request' && eventName !== 'pull_request_target')
+    return null
+  if (!payload || typeof payload !== 'object')
+    return null
+  const pr = (payload as { pull_request?: { number?: number }, number?: number }).pull_request
+  const n = pr?.number ?? (payload as { number?: number }).number
+  return typeof n === 'number' ? n : null
+}

--- a/packages/github-action/src/main.ts
+++ b/packages/github-action/src/main.ts
@@ -1,0 +1,135 @@
+// Entry point invoked by `action.yml`'s composite shell step. Reads inputs
+// from `UNLIGHTHOUSE_*` env vars (set by the composite step), runs
+// `unlighthouse-ci` via `npx`, then — if the workflow was triggered by a
+// pull request and `comment-on-pr` is enabled — POSTs the rendered
+// `compare.markdown` to the PR via the GitHub REST API.
+
+import type { ActionInputs } from './index'
+import { spawn } from 'node:child_process'
+import { appendFileSync, existsSync } from 'node:fs'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { buildCliArgs, buildPrCommentRequest, extractPrNumber, parseBooleanInput } from './index'
+
+function readInputs(): ActionInputs {
+  const site = (process.env.UNLIGHTHOUSE_SITE ?? '').trim()
+  if (!site) {
+    console.error('::error::Input `site` is required.')
+    process.exit(1)
+  }
+  return {
+    site,
+    device: process.env.UNLIGHTHOUSE_DEVICE ?? 'mobile',
+    budget: process.env.UNLIGHTHOUSE_BUDGET,
+    buildStatic: parseBooleanInput(process.env.UNLIGHTHOUSE_BUILD_STATIC, false),
+    compareWith: process.env.UNLIGHTHOUSE_COMPARE_WITH ?? '',
+    commentOnPr: parseBooleanInput(process.env.UNLIGHTHOUSE_COMMENT_ON_PR, true),
+    workingDirectory: process.cwd(),
+  }
+}
+
+function writeOutput(name: string, value: string): void {
+  const file = process.env.GITHUB_OUTPUT
+  if (!file)
+    return
+  // Use a heredoc-style delimiter so multi-line / path values survive verbatim.
+  const delim = `EOF_${Math.random().toString(36).slice(2)}`
+  const line = `${name}<<${delim}\n${value}\n${delim}\n`
+  appendFileSync(file, line, 'utf8')
+}
+
+async function runUnlighthouseCi(args: string[]): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = spawn('npx', ['--no-install', 'unlighthouse-ci', ...args], {
+      stdio: 'inherit',
+      env: process.env,
+      shell: false,
+    })
+    child.on('error', reject)
+    child.on('exit', code => resolve(code ?? 0))
+  })
+}
+
+async function postPrComment(markdown: string): Promise<void> {
+  const token = process.env.GITHUB_TOKEN
+  const repository = process.env.GITHUB_REPOSITORY
+  const eventName = process.env.GITHUB_EVENT_NAME
+  const eventPath = process.env.GITHUB_EVENT_PATH
+
+  if (!token) {
+    process.stdout.write('::notice::Skipping PR comment — no `GITHUB_TOKEN` set.\n')
+    return
+  }
+  if (!repository || !eventPath || !existsSync(eventPath)) {
+    process.stdout.write('::notice::Skipping PR comment — workflow does not look like a GitHub Actions run.\n')
+    return
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(await readFile(eventPath, 'utf8'))
+  }
+  catch (err) {
+    console.warn(`::warning::Failed to parse GITHUB_EVENT_PATH — skipping PR comment: ${(err as Error).message}`)
+    return
+  }
+
+  const prNumber = extractPrNumber(eventName, payload)
+  if (prNumber == null) {
+    process.stdout.write(`::notice::Skipping PR comment — event \`${eventName}\` is not a pull request.\n`)
+    return
+  }
+
+  const { url, init } = buildPrCommentRequest({ repository, prNumber, body: markdown, token })
+  const res = await fetch(url, init)
+  if (!res.ok) {
+    const text = await res.text().catch(() => '<no body>')
+    console.error(`::error::Failed to post PR comment (HTTP ${res.status}): ${text}`)
+    process.exit(1)
+  }
+  process.stdout.write(`Posted Unlighthouse comparison to PR #${prNumber}.\n`)
+}
+
+async function main(): Promise<void> {
+  const inputs = readInputs()
+
+  let compareOutputPath: string | null = null
+  if (inputs.compareWith.trim() !== '') {
+    const dir = await mkdtemp(join(tmpdir(), 'unlighthouse-action-'))
+    compareOutputPath = join(dir, 'compare.md')
+  }
+
+  const args = buildCliArgs(inputs, compareOutputPath)
+  process.stdout.write(`Running: unlighthouse-ci ${args.join(' ')}\n`)
+
+  const exitCode = await runUnlighthouseCi(args)
+
+  let hasRegressions = false
+  if (compareOutputPath && existsSync(compareOutputPath)) {
+    const markdown = await readFile(compareOutputPath, 'utf8')
+    // CLI exits non-zero only when assertions or `--compare` regressions
+    // tripped. We bubble that through `has-regressions` as well so callers
+    // can branch in YAML without re-parsing the markdown.
+    hasRegressions = exitCode !== 0
+    writeOutput('has-regressions', String(hasRegressions))
+    writeOutput('compare-markdown-path', compareOutputPath)
+
+    if (inputs.commentOnPr)
+      await postPrComment(markdown)
+  }
+  else {
+    writeOutput('has-regressions', 'false')
+    writeOutput('compare-markdown-path', '')
+  }
+
+  // Preserve the CI exit code — regressions / failing assertions must keep
+  // failing the workflow even when we successfully posted a comment.
+  process.exit(exitCode)
+}
+
+main().catch((err) => {
+  console.error(`::error::${(err as Error).stack ?? err}`)
+  process.exit(1)
+})

--- a/packages/github-action/test/action-shape.test.ts
+++ b/packages/github-action/test/action-shape.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCliArgs,
+  buildPrCommentRequest,
+  extractPrNumber,
+  parseBooleanInput,
+} from '../src/index'
+
+describe('parseBooleanInput', () => {
+  it('treats `false`, `0`, `no`, empty as false; everything else truthy', () => {
+    expect(parseBooleanInput('true', false)).toBe(true)
+    expect(parseBooleanInput('TRUE', false)).toBe(true)
+    expect(parseBooleanInput('1', false)).toBe(true)
+    expect(parseBooleanInput('false', true)).toBe(false)
+    expect(parseBooleanInput('0', true)).toBe(false)
+    expect(parseBooleanInput('no', true)).toBe(false)
+    expect(parseBooleanInput('', true)).toBe(true) // empty falls back
+    expect(parseBooleanInput(undefined, false)).toBe(false)
+  })
+})
+
+describe('buildCliArgs', () => {
+  const base = {
+    site: 'https://example.com',
+    device: 'mobile',
+    buildStatic: false,
+    compareWith: '',
+    commentOnPr: false,
+    workingDirectory: '.',
+  }
+
+  it('always emits `--site` and `--no-open`', () => {
+    expect(buildCliArgs(base, null)).toEqual([
+      '--site',
+      'https://example.com',
+      '--no-open',
+      '--device',
+      'mobile',
+    ])
+  })
+
+  it('forwards a comma-separated device matrix verbatim', () => {
+    const args = buildCliArgs({ ...base, device: 'mobile,desktop' }, null)
+    expect(args).toContain('--device')
+    expect(args[args.indexOf('--device') + 1]).toBe('mobile,desktop')
+  })
+
+  it('appends `--compare` + `--compare-output` only when `compareWith` is set', () => {
+    const withCompare = buildCliArgs({ ...base, compareWith: 'latest' }, '/tmp/x.md')
+    expect(withCompare).toContain('--compare')
+    expect(withCompare[withCompare.indexOf('--compare') + 1]).toBe('latest')
+    expect(withCompare).toContain('--compare-output')
+    expect(withCompare[withCompare.indexOf('--compare-output') + 1]).toBe('/tmp/x.md')
+
+    const noCompare = buildCliArgs(base, '/tmp/x.md')
+    expect(noCompare).not.toContain('--compare')
+    expect(noCompare).not.toContain('--compare-output')
+  })
+
+  it('forwards `--budget` and `--build-static`', () => {
+    const args = buildCliArgs({ ...base, budget: '85', buildStatic: true }, null)
+    expect(args).toContain('--budget')
+    expect(args[args.indexOf('--budget') + 1]).toBe('85')
+    expect(args).toContain('--build-static')
+  })
+})
+
+describe('buildPrCommentRequest', () => {
+  it('targets the issues/<n>/comments endpoint and uses Bearer auth', () => {
+    const req = buildPrCommentRequest({
+      repository: 'harlan-zw/unlighthouse',
+      prNumber: 365,
+      body: '## hi',
+      token: 't0k3n',
+    })
+    expect(req.url).toBe('https://api.github.com/repos/harlan-zw/unlighthouse/issues/365/comments')
+    expect(req.init.method).toBe('POST')
+    expect(req.init.headers.authorization).toBe('Bearer t0k3n')
+    expect(req.init.headers['x-github-api-version']).toBe('2022-11-28')
+    expect(JSON.parse(req.init.body)).toEqual({ body: '## hi' })
+  })
+})
+
+describe('extractPrNumber', () => {
+  it('reads `pull_request.number` for the `pull_request` event', () => {
+    expect(extractPrNumber('pull_request', { pull_request: { number: 7 } })).toBe(7)
+    expect(extractPrNumber('pull_request_target', { pull_request: { number: 9 } })).toBe(9)
+  })
+
+  it('falls back to top-level `number` when `pull_request` is absent', () => {
+    expect(extractPrNumber('pull_request', { number: 12 })).toBe(12)
+  })
+
+  it('returns null for non-PR events or malformed payloads', () => {
+    expect(extractPrNumber('push', { pull_request: { number: 1 } })).toBeNull()
+    expect(extractPrNumber('pull_request', null)).toBeNull()
+    expect(extractPrNumber(undefined, { pull_request: { number: 1 } })).toBeNull()
+  })
+})

--- a/packages/github-action/tsconfig.json
+++ b/packages/github-action/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/github-action/vitest.config.ts
+++ b/packages/github-action/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// Local config so `pnpm --filter @unlighthouse/github-action test` works
+// without pulling root workspace aliases — these tests only exercise the
+// shell-command builder and the PR-comment poster shape, no `unlighthouse`
+// runtime is loaded.
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,19 @@ importers:
         specifier: 'catalog:'
         version: 1.17.5(db0@0.3.4(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.10.0)))(ioredis@5.8.2)
 
+  packages/github-action:
+    dependencies:
+      unlighthouse:
+        specifier: workspace:*
+        version: link:../unlighthouse
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.7.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.7.0)(jsdom@26.1.0)(vite@8.0.0-beta.2(@types/node@25.7.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
## Summary

Phase 15 (fifth bullet) of #349 — addresses #134.

- New workspace package `@unlighthouse/github-action` (`packages/github-action/`) shipping a composite GitHub Action (`action.yml` + bundled `dist/main.mjs`) that wraps `unlighthouse-ci`.
- Inputs cover the v1 surface: `site`, `device` (single value or `mobile,desktop` matrix — forwards to the CLI's `--device` flag from D-029), `budget`, `build-static`, `compare-with`, `comment-on-pr`, `working-directory`, `github-token`.
- On `pull_request` / `pull_request_target` events the action reads the rendered `compare.markdown` summary (from #353) off disk via `--compare-output` and POSTs it to the triggering PR through the GitHub REST API, preserving the CLI exit code so regressions / budget failures still fail the workflow.
- Outputs: `has-regressions`, `compare-markdown-path`.

## Test plan

- [x] `pnpm --filter @unlighthouse/github-action test` — 9 unit tests covering `parseBooleanInput`, `buildCliArgs` (device matrix + compare wiring), `buildPrCommentRequest` (REST shape), `extractPrNumber` (event-payload parsing).
- [x] `pnpm --filter @unlighthouse/github-action typecheck` clean.
- [x] `pnpm --filter @unlighthouse/github-action build` — emits `dist/index.mjs` + `dist/main.mjs`; smoke-loaded with empty `UNLIGHTHOUSE_SITE` to confirm the entrypoint exits with the expected error.
- [x] `npx eslint packages/github-action .github/workflows/test-action.yml` clean.
- [x] New `.github/workflows/test-action.yml` re-runs the build/test + a metadata + smoke-load check in CI on changes to the action.

## Out of scope

- Publishing to the GitHub Marketplace is intentionally not part of this PR; release/tagging is left to maintainers.