### PR TITLE
fix(ui): empty-data scans + favicon a11y + tunnel hosts

### DIFF
--- a/packages/ui/composables/useScannedSites.ts
+++ b/packages/ui/composables/useScannedSites.ts
@@ -8,8 +8,8 @@
 // composition over `history.list`).
 
 import type { Scan } from '@unlighthouse/contracts'
-import { useApiClient } from './useApiClient'
 import { siteHostname, useSites } from './sites'
+import { useApiClient } from './useApiClient'
 
 export interface ScannedSiteScores {
   performance: number | null
@@ -86,7 +86,13 @@ export function useScannedSites() {
       // Most-recent first.
       const sorted = [...group].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
       const latest = sorted[0] ?? null
-      const latestComplete = sorted.find(s => s.status === 'complete') ?? latest
+      // A scan can be structurally `complete` but have zero audited routes
+      // (e.g. local Chrome sandbox blocking puppeteer). Skip those when
+      // sourcing the score cards so the dashboard doesn't render "No data"
+      // for a site that actually has older scored scans.
+      const latestComplete = sorted.find(
+        s => s.status === 'complete' && s.summary?.scoreAverage != null,
+      ) ?? sorted.find(s => s.status === 'complete') ?? latest
       // Trend: chronological (oldest→newest), last 10 completed scans with a score.
       const trend = [...sorted]
         .reverse()

--- a/packages/ui/nuxt.config.ts
+++ b/packages/ui/nuxt.config.ts
@@ -43,5 +43,16 @@ export default defineNuxtConfig({
       pathPrefix: false,
     },
   ],
+  // Allow extra dev-server hostnames (tailscale, ngrok, cloudflare tunnels…)
+  // through Vite's allowedHosts check. Comma-separated env var so personal
+  // hostnames stay out of the repo. Unset → Vite default (localhost only).
+  vite: {
+    server: {
+      allowedHosts: process.env.NUXT_DEV_ALLOWED_HOSTS
+        ?.split(',')
+        .map(h => h.trim())
+        .filter(Boolean),
+    },
+  },
   compatibilityDate: '2025-12-12',
 })

--- a/packages/ui/pages/compare.vue
+++ b/packages/ui/pages/compare.vue
@@ -46,8 +46,13 @@ const { data: scansData, pending: scansPending } = await useAsyncData(
   },
 )
 
