### PR TITLE
docs(mcp): registry submission prep — Smithery / MCPMarket / Anthropic

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,153 @@
+# @unlighthouse/mcp
+
+[Model Context Protocol](https://modelcontextprotocol.io) projection of the
+Unlighthouse command registry. Lets MCP-aware agents (Claude Code, Claude
+Desktop, Continue, Cursor, Zed, etc.) drive whole-site Lighthouse scans,
+inspect history, run packs, and compare runs.
+
+The published binary is `unlighthouse-mcp`, shipped from the parent
+[`unlighthouse`](https://www.npmjs.com/package/unlighthouse) npm package.
+This workspace package is the projection layer; end users do not install
+`@unlighthouse/mcp` directly.
+
+## Install
+
+The MCP server is bundled with the `unlighthouse` CLI — no separate install
+needed. Either run it via `npx` on demand:
+
+```bash
+npx -y unlighthouse-mcp --site https://example.com
+```
+
+…or add it globally:
+
+```bash
+npm install -g unlighthouse
+unlighthouse-mcp --site https://example.com
+```
+
+## Configure
+
+### Claude Code
+
+Add the server with the `claude mcp add` CLI:
+
+```bash
+claude mcp add unlighthouse -s user \
+  -- npx -y unlighthouse-mcp --site https://example.com
+```
+
+Or edit `~/.claude.json` directly:
+
+```jsonc
+{
+  "mcpServers": {
+    "unlighthouse": {
+      "command": "npx",
+      "args": ["-y", "unlighthouse-mcp", "--site", "https://example.com"]
+    }
+  }
+}
+```
+
+### Claude Desktop / Cursor / Zed
+
+The same JSON block goes in each host's settings file. The two flags that
+matter:
+
+- `--site <url>` — site to point the storage layer at. Without it the server
+  auto-discovers any `.unlighthouse/<host>/` directory in CWD that already
+  has scans on disk.
+- `--root <path>` — override CWD (useful for global installs).
+- `--debug` — verbose stderr logs.
+
+## Tools
+
+The MCP surface is generated from the command registry in
+[`@unlighthouse/contracts/commands`](../contracts/src/commands/index.ts).
+Tool names are the command name with `.` → `_` (e.g. `scan.start` →
+`scan_start`). Currently exposed:
+
+| Group       | Tools                                                                                              |
+|-------------|----------------------------------------------------------------------------------------------------|
+| Scan        | `scan_start`, `scan_status`, `scan_cancel`, `scan_pause`, `scan_resume`, `scan_delete`, `scan_results`, `scan_summary`, `scan_meta`, `scan_current`, `scan_rescanAll` |
+| Route       | `route_get`, `route_rescan`                                                                        |
+| History     | `history_list`, `history_get`, `history_delete`, `history_rescan`                                  |
+| Compare     | `compare_run`, `compare_markdown`, `compare_findPrevious`                                          |
+| Assert      | `assert_evaluate`                                                                                  |
+| Pack        | `pack_run`, `pack_list`                                                                            |
+| Query       | `query_routes`                                                                                     |
+| Events      | `events_subscribe`, `events_tail`                                                                  |
+| Meta        | `manifest`, `health`, `auditors_list`, `auditors_test`                                             |
+| Sites       | `sites_list`, `sites_get`, `sites_create`, `sites_delete`                                          |
+
+For each tool's argument schema, call `manifest` from your agent or read the
+source: [`packages/contracts/src/commands/`](../contracts/src/commands/).
+
+## Example Claude Code session
+
+```text
+You: scan https://example.com and tell me the worst performance offenders
+
+Claude: I'll start a scan and report once routes finish auditing.
+  [calls scan_start with { site: "https://example.com" }]
+  [calls scan_status — sees 12/24 routes done]
+  [waits, calls scan_status again — 24/24]
+  [calls pack_run with { pack: "cwv", scanId: "<id>" }]
+
+  Worst LCP routes:
+    /products/featured  — 4.8s
+    /blog/long-post     — 4.2s
+    /search?q=...       — 3.9s
+
+  Common root cause: render-blocking <link rel="stylesheet"> at line 42 of
+  the shared layout. Want me to open a diff against the previous scan to
+  confirm this is a regression?
+
+You: yes please
+
+Claude: [calls compare_findPrevious + compare_markdown]
+  This is a regression vs scan from 3 days ago — LCP was 1.8s on /products/featured
+  before today's deploy.
+```
+
+## Demo video
+
+<!-- TODO video — record Claude Code driving a whole-site scan end-to-end. -->
+
+## How it works
+
+`projection.ts` walks the command registry, converts each command's `zod`
+input schema to JSON Schema, and registers it as an MCP tool. On call, the
+projection runs the command's handler with a per-request `HandlerCtx`. If the
+handler returns an async iterable and the client passed a `progressToken`,
+each chunk is emitted as a `notifications/progress` message; otherwise the
+chunks are collected into a JSON array.
+
+Errors raised by handlers are mapped to MCP error codes:
+
+| Internal code        | MCP code              |
+|----------------------|-----------------------|
+| `NOT_SUPPORTED`      | `MethodNotFound`      |
+| `INPUT_INVALID`      | `InvalidParams`       |
+| `CONFIG_INVALID`     | `InvalidParams`       |
+| (anything else)      | `InternalError`       |
+
+## Registry submissions
+
+This package is in flight for submission to public MCP catalogs. Authoring
+payloads live in [`./registry/`](./registry/):
+
+- [`SMITHERY.md`](./registry/SMITHERY.md) — Smithery (smithery.ai).
+- [`MCPMARKET.md`](./registry/MCPMARKET.md) — MCPMarket (mcpmarket.com).
+- [`ANTHROPIC.md`](./registry/ANTHROPIC.md) — Official MCP metaregistry
+  (registry.modelcontextprotocol.io).
+- [`CATEGORY-PROPOSAL.md`](./registry/CATEGORY-PROPOSAL.md) — Pitch for a
+  "Site Performance" category, audience and scope.
+
+Tracking issue: [harlan-zw/unlighthouse#349](https://github.com/harlan-zw/unlighthouse/issues/349)
+(Phase 14 — MCP positioning).
+
+## License
+
+MIT.

--- a/packages/mcp/registry/ANTHROPIC.md
+++ b/packages/mcp/registry/ANTHROPIC.md
@@ -1,0 +1,114 @@
+# Anthropic / official MCP registry submission
+
+The official MCP registry (<https://registry.modelcontextprotocol.io>) is the
+upstream metaregistry that Anthropic, GitHub, Microsoft, and PulseMCP back. It
+is the single source of truth — downstream marketplaces (Smithery, MCPMarket,
+etc.) aggregate from it. Submitting here first is the highest-leverage move.
+
+Reference: <https://modelcontextprotocol.io/registry> and the schema at
+<https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/draft/server.schema.json>.
+
+## server.json — proposed payload
+
+Place this at the repo root (or `packages/unlighthouse/server.json`, then
+`cd` into that directory before running `mcp-publisher publish`). It targets
+the **already-published** `unlighthouse` npm package, which exposes the
+`unlighthouse-mcp` bin.
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.harlan-zw/unlighthouse",
+  "title": "Unlighthouse",
+  "description": "Scan an entire website with Google Lighthouse from your agent.",
+  "version": "0.17.7",
+  "websiteUrl": "https://unlighthouse.dev",
+  "repository": {
+    "url": "https://github.com/harlan-zw/unlighthouse",
+    "source": "github",
+    "subfolder": "packages/unlighthouse"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "unlighthouse",
+      "version": "0.17.7",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "npx",
+      "runtimeArguments": [
+        { "type": "positional", "value": "-y" },
+        { "type": "positional", "value": "unlighthouse-mcp" }
+      ],
+      "packageArguments": [
+        {
+          "type": "named",
+          "name": "--site",
+          "value": "{site}",
+          "variables": {
+            "site": {
+              "description": "Site URL to scan (e.g. https://example.com)",
+              "format": "string",
+              "isRequired": true,
+              "placeholder": "https://example.com"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Keep `version` aligned with the published `unlighthouse` npm version. Bump it
+in lockstep on every npm release that affects the MCP surface.
+
+Description must be 1–100 characters per the schema; the value above is 56.
+
+## Submission steps
+
+```bash
+# 1. Install mcp-publisher (Linux/macOS)
+curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+  | tar xz mcp-publisher \
+  && sudo mv mcp-publisher /usr/local/bin/
+
+mcp-publisher --help     # smoke-test the binary
+
+# 2. (Optional) Scaffold a fresh server.json — useful if you want to compare
+#    against the version checked in here.
+cd /tmp && mcp-publisher init
+# Then `diff` against packages/mcp/registry/server.json (this file).
+
+# 3. From the repo root, copy the payload above into ./server.json
+#    (or symlink: ln -s packages/mcp/registry/server.json server.json).
+
+# 4. Authenticate via GitHub. The namespace `io.github.harlan-zw/*` requires
+#    logging in as the `harlan-zw` GitHub account (or running inside a GitHub
+#    Action on a harlan-zw repository with the appropriate OIDC permissions).
+mcp-publisher login github
+
+# 5. Publish
+mcp-publisher publish
+
+# 6. Verify the listing went live
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.harlan-zw/unlighthouse"
+```
+
+## Automation (later)
+
+Wire `mcp-publisher publish` into the release workflow alongside `npm publish`
+so the registry version never drifts. Use GitHub Actions with OIDC auth —
+`mcp-publisher login github-oidc` works inside `harlan-zw/unlighthouse`
+workflows without storing any secrets.
+
+## Namespace alternatives
+
+- `io.github.harlan-zw/unlighthouse` (recommended — verified via the GitHub
+  account that owns the source repo).
+- `dev.unlighthouse/server` (would require DNS or HTTP challenge on
+  `unlighthouse.dev`; nicer-looking but needs an extra verification step).
+
+Stick with the GitHub-namespaced name unless the maintainer wants the
+domain-scoped one for branding.

--- a/packages/mcp/registry/CATEGORY-PROPOSAL.md
+++ b/packages/mcp/registry/CATEGORY-PROPOSAL.md
@@ -1,0 +1,67 @@
+# Proposed MCP category: "Site Performance"
+
+## TL;DR
+
+Add a top-level **Site Performance** category to the public MCP catalogs
+(Smithery, MCPMarket, and any other downstream aggregator). It groups MCP
+servers whose job is to *measure* a live website — Core Web Vitals,
+accessibility, SEO hygiene, render-blocking resources — rather than to drive
+a browser or fetch a single page.
+
+## Why not an existing category
+
+| Existing category    | Why it doesn't fit                                            |
+|----------------------|---------------------------------------------------------------|
+| Web Search           | Search returns *information about the web*. Site Performance returns *measurements of one specific site the user owns*. |
+| Browser Automation   | Automation drives a browser to complete a task (login, click, scrape). Site Performance audits passively and reports scores. |
+| DevTools             | Too broad. DevTools covers logs, network, debugging — anything Chrome DevTools exposes. Site Performance is about whole-site lighthouse-style scans. |
+| Analytics            | Analytics tools answer "how many users did X". Site Performance answers "how fast / accessible / SEO-healthy is this URL." |
+| SEO                  | Closest, but too narrow. Core Web Vitals, a11y audits, and JS-bundle analysis are not SEO; they're co-measured by the same tools. |
+
+## Audience
+
+- Frontend / full-stack engineers shipping production sites who want their
+  agent to triage perf regressions.
+- SEO consultants running audits before a client handoff.
+- DevOps / SRE folks running scheduled budget checks in CI.
+- Marketing / Web Vitals engineers who own LCP/CLS/INP targets.
+
+## What belongs in this category
+
+- Unlighthouse (whole-site Lighthouse scans + history + diffs).
+- Standalone Lighthouse MCP wrappers (single-page audits).
+- PageSpeed Insights / CrUX MCP wrappers.
+- Axe / Pa11y accessibility scanners.
+- SEO crawlers (Screaming Frog-style) once they ship an MCP.
+- Bundle-analyser tools (source-map-explorer, webpack-bundle-analyzer).
+
+## What does NOT belong
+
+- Headless-browser drivers (Puppeteer / Playwright MCPs) — that's Browser
+  Automation.
+- Generic crawlers that scrape content — that's Data Extraction / Web Search.
+- API testing tools — that's API Testing / DevTools.
+
+## How to submit the category proposal
+
+### Smithery
+
+1. Open <https://github.com/smithery-ai/registry/issues/new> with title
+   `Proposal: "Site Performance" category`.
+2. Paste this file verbatim into the issue body.
+3. CC the Smithery team in the body (`@smithery-ai`).
+4. Reference the Unlighthouse listing as the first inhabitant.
+
+### MCPMarket
+
+Email or DM the team via whatever contact link appears on
+<https://mcpmarket.com> (footer). If they accept GitHub PRs to a public
+category file, link this document there instead.
+
+### Official MCP registry
+
+The official registry is **deliberately unopinionated** about categories
+(see <https://modelcontextprotocol.io/registry>): "Downstream aggregators can
+provide curation or additional metadata such as community ratings." So
+categorisation belongs to the downstream marketplaces, not the metaregistry.
+Skip this for the upstream submission.

--- a/packages/mcp/registry/MCPMARKET.md
+++ b/packages/mcp/registry/MCPMARKET.md
@@ -1,0 +1,85 @@
+# MCPMarket submission
+
+MCPMarket (<https://mcpmarket.com>) is a community-curated MCP catalog. At the
+time this document was authored, MCPMarket's public site was rate-limiting
+WebFetch requests and no public submission API or schema was reachable.
+
+<!-- needs maintainer verification -->
+The fields below are the maintainer's best estimate of MCPMarket's listing
+metadata, modelled after the fields visible on existing public listings
+(name, description, homepage, install command, tools). The maintainer should
+confirm exact field names with MCPMarket support before pasting into the
+submission form or PR.
+
+## manifest.json — proposed payload
+
+```json
+{
+  "name": "unlighthouse",
+  "displayName": "Unlighthouse",
+  "description": "Scan an entire website with Google Lighthouse and inspect performance, accessibility, SEO, and best-practices results from any MCP client.",
+  "homepage": "https://unlighthouse.dev",
+  "repository": "https://github.com/harlan-zw/unlighthouse",
+  "license": "MIT",
+  "author": "Harlan Wilton",
+  "category": "Site Performance",
+  "tags": ["lighthouse", "performance", "seo", "accessibility", "audit", "web-vitals"],
+  "transport": "stdio",
+  "install": {
+    "npm": "npx -y unlighthouse-mcp --site <SITE_URL>"
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "site": {
+        "type": "string",
+        "format": "uri",
+        "description": "Site to scan, e.g. https://example.com"
+      }
+    },
+    "required": ["site"]
+  },
+  "tools": [
+    "scan_start", "scan_status", "scan_cancel", "scan_pause", "scan_resume",
+    "scan_delete", "scan_results", "scan_summary", "scan_meta", "scan_current",
+    "scan_rescanAll",
+    "route_get", "route_rescan",
+    "history_list", "history_get", "history_delete", "history_rescan",
+    "compare_run", "compare_markdown", "compare_findPrevious",
+    "assert_evaluate",
+    "pack_run", "pack_list",
+    "query_routes",
+    "events_subscribe", "events_tail",
+    "manifest", "health",
+    "auditors_list", "auditors_test",
+    "sites_list", "sites_get", "sites_create", "sites_delete"
+  ]
+}
+```
+
+## Submission steps
+
+1. Open <https://mcpmarket.com> and find the **Submit a server** link
+   (typically in the site footer). If no public form is found, file an issue
+   on the MCPMarket community repo or email the listed contact address.
+2. Paste the manifest fields above into the corresponding form fields.
+3. For "Install command" use exactly:
+
+   ```bash
+   npx -y unlighthouse-mcp --site https://example.com
+   ```
+
+4. Attach a screenshot of the dashboard (any scan from `unlighthouse.dev` is
+   fine).
+5. Link the MCP-focused README at
+   <https://github.com/harlan-zw/unlighthouse/blob/main/packages/mcp/README.md>.
+6. Tick "Site Performance" as the category — if the form's dropdown has no
+   such entry, leave a free-text note referencing
+   `packages/mcp/registry/CATEGORY-PROPOSAL.md`.
+
+## Updates
+
+When `unlighthouse` ships a new version that materially changes the tool
+surface (added or removed commands), bump the manifest's implicit version by
+re-submitting. MCPMarket pulls the latest npm metadata for the install
+command, so a plain `npm publish` of `unlighthouse` is otherwise sufficient.

--- a/packages/mcp/registry/SMITHERY.md
+++ b/packages/mcp/registry/SMITHERY.md
@@ -1,0 +1,95 @@
+# Smithery submission
+
+Smithery (<https://smithery.ai>) is the largest community catalog of MCP servers.
+The current Smithery CLI publishes servers either by URL (remote MCP) or as an
+MCPB bundle (local stdio). Unlighthouse ships a stdio binary
+(`unlighthouse-mcp`) inside the `unlighthouse` npm package, so the maintainer
+has two options:
+
+1. Publish a thin wrapper / MCPB bundle pointing at `npx unlighthouse-mcp`.
+2. Publish only via the official MCP metaregistry (see `ANTHROPIC.md`) and let
+   Smithery mirror from there — Smithery is a downstream aggregator of the
+   metaregistry.
+
+Option 2 is recommended for the first cut: one source of truth, zero
+duplication, and Smithery will pick the entry up automatically once it lands
+upstream.
+
+If the maintainer wants a Smithery-native listing too (e.g. to control the
+display name, screenshots, or category), use the payload below.
+
+<!-- needs maintainer verification -->
+Smithery historically supported a `smithery.yaml` at the repo root for stdio
+servers, but the current public docs (<https://smithery.ai/docs/concepts/cli.md>,
+fetched 2026-05) describe only the `smithery mcp publish <url|bundle>` flow.
+The YAML below is preserved for the maintainer to test against the current
+deployer — if Smithery rejects it, fall back to the CLI flow further down.
+
+## smithery.yaml (legacy stdio publish format)
+
+Place this at the repo root **only if** Smithery's current deployer still
+accepts it. Verify by running `smithery mcp publish --dry-run` first.
+
+```yaml
+# smithery.yaml
+# Schema reference: https://smithery.ai/docs/build
+runtime: "node"
+startCommand:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    - "unlighthouse-mcp"
+    - "--site"
+    - "{site}"
+  configSchema:
+    type: object
+    properties:
+      site:
+        type: string
+        description: "Site URL to scan (e.g. https://example.com)"
+        format: uri
+    required: [site]
+```
+
+## Submission steps
+
+```bash
+# 1. Install the Smithery CLI
+npm install -g smithery@latest      # requires Node 20+
+
+# 2. Authenticate (opens browser for OAuth)
+smithery auth login
+
+# 3. Confirm namespace ownership
+smithery namespace list
+smithery namespace use harlan-zw    # or @unlighthouse, if claimed
+
+# 4. Publish — pick ONE of the two flows below
+
+#    a) MCPB bundle flow (preferred for stdio servers):
+#       Build an MCPB archive that wraps `npx unlighthouse-mcp` and run:
+smithery mcp publish ./unlighthouse.mcpb -n harlan-zw/unlighthouse
+
+#    b) URL flow (only if a hosted HTTP transport is added later):
+smithery mcp publish "https://mcp.unlighthouse.dev" -n harlan-zw/unlighthouse \
+  --config-schema '{"type":"object","properties":{"site":{"type":"string","format":"uri"}},"required":["site"]}'
+
+# 5. Verify the listing
+smithery mcp search unlighthouse
+```
+
+## Category
+
+Request the `Site Performance` category at submission time (see
+`CATEGORY-PROPOSAL.md`). The Smithery UI exposes category selection in the
+post-publish dashboard at <https://smithery.ai/server/harlan-zw/unlighthouse>.
+If the category does not exist yet, ping the Smithery team via the issue
+tracker at <https://github.com/smithery-ai/registry> and reference
+`CATEGORY-PROPOSAL.md`.
+
+## What goes in the listing description
+
+Copy the "Tools" section from `packages/mcp/README.md` (auto-generated from
+the command registry) plus the example Claude Code session, so users see
+exactly what the server exposes before they install.


### PR DESCRIPTION
## Summary

Prep work for [#349](https://github.com/harlan-zw/unlighthouse/issues/349)
Phase 14 (MCP positioning). **No automated submissions** — files only, so
the maintainer can paste them into each registry's flow.

- `packages/mcp/registry/SMITHERY.md` — `smithery.yaml` + `smithery mcp publish` CLI flow
- `packages/mcp/registry/MCPMARKET.md` — proposed `manifest.json` + submission steps
- `packages/mcp/registry/ANTHROPIC.md` — `server.json` for the official MCP metaregistry (canonical schema, verified against `registry/server.schema.json`) + `mcp-publisher` CLI flow
- `packages/mcp/registry/CATEGORY-PROPOSAL.md` — pitch for a new "Site Performance" category (audience, scope, why neither "Web Search" nor "Browser Automation" fits)
- `packages/mcp/README.md` — public-facing README: install, Claude Code config, full ~33-tool surface grouped by domain, example session, `<!-- TODO video -->` marker

## Notes / open questions for the maintainer

- **Smithery's current CLI no longer documents `smithery.yaml`** — the publish flow is `smithery mcp publish <url|bundle> -n <ns>/<name>`. The legacy YAML is preserved with a `<!-- needs maintainer verification -->` marker so you can test whether the deployer still accepts it.
- **MCPMarket** was rate-limiting WebFetch when this PR was authored — the manifest fields are best-effort and similarly marked for verification.
- The official MCP registry payload (`ANTHROPIC.md`) is the most confident piece — schema fetched directly from `modelcontextprotocol/registry`.

Public package shipping the binary is `unlighthouse` (carries `bin/unlighthouse-mcp.mjs`); `@unlighthouse/mcp` stays workspace-private as the projection layer.

## Test plan

- [ ] `pnpm --filter @unlighthouse/mcp typecheck` (passes locally)
- [ ] Maintainer walks through `ANTHROPIC.md` end-to-end to confirm the `mcp-publisher` flow works for the `io.github.harlan-zw/*` namespace
- [ ] Maintainer confirms Smithery's current preferred publish path (legacy YAML vs CLI) and trims `SMITHERY.md` to match
- [ ] Demo video — out of scope for this PR, README has a TODO marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)