### PR TITLE
chore: CODEOWNERS + FUNDING + Renovate grouping (Phase 20)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for unlighthouse
+#
+# These owners will be the default owners for everything in the repo.
+# Order is important; the last matching pattern takes the most precedence.
+# See https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Note: this repo currently has a single maintainer with the overwhelming
+# majority of contributions. Per-package owners can be added as the
+# contributor base grows.
+
+* @harlan-zw

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [harlan-zw]
+custom: ['https://harlanzw.com']

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":dependencyDashboard"
+  ],
+  "schedule": ["every weekend"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "bump",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": false
+    },
+    {
+      "groupName": "nuxt",
+      "matchPackagePatterns": ["^@nuxt/", "^nuxt$", "^nuxt-", "^@nuxtjs/"]
+    },
+    {
+      "groupName": "vitest",
+      "matchPackagePatterns": ["^vitest", "^@vitest/", "^@testing-library/"],
+      "matchPackageNames": ["happy-dom", "jsdom"]
+    },
+    {
+      "groupName": "lighthouse + puppeteer (audit core)",
+      "matchPackagePatterns": ["^lighthouse", "^puppeteer", "^@puppeteer/"],
+      "matchPackageNames": ["chrome-launcher", "playwright", "playwright-core"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackagePatterns": ["^eslint", "^@eslint/", "^@typescript-eslint/", "^eslint-"]
+    },
+    {
+      "groupName": "typescript",
+      "matchPackageNames": ["typescript", "tsx", "tslib", "ts-node"],
+      "matchPackagePatterns": ["^@tsconfig/"]
+    }
+  ],
+  "ignoreDeps": [],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  }
+}


### PR DESCRIPTION
## Summary

Repository housekeeping items from #349 Phase 20. No source changes — only `.github/` meta files.

- **`.github/CODEOWNERS`** — default ownership to `@harlan-zw`. Contributor distribution is skewed (918 commits vs the next contributor at 4), so per-package globs are deferred until the contributor base grows.
- **`.github/FUNDING.yml`** — expanded the existing GitHub Sponsors entry with the verified maintainer site (`harlanzw.com`, from the GitHub user profile).
- **`.github/renovate.json`** — Renovate config (chosen over Dependabot for monorepo grouping support):
  - Extends `config:recommended` + semantic commits + dependency dashboard
  - **Schedule:** weekends only (avoids workweek noise)
  - **PR limit:** 5 concurrent / 2 per hour
  - **Groups:** `@nuxt/*`, `vitest` + test deps, `lighthouse*` + `puppeteer*` (audit core), `eslint*` + `@typescript-eslint/*`, TypeScript family
  - Weekly lockfile maintenance on Monday mornings

Phase 20 deferred items not addressed here (per the roadmap):
- v0 `0.17.x` patch-line decision — maintainer call
- Stale Discussions triage — needs maintainer access

Discord link intentionally omitted from `FUNDING.yml` — GitHub's FUNDING schema doesn't accept chat URLs, and the README already advertises the Discord.

Refs #349

## Test plan

- [ ] CODEOWNERS surfaces `@harlan-zw` as the suggested reviewer on new PRs to this branch
- [ ] Renovate (once enabled on the repo) opens grouped PRs matching the configured packageRules
- [ ] FUNDING sidebar shows both Sponsors and the custom link on the repo homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)