### PR TITLE
docs: fix global install package name (#377)

### DIFF
--- a/docs/1.guide/1.getting-started/0.installation.md
+++ b/docs/1.guide/1.getting-started/0.installation.md
@@ -78,7 +78,7 @@ A browser window opens automatically showing your scan progress. Results appear 
 If you scan sites frequently:
 
 ```bash
-npm install -g @unlighthouse/cli
+npm install -g unlighthouse
 unlighthouse --site example.com
 ```
 

--- a/docs/1.guide/1.getting-started/0.unlighthouse-cli.md
+++ b/docs/1.guide/1.getting-started/0.unlighthouse-cli.md
@@ -72,7 +72,7 @@ A browser window opens automatically showing your scan progress. Results appear 
 If you scan sites frequently:
 
 ```bash
-npm install -g @unlighthouse/cli
+npm install -g unlighthouse
 unlighthouse --site example.com
 ```
 

--- a/docs/2.integrations/0.cli.md
+++ b/docs/2.integrations/0.cli.md
@@ -28,7 +28,7 @@ Scan your entire website from the command line with a rich interactive dashboard
 ### Global install (recommended for frequent use)
 
 ```bash
-npm install -g @unlighthouse/cli
+npm install -g unlighthouse
 ```
 
 ### One-time run (no install)
@@ -43,7 +43,7 @@ Unlighthouse wraps the [Lighthouse npm package](https://www.npmjs.com/package/li
 
 | Feature | lighthouse CLI | unlighthouse CLI |
 |---------|---------------|------------------|
-| Package | `lighthouse` | `@unlighthouse/cli` |
+| Package | `lighthouse` | `unlighthouse` |
 | Pages per run | 1 | Unlimited |
 | URL discovery | Manual | Automatic |
 | Interactive UI | No | Yes |


### PR DESCRIPTION
Fixes #377

The global-install docs tell users to run `npm install -g @unlighthouse/cli` and then `unlighthouse --site …`, but the `@unlighthouse/cli` package only ships the `unlighthouse-ci` bin. The interactive `unlighthouse` command lives in the `unlighthouse` package.

## Changes
- `docs/1.guide/1.getting-started/0.installation.md` — install `unlighthouse`
- `docs/1.guide/1.getting-started/0.unlighthouse-cli.md` — install `unlighthouse`
- `docs/2.integrations/0.cli.md` — install `unlighthouse` + fix the comparison-table package name

## Left unchanged (correct)
CI docs (`docs/2.integrations/1.ci.md`, `docs/1.guide/guides/generating-static-reports.md`) intentionally install `@unlighthouse/cli` because they invoke `unlighthouse-ci`, which that package does ship.

## Verification
```
unlighthouse pkg bin:    { unlighthouse, unlighthouse-ci }
@unlighthouse/cli bin:   { unlighthouse-ci }
```