### PR TITLE
docs: architecture + self-host on Cloudflare

### DIFF
--- a/docs/4.architecture.md
+++ b/docs/4.architecture.md
@@ -1,0 +1,215 @@
+---
+title: "Unlighthouse v1 Architecture"
+icon: i-carbon-network-3
+description: "How Unlighthouse v1 is structured: four ports (SeedSource, Crawler, Auditor, Storage), eight packages, and the adapter wiring that makes one core run on Node CLI and Cloudflare Workers."
+keywords:
+  - unlighthouse architecture
+  - unlighthouse v1
+  - ports and adapters
+  - hexagonal architecture
+  - cloudflare workers
+  - lighthouse architecture
+navigation:
+  title: "Architecture"
+relatedPages:
+  - path: /integrations/cli
+    title: CLI
+  - path: /integrations/mcp
+    title: MCP for AI Agents
+  - path: /self-host-cloudflare
+    title: Self-Host on Cloudflare
+  - path: /api-doc
+    title: API Reference
+---
+
+# Unlighthouse v1 Architecture
+
+Unlighthouse v1 is a site-wide Lighthouse scanner built on a **ports-and-adapters** core. The same `@unlighthouse/core` engine drives the local CLI, the MCP server, and the Cloudflare Worker preset — because every runtime-specific concern (where seeds come from, how Chrome is reached, where rows and blobs live) is behind a port the host wires up.
+
+<!-- TODO screenshot: high-level architecture diagram (CLI vs Worker, same core) -->
+
+## What changed from v0
+
+- v0 ran a single Node-only pipeline: chrome-launcher + puppeteer-cluster + a `history.db` SQLite file.
+- v1 splits that pipeline into four interchangeable ports and one event bus, so the same engine runs unmodified inside a Cloudflare Worker against Browser Run + D1 + R2.
+- `createUnlighthouse` / `UnlighthouseContext` / `useLogger()` / the v0 `history.db` are gone. `createUnlighthouseCore(opts)` is the only factory; everything reads and writes through the `Storage` port.
+- Node ≥ 22 baseline on every published package (unlocks `node:sqlite`, native `fetch`, `require(esm)`).
+
+## Ports
+
+```
+   SeedSource[]  ──►  Crawler  ──►  Auditor (often AuditorRouter)
+                       │  ▲              │
+                       │  └─core.run()   └── audits each URL
+                       │
+                       ▼
+                    Storage (rows + blobs)
+                       │
+                       └──── @unlighthouse/core/api ──► UI
+                                  │
+               (Hookable bus: scan:*, assert:*, compare:*, quota:*, log)
+```
+
+A port qualifies for v1 when it has at least two real adapters today, or a treeshake invariant forces an import boundary. Single-adapter seams (Policy, BrowserPool, Broadcaster, RateLimiter) stay inline shapes until a second adapter ships.
+
+### `SeedSource` — pure URL producers
+
+```ts
+interface SeedSource {
+  seeds(): AsyncIterable<Seed>
+}
+interface Seed { url: string; from: 'sitemap' | 'manual' | 'route-def' }
+```
+
+Shipped adapters: `seeds/{sitemap, manual, route-definitions, fuse}`. All pure HTTP except `route-definitions` (Node `fs` scan of Nuxt/Next page files). `manual` accepts an opaque `urls: string[]` and bypasses URL discovery — the answer to SPA / hash-routing / dotted-slug scans.
+
+### `Crawler` — drives the seed-to-audit loop
+
+```ts
+interface Crawler {
+  run(opts: {
+    seeds: SeedSource
+    audit: (url: string, ctx: CrawlCtx) => Promise<void>
+    allows?: (url: string) => boolean
+    crawlDelayMs?: number
+    signal?: AbortSignal
+  }): AsyncIterable<CrawlEvent>
+  pause?(): Promise<void>
+  resume?(): Promise<void>
+  state?(): CrawlerState
+}
+```
+
+Three blessed adapters ship under `@unlighthouse/core/crawlers/*`:
+
+| Adapter | Use case | Pause/resume | Worker-safe |
+|---|---|---|---|
+| `crawlers/parallel-map` | Finite seed list, no discovery (PSI/CrUX bulk runs) | yes | yes |
+| `crawlers/crawlee` | Sitemap + manual + link-discovery URL graph walk | yes | no (Node-only) |
+| `crawlers/cloudflare-crawl` | CF Browser Rendering crawl inside a Worker | throws `NotSupportedError` | yes |
+
+The treeshake-by-import-boundary rule: a Worker bundle that imports `crawlers/cloudflare-crawl` must not pull in crawlee; a CLI bundle that imports `crawlers/crawlee` must not pull in `cloudflare-crawl`. Enforced by CI bundle tests, not a config enum.
+
+### `Auditor` — produces a Lighthouse report for one URL
+
+```ts
+interface Auditor {
+  audit(url: string, page?: Page, opts?: { signal?: AbortSignal }): Promise<LighthouseReport>
+  readonly capabilities: AuditorCapabilities
+}
+interface AuditorCapabilities {
+  reliablePerfScores: boolean
+  reliableFieldData:  boolean
+  supportsThrottling: boolean
+  categories: Category[]
+}
+```
+
+Shipped adapters: `auditors/{local, cdp-connect, psi, crux, dataforseo, mock}`.
+
+- **`local`** — spawns Chrome locally (chrome-launcher + Puppeteer). `reliablePerfScores: true`.
+- **`cdp-connect`** — connects to any remote Chrome over a CDP WebSocket. Covers Cloudflare Browser Run, browserless.io, and self-hosted puppeteer-cluster in one adapter. `reliablePerfScores: false` (network RTT contaminates LCP/TBT).
+- **`psi`** / **`crux`** / **`dataforseo`** — fetch precomputed reports. `crux.capabilities.reliableFieldData = true`; the others are lab/synthetic.
+- **`mock`** — fixture-driven for tests.
+
+`AuditorRouter` (composition adapter, also an `Auditor`) takes a single `pick` function. Helpers ship as composable functions — `roundRobinPick`, `weightedPick`, `rateLimitedPick`, `fallbackPick`, `predicatePick` — so new routing strategies don't need a PR to `core`. The PSI 25k/day quota cliff is closed by `fallbackPick({ primary: rateLimitedPick(...), onQuotaExceeded: 'local' })`.
+
+### `Storage` — rows and blobs
+
+```ts
+interface Storage {
+  scans: ScanRepository
+  routes: RouteRepository
+  metrics: ExtractedMetricsRepository
+  reports: ReportBlobRepository
+  packs: PackRunRepository
+  events: EventBlobRepository
+}
+```
+
+Two blessed shapes today: `storage/drizzle` (rows, sqlite dialect — covers `node:sqlite`, libsql/Turso, D1) + `storage/unstorage-blobs` (blob driver — fs for local, R2 for Cloudflare). A pure `storage/memory` adapter is used for tests and Worker default. Postgres is deferred to v1.x.
+
+## Adapters per host
+
+| Host | Crawler | Auditor | Rows | Blobs |
+|---|---|---|---|---|
+| Local CLI (`unlighthouse`) | `crawlee` | `local` (chrome-launcher) | `drizzle` + `node:sqlite` | `unstorage-blobs` + fs |
+| MCP server (`unlighthouse mcp`) | `parallel-map` or `crawlee` | inherits CLI auditor | inherits CLI storage | inherits CLI storage |
+| Cloudflare Worker (`@unlighthouse/cloudflare`) | `cloudflare-crawl` | `cdp-connect` + Browser Run + Container | `drizzle` + D1 | `unstorage-blobs` + R2 |
+| SaaS / multi-tenant | `cloudflare-crawl` or `parallel-map` | `routeAuditors({ psi, crux, local })` | `drizzle` (sqlite today, postgres v1.x) | R2 / S3 via unstorage |
+
+The dashboard, MCP, and HTTP API are projections of one command registry — same shapes, same types, regardless of host.
+
+## Multi-site and the device matrix
+
+`scan.start.input.device: Device | Device[]`. One scan can fan out across mobile and desktop in a single matrix; `ExtractedMetrics` carries a `device` column and `ScanRoute`'s primary key is `(scanId, url, device)`. Closes [LHCI #138](https://github.com/GoogleChrome/lighthouse-ci/issues/138) (63👍, open 6+ years). See decision **D-029**.
+
+Multi-site is the dashboard concern: each `scan.start` accepts an optional `site` override (PR #345) so one Worker / one CLI install can scan many hostnames without spinning up separate configs. The dashboard groups runs by `(site, branch)` and surfaces the device-matrix as side-by-side columns.
+
+<!-- TODO screenshot: multi-site dashboard with mobile + desktop columns -->
+
+## Packs
+
+A **Pack** is the v1 unit of curated, multi-audit output. It picks a problem class (Core Web Vitals, image optimisation, JS bundle health, a11y quick wins), declares which auditors it needs, and ships a reconciler that joins raw audit signals into a typed `PackReport` with prioritised fixes. Packs let agents and humans get an *answer* instead of a flat dump of Lighthouse audits.
+
+```ts
+interface Pack<TReport = unknown> {
+  name: string                                   // 'cwv', 'images', '@unlighthouse-pack/geo'
+  version: string
+  description: string
+  requires: AuditorRequirement[]
+  reconciler: (ctx: PackReconcileCtx) => Promise<TReport>
+  reportSchema: z.ZodType<TReport>
+}
+```
+
+Built-in packs at v1.0 (under `@unlighthouse/core/packs/*`):
+
+| Pack | What it answers |
+|---|---|
+| `overview` | The `scan.summary` default — top-N regressions across all categories, sub-1KB output. |
+| `cwv` | Core Web Vitals (LCP / CLS / INP) breakdown with field-vs-lab gap, lab + CrUX joined. |
+| `images` | Per-route image findings (modern formats, dimensions, lazy-loading) with byte savings. |
+| `js-bundle` | Heaviest JS chunks, unused JS, third-party blocking. |
+| `a11y-quick-wins` | High-impact, low-effort accessibility fixes prioritised by route count. |
+| `seo-basics` | Title / meta / canonical / heading / robots issues with redirect-chain detection. |
+| `crux` | Field data joined per-route (PR #354 — separate auditor capability, surfaced lab vs field gap). |
+
+Third-party packs publish as `@unlighthouse-pack/<name>` on npm. Auditors flagged `kind: 'custom'` only run when an active pack requires them, so installing a heavy GEO pack doesn't tax scans that don't use it.
+
+## Packages
+
+Eight published packages at v1.0:
+
+| Package | Role |
+|---|---|
+| `@unlighthouse/contracts` | Types + Zod schemas. Single peer dep on `zod ≥ 4`. Imported by every other package. |
+| `@unlighthouse/core` | The engine. Adapters live as subpath exports (`./seeds/*`, `./crawlers/*`, `./auditors/*`, `./storage/*`, `./packs/*`). Runtime-portable. |
+| `@unlighthouse/audit-pool` | Browser-pool shape (`puppeteer-cluster` wrapper) consumed by `auditors/local`. Will promote to a `BrowserPool` port when a second adapter ships. |
+| `@unlighthouse/cloudflare` | CF Worker preset — wires `cloudflare-crawl` + `cdp-connect` + D1 + R2 + Durable Objects. |
+| `@unlighthouse/cloudflare-lighthouse` | Tiny h3 Node server that runs inside a Cloudflare Container and drives real Lighthouse against Browser Run's external CDP endpoint. |
+| `@unlighthouse/mcp` | MCP server preset. Exposes the command registry over stdio for Claude Code, Cursor, and other MCP clients. |
+| `@unlighthouse/ui` | Static UI bundle. Types-only on `@unlighthouse/contracts` + `@unlighthouse/core/api/types` — no runtime dep on the engine. |
+| `unlighthouse` | CLI preset (the npm-name umbrella). Owns bins (`unlighthouse`, `unlighthouse-ci`, `unlighthouse-mcp`), c12 config loader, listhen, host-specific imperative rules. |
+
+The dependency graph is acyclic:
+
+```
+contracts            (peer: zod)
+   ↑
+   └── core              (peer: contracts; drizzle-orm + unstorage)
+          ↑
+          ├── ui                                    [types-only on core/api]
+          ├── audit-pool                            [Node-only]
+          ├── cloudflare-lighthouse                 [Container-only]
+          └── mcp, cloudflare, unlighthouse         [presets]
+```
+
+CI enforces a treeshake invariant per host bundle (Worker HTTP-only, Worker CF rendering, Worker memory-only, UI typecheck, MCP). A Worker bundle that accidentally pulls in `lighthouse`, `chrome-launcher`, `better-sqlite3`, or `listhen` fails the build.
+
+## Where to go next
+
+- [Self-Host on Cloudflare](/self-host-cloudflare) — end-to-end walkthrough of the `@unlighthouse/cloudflare` preset.
+- [MCP for AI Agents](/integrations/mcp) — drive Unlighthouse from Claude Code / Cursor.
+- [CLI](/integrations/cli) — the local-host story.
+- [API Reference](/api-doc) — command registry, types, and config schema.

--- a/docs/5.self-host-cloudflare.md
+++ b/docs/5.self-host-cloudflare.md
@@ -1,0 +1,292 @@
+---
+title: "Self-Host Unlighthouse on Cloudflare"
+icon: i-carbon-cloud
+description: "Deploy your own Unlighthouse instance on Cloudflare Workers + Containers + Browser Run + D1 + R2. Step-by-step walkthrough with wrangler.toml, deploy commands, and cost estimate."
+keywords:
+  - self host lighthouse
+  - cloudflare lighthouse
+  - cloudflare browser run
+  - cloudflare containers lighthouse
+  - workers d1 r2
+  - unlighthouse cloudflare
+  - lighthouse worker
+navigation:
+  title: "Self-Host on Cloudflare"
+relatedPages:
+  - path: /architecture
+    title: Architecture
+  - path: /integrations/cli
+    title: CLI
+  - path: /integrations/mcp
+    title: MCP for AI Agents
+---
+
+# Self-Host Unlighthouse on Cloudflare
+
+The `@unlighthouse/cloudflare` preset wires the v1 core into a Cloudflare Worker. A Worker handles the HTTP API, Durable Objects own WebSocket fan-out + rate limiting, a Cloudflare Container runs real Lighthouse, and Browser Run provides Chromium. D1 stores rows; R2 stores reports and event blobs.
+
+This guide walks you through provisioning, deploying, and triggering a scan against your own instance. It mirrors the reference setup in [`packages/cloudflare/examples/basic/`](https://github.com/harlan-zw/unlighthouse/tree/v1/packages/cloudflare/examples/basic) — start there if you want a copy-pasteable template.
+
+## How the pieces fit
+
+```
+Worker (HTTP, D1, R2, DOs, WS fan-out, cron sweeper)
+  │ env.LIGHTHOUSE_CONTAINER.getByName('default').fetch('/audit', ...)
+  ▼
+LighthouseContainer (Node 22 image, ~250 MB, no Chromium)
+  │ puppeteer.connect to wss://api.cloudflare.com/.../browser-rendering/...
+  ▼
+Browser Run (managed Chromium on Cloudflare's edge)
+```
+
+The Worker never touches `lighthouse` directly (it can't — `fileURLToPath(import.meta.url)` crashes in the Workers runtime). The Container does the Lighthouse work and talks to Cloudflare-hosted Chromium over CDP.
+
+<!-- TODO screenshot: deployed Cloudflare dashboard showing Worker + Container + D1 + R2 -->
+
+## Prerequisites
+
+- **Cloudflare Workers Paid plan** ($5/mo). Containers and Browser Run both require it.
+- **Browser Rendering enabled** on your account. From the dashboard: *Workers & Pages → AI → Browser Rendering → Enable*.
+- **Wrangler ≥ 4** installed: `npm i -g wrangler` (or `pnpm i -g wrangler`).
+- One-time login: `wrangler login`.
+- **Node ≥ 22** locally (Unlighthouse v1's baseline).
+- **Docker** running locally (Wrangler builds the Container image before push).
+
+## Step 1 — Clone and install
+
+```sh
+git clone https://github.com/harlan-zw/unlighthouse.git
+cd unlighthouse
+git checkout v1
+pnpm install
+```
+
+The reference deploy template lives at `packages/cloudflare/examples/basic/`:
+
+```sh
+cd packages/cloudflare/examples/basic
+```
+
+Copy this directory out of the monorepo if you want to keep your deploy config in its own repo — the only relative paths it uses are the Container `Dockerfile` reference (which you can vendor by copying `packages/cloudflare-lighthouse/Dockerfile` into your project).
+
+## Step 2 — Provision the bindings
+
+Run each command and copy the resulting IDs into `wrangler.toml`.
+
+```sh
+# D1 — relational rows (scans, routes, metrics, pack runs)
+wrangler d1 create unlighthouse
+# → copy `database_id` into wrangler.toml's [[d1_databases]] block
+
+# R2 — blob storage (reports + event log)
+wrangler r2 bucket create unlighthouse
+# no id needed; the bucket_name binding is enough
+
+# Secrets — stored encrypted, never in wrangler.toml
+wrangler secret put SHARED_AUDIT_TOKEN       # random 32 bytes: `openssl rand -hex 32`
+wrangler secret put CF_ACCOUNT_ID            # your Cloudflare account ID
+wrangler secret put CF_BROWSER_RUN_TOKEN     # API token, scope: Browser Rendering - Edit
+wrangler secret put CRUX_API_KEY             # optional; enables CrUX fallback
+```
+
+`CF_BROWSER_RUN_TOKEN` is created at *My Profile → API Tokens → Create Token → Custom* with the **Browser Rendering — Edit** permission scoped to your account.
+
+## Step 3 — Configure `wrangler.toml`
+
+The reference `wrangler.toml` already wires every binding. Edit three things:
+
+```toml
+name = "unlighthouse"                              # your Worker name
+main = "worker.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = [ "nodejs_compat" ]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "unlighthouse"
+database_id = "<PASTE-FROM-STEP-2>"                # ← replace
+
+[[r2_buckets]]
+binding = "BLOBS"
+bucket_name = "unlighthouse"
+
+[[durable_objects.bindings]]
+name = "SCAN_EVENTS_DO"
+class_name = "ScanEventsDO"
+
+[[durable_objects.bindings]]
+name = "RATE_LIMITER_DO"
+class_name = "RateLimiterDO"
+
+[[durable_objects.bindings]]
+name = "LIGHTHOUSE_CONTAINER"
+class_name = "LighthouseContainer"
+
+[[containers]]
+class_name = "LighthouseContainer"
+image = "./Dockerfile"                             # path to packages/cloudflare-lighthouse/Dockerfile
+instance_type = "standard-1"                       # 1 GiB / 0.5 vCPU
+max_instances = 5                                  # caps blast radius
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = [ "ScanEventsDO", "RateLimiterDO" ]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = [ "LighthouseContainer" ]
+
+[triggers]
+crons = [ "0 * * * *" ]                            # hourly R2 TTL sweeper
+
+[vars]
+# Inline unlighthouse config (JSON). Same schema as the CLI's unlighthouse.config.ts.
+UNLIGHTHOUSE_CONFIG = """
+{
+  "site": "https://example.com",
+  "scanner": { "samples": 1, "device": ["mobile", "desktop"] }
+}
+"""
+UNLIGHTHOUSE_VERSION = "1.0.0-rc.2"                # bump on each deploy
+RATE_LIMITER_CAPACITY = "10"                       # token bucket per (API key | IP)
+RATE_LIMITER_REFILL_PER_SEC = "1"
+```
+
+**Required edits:**
+1. Paste the `database_id` from `wrangler d1 create`.
+2. Replace `UNLIGHTHOUSE_CONFIG`'s `site` with your real target.
+3. Bump `UNLIGHTHOUSE_VERSION` on each deploy (used as a cache buster for the UI bundle).
+
+<!-- TODO screenshot: wrangler.toml with the three required edits highlighted -->
+
+## Step 4 — Deploy
+
+```sh
+pnpm deploy
+# or, equivalently:
+wrangler deploy
+```
+
+`wrangler deploy` builds the Container image from the Dockerfile, pushes it to Cloudflare's registry, and then deploys the Worker. The Durable Object migrations (`v1` for `ScanEventsDO` + `RateLimiterDO`, `v2` for `LighthouseContainer`) run automatically. The D1 schema is applied in-process on first request — no separate `wrangler d1 migrations apply` step.
+
+First deploy takes 2–4 minutes (Container build dominates). Subsequent deploys with no Container change are 20–30 seconds.
+
+## Step 5 — Verify
+
+```sh
+WORKER=https://<your-worker-name>.<your-subdomain>.workers.dev
+
+# Health — proves the Worker booted.
+curl $WORKER/api/health
+# → { ok: true, version: "1.0.0-rc.2", uptimeMs, storage, activeScans }
+```
+
+Open the dashboard:
+
+```sh
+open $WORKER         # or just paste into a browser
+```
+
+<!-- TODO screenshot: deployed Unlighthouse dashboard at workers.dev URL, empty state -->
+
+Kick off a scan from the CLI (or `curl`):
+
+```sh
+SCAN=$(curl -fsS -X POST $WORKER/api/scan/start \
+  -H 'content-type: application/json' \
+  -d '{"site":"https://example.com"}' | jq -r .scanId)
+echo "scanId=$SCAN"
+
+# Tail the Worker + Container logs in another terminal:
+wrangler tail
+# You should see:
+#   LighthouseContainer started
+#   [cloudflare-lighthouse] listening on :8080
+#   scan:route:completed url=https://example.com/
+```
+
+Poll until done:
+
+```sh
+while [ "$(curl -fsS "$WORKER/api/scan/status?scanId=$SCAN" | jq -r .status)" != "completed" ]; do
+  sleep 5
+done
+
+curl -fsS "$WORKER/api/scan/results?scanId=$SCAN" \
+  | jq '.routes[0].extracted.categories.performance.score'
+# → 0.92 (or similar — NOT null. Null means the mock auditor ran; the Container failed.)
+```
+
+<!-- TODO screenshot: completed scan in the dashboard with mobile + desktop scores -->
+
+You can also point the CLI at the deployed instance:
+
+```sh
+UNLIGHTHOUSE_API_URL=$WORKER/api pnpm unlighthouse --site https://example.com --no-open
+```
+
+The CLI talks to the same command registry over HTTP; the scan runs in the Worker, results stream back over the WebSocket fan-out.
+
+## Cost estimate
+
+For a typical workload of **500 routes scanned per day** (one device, one sample per route):
+
+| Component | Volume | Cost |
+|---|---|---|
+| Workers Paid plan | flat | $5 / mo |
+| Browser Run | ~5 browser-hours / mo | ~$3 / mo (10 hrs/mo included on Paid) |
+| Cloudflare Containers | `standard-1` instance, ~30 min / day active, scales to zero | ~$7 / mo |
+| D1 | well below free tier for 500 routes/day | $0 |
+| R2 | ~2 GB stored, ~5 GB egress / mo | < $1 / mo |
+| **Total** | | **≈ $15 / mo** |
+
+A 500-route scan typically consumes **5–7 Container compute-minutes** end-to-end (with `samples: 1`, single device, parallel-map crawler). Doubling to `device: ['mobile', 'desktop']` roughly doubles compute-minutes; `samples: 3` roughly triples them.
+
+Caveats: the numbers above assume scans stay within Browser Run's included quota and the Container sleeps between scans (`sleepAfter = '10m'` is the default). High-frequency CI usage (e.g. scanning every PR for a busy monorepo) will push you toward `standard-2` and bump Browser Run into the paid tier — budget ~$30–50/mo for that profile.
+
+## Troubleshooting
+
+**Rate limiter rejecting scan requests.** `RATE_LIMITER_CAPACITY` / `RATE_LIMITER_REFILL_PER_SEC` is a token bucket keyed on (API key or client IP). Defaults are 10 / 1-per-sec. Bump the capacity in `wrangler.toml` if CI fires bursts of scans:
+
+```toml
+[vars]
+RATE_LIMITER_CAPACITY = "60"
+RATE_LIMITER_REFILL_PER_SEC = "10"
+```
+
+**R2 sweeper missing.** The hourly cron (`0 * * * *`) calls the R2 TTL sweeper, which deletes report blobs past their retention window. Watch for `[r2-sweeper] scanned=N deleted=M` in `wrangler tail`. If you don't see it, confirm `[triggers].crons` is set in `wrangler.toml` and that Cron Triggers are enabled on the Worker.
+
+**Cold start after idle.** `sleepAfter = '10m'` means the Container hibernates after 10 minutes of no traffic. The first scan after idle pays a 3–5 second boot. For latency-sensitive setups, set `sleepAfter` higher (e.g. `'1h'`) — you pay slightly more idle compute but eliminate the cold start.
+
+**`performance.score` returns `null`.** The Container fell over and the fallback auditor (mock) ran. Check `wrangler tail` for `container-lighthouse failed:`. Common causes:
+- Browser Run rate limit (10 req/sec, 10 concurrent baseline) — back off concurrency or upgrade.
+- Container OOM on a heavy SPA — bump `instance_type` to `standard-2` (2 GiB / 1 vCPU).
+- `CF_BROWSER_RUN_TOKEN` missing the Browser Rendering scope.
+
+**Fallback cascade verification.** The default `auditorFactory` wires `fallbackAuditor([container, crux?, mock])`. To prove the cascade:
+
+```sh
+wrangler containers instances list
+wrangler containers instances stop <id> --force
+# Re-run the scan — wrangler tail should show:
+#   container-lighthouse failed: ECONNREFUSED
+#   trying next auditor: crux         (if CRUX_API_KEY was set)
+```
+
+**Observability.** `wrangler tail` streams Worker + Container logs together. The Worker emits Hookable events (`scan:*`, `quota:*`) as structured log lines; the Container logs h3's request log and Lighthouse's own output.
+
+## Tear-down
+
+```sh
+wrangler delete                                # removes the Worker + Container
+wrangler d1 delete unlighthouse                # removes the D1 database
+wrangler r2 bucket delete unlighthouse         # removes the R2 bucket
+```
+
+Secrets are removed automatically with the Worker.
+
+## Where to go next
+
+- [Architecture](/architecture) — how the four ports map to D1, R2, Browser Run, and the Container.
+- [CLI](/integrations/cli) — point the CLI at your deployed instance with `UNLIGHTHOUSE_API_URL`.
+- [MCP for AI Agents](/integrations/mcp) — connect Claude Code or Cursor to your deployed scans.


### PR DESCRIPTION
## Summary

Two new top-level docs pages, drafted for **Phase 18 of #349** (the v1 rewrite roadmap):

- `docs/4.architecture.md` — overview of the v1 ports-and-adapters core. Covers the four ports (`SeedSource`, `Crawler`, `Auditor`, `Storage`), the ASCII ports diagram from `v1.md`, the adapter table per host (local CLI / MCP / Cloudflare Worker / SaaS), the **D-029 multi-device matrix scan** + `scan.start` `site` override (PR #345), the six built-in **packs** plus the **crux** pack from PR #354, and the **8-package layout** (`audit-pool`, `cloudflare`, `cloudflare-lighthouse`, `contracts`, `core`, `mcp`, `ui`, `unlighthouse`).
- `docs/5.self-host-cloudflare.md` — full walkthrough of the `@unlighthouse/cloudflare` preset. Expanded from `packages/cloudflare/examples/basic/README.md` with: prereqs (Workers Paid, Browser Rendering, Wrangler ≥ 4), step-by-step provisioning (D1 + R2 + secrets), annotated `wrangler.toml` with the three required edits, Container + Browser Run wiring, deploy commands, dashboard hookup, CLI hookup via `UNLIGHTHOUSE_API_URL`, cost estimate (~$15/mo for 500 routes/day), troubleshooting (rate limiter, R2 sweeper, cold start, fallback cascade), observability, tear-down.

## Conventions

- Both pages use the existing Nuxt Content front-matter style (title / icon / description / keywords / navigation / relatedPages) so they slot into the live docs site without restructuring.
- Numbered prefixes `4.` and `5.` to follow the existing `1.guide` / `2.integrations` / `3.api-doc` top-level convention.
- Cross-links to `/architecture`, `/self-host-cloudflare`, `/integrations/{cli,mcp}`, and `/api-doc`.

## Screenshots

Placeholder `<!-- TODO screenshot: ... -->` comments mark the four spots that need real images:
- high-level architecture diagram (CLI vs Worker, same core)
- multi-site dashboard with mobile + desktop columns
- deployed Cloudflare dashboard showing Worker + Container + D1 + R2
- `wrangler.toml` with the three required edits highlighted
- deployed Unlighthouse dashboard at `workers.dev` URL (empty state + completed scan)

Keeping the PR text-only so review is fast — screenshots can be added in a follow-up once a reference instance is live.

## Test plan

- [ ] Render both pages locally (Nuxt Content dev) and check the nav / sidebar entries.
- [ ] Confirm internal links resolve (`/architecture`, `/self-host-cloudflare`, `/integrations/cli`, `/integrations/mcp`, `/api-doc`).
- [ ] Verify the `wrangler.toml` example matches the latest reference at `packages/cloudflare/examples/basic/wrangler.toml`.
- [ ] Sanity-check the cost numbers against the latest Cloudflare pricing.

Refs #349 (Phase 18 — Documentation rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)