+// Only scans that actually produced score data — a structurally `complete`
+// scan with `scoreAverage === null` (e.g. sandbox blocked every audit) makes
+// a pointless diff target, so we hide them from the picker.
 const completeScans = computed<Scan[]>(() =>
-  (scansData.value ?? []).filter(s => s.status === 'complete'),
+  (scansData.value ?? []).filter(
+    s => s.status === 'complete' && s.summary?.scoreAverage != null,
+  ),
 )
 
 function fmtScanLabel(s: Scan): string {

--- a/packages/ui/pages/sites/[siteId]/index.vue
+++ b/packages/ui/pages/sites/[siteId]/index.vue
@@ -34,7 +34,7 @@ function pct(s: number | null | undefined) {
     <header class="mb-6 flex items-center justify-between gap-4">
       <div>
         <h1 class="text-xl font-semibold text-highlighted flex items-center gap-2">
-          <SiteFavicon :url="site.url" :alt="site.name" class="size-5" />
+          <SiteFavicon :url="site.url" alt="" class="size-5" aria-hidden="true" />
           {{ site.name }}
         </h1>
         <a :href="site.url" target="_blank" class="text-sm text-muted font-mono hover:text-default transition-colors">
@@ -72,11 +72,12 @@ function pct(s: number | null | undefined) {
           <span class="text-xs text-dimmed">{{ scan.summary?.completed ?? 0 }}/{{ scan.summary?.routes ?? 0 }} routes</span>
           <span
             class="text-[11px] px-1.5 py-0.5 rounded"
-            :class="scan.status === 'complete' ? 'bg-success/10 text-success'
-              : scan.status === 'error' || scan.status === 'cancelled' ? 'bg-error/10 text-error'
-                : scan.status === 'scanning' || scan.status === 'starting' || scan.status === 'discovering' ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'"
+            :class="scan.status === 'complete' && (scan.summary?.completed ?? 0) === 0 ? 'bg-elevated text-dimmed'
+              : scan.status === 'complete' ? 'bg-success/10 text-success'
+                : scan.status === 'error' || scan.status === 'cancelled' ? 'bg-error/10 text-error'
+                  : scan.status === 'scanning' || scan.status === 'starting' || scan.status === 'discovering' ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'"
           >
-            {{ scan.status }}
+            {{ scan.status === 'complete' && (scan.summary?.completed ?? 0) === 0 ? 'no data' : scan.status }}
           </span>
           <div class="ml-auto flex items-center gap-1.5">
             <TableScoreTile

--- a/packages/ui/pages/sites/scanned/[host].vue
+++ b/packages/ui/pages/sites/scanned/[host].vue
@@ -80,14 +80,15 @@ function pct(s: number | null | undefined) {
       >
         <span class="text-sm text-muted w-44">{{ fmt(scan.startedAt) }}</span>
         <span class="text-xs text-dimmed capitalize w-16">{{ scan.device }}</span>
-        <span class="text-xs text-dimmed">{{ scan.summary?.routes ?? 0 }} routes</span>
+        <span class="text-xs text-dimmed">{{ scan.summary?.completed ?? 0 }}/{{ scan.summary?.routes ?? 0 }} routes</span>
         <span
           class="text-[11px] px-1.5 py-0.5 rounded"
-          :class="scan.status === 'complete' ? 'bg-success/10 text-success'
-            : scan.status === 'error' || scan.status === 'cancelled' ? 'bg-error/10 text-error'
-              : scan.status === 'scanning' || scan.status === 'starting' || scan.status === 'discovering' ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'"
+          :class="scan.status === 'complete' && (scan.summary?.completed ?? 0) === 0 ? 'bg-elevated text-dimmed'
+            : scan.status === 'complete' ? 'bg-success/10 text-success'
+              : scan.status === 'error' || scan.status === 'cancelled' ? 'bg-error/10 text-error'
+                : scan.status === 'scanning' || scan.status === 'starting' || scan.status === 'discovering' ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'"
         >
-          {{ scan.status }}
+          {{ scan.status === 'complete' && (scan.summary?.completed ?? 0) === 0 ? 'no data' : scan.status }}
         </span>
         <div class="ml-auto flex items-center gap-1.5">
           <TableScoreTile


### PR DESCRIPTION
## Summary

Five small bugs / UX dishonesties caught by a Chrome DevTools MCP smoke-test of the multi-site dashboard once we ran with degraded scan data (local Chrome AppArmor sandbox blocked every audit, so scans are `status: complete` but `summary.completed === 0` and `scoresByCategory: {}`).

- **`composables/useScannedSites.ts`** — `latestComplete` now prefers a completed scan that actually produced score data; falls back to the latest *structurally* complete scan only when no scored scan exists. Stops the /sites card from rendering "No data" for a site that has older scored scans.
- **`pages/compare.vue`** — picker filters `scoreAverage != null` so empty-data scans are hidden; the diff target list only includes scans that can actually diff (collapsed 7 → 4 picker entries in local repro).
- **`pages/sites/[siteId]/index.vue`** — favicon `<img alt="…">` was repeating the site name next to the visible text, so screen readers heard "harlanzw.com harlanzw.com". `alt=""` + `aria-hidden=true` is the standard decorative pattern when text is adjacent. Status badge now reads "no data" (grey) instead of "complete" (green) for the zero-audits case.
- **`pages/sites/scanned/[host].vue`** — same `no data` status; also shows `completed/total` routes to match the per-site page format (was bare `total`).
- **`nuxt.config.ts`** — restore the `vite.server.allowedHosts` env-driven block; it was wiped during an earlier branch reset and `packages/ui/.env`'s `NUXT_DEV_ALLOWED_HOSTS` had no reader, so Vite kept 403-ing tailscale / tunnel hostnames.

## Test plan

Verified via Chrome DevTools MCP against the running dev server:

- /sites — harlanzw.com card now shows P:91 / A:92 / B:95 / S:98 instead of "No data"
- /sites/[siteId] + /sites/scanned/[host] — both show "0/24 routes · no data" (grey badge) for today's empty scan, "23/450 routes · complete" (green) for older scored scans
- /compare — picker collapsed from 7 entries to 4 (all scored)
- tailscale `https://server1.tail0b5228.ts.net:3000` reachable again

🤖 Generated with [Claude Code](https://claude.com/claude-code)