### PR TITLE
fix: LCP column blank & report/column metric mismatch (#375, #376)

### DIFF
--- a/packages/client/components/Cell/CellLargestContentfulPaint.vue
+++ b/packages/client/components/Cell/CellLargestContentfulPaint.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { UnlighthouseColumn, UnlighthouseRouteReport } from '@unlighthouse/core'
-import { iframeModalUrl, isModalOpen, isOffline } from '../../logic'
+import { iframeModalUrl, isModalOpen, isOffline, lcpElementItems } from '../../logic'
 import CellImageOutline from './CellImageOutline.vue'
 
 defineProps<{
@@ -31,7 +31,7 @@ watch(isModalOpen, () => {
 <template>
   <div v-if="report.report" class="text-sm w-full">
     <audit-result :value="report.report.audits['largest-contentful-paint']" class="ml-2" />
-    <div v-for="(item, key) in report.report.audits['largest-contentful-paint-element'].details.items[0].items" :key="key" class="flex items-center">
+    <div v-for="(item, key) in lcpElementItems(report.report.audits['largest-contentful-paint-element'])" :key="key" class="flex items-center">
       <btn-action title="Open full image" @click="openModal">
         <CellImageOutline :item="item" :report="report" :column="column" :size="{ width: 150, height: 112 }" />
       </btn-action>

--- a/packages/client/logic/index.ts
+++ b/packages/client/logic/index.ts
@@ -1,6 +1,7 @@
 export * from './actions/rescanSite'
 export * from './dark'
 export * from './fetch'
+export * from './lighthouse'
 export * from './search'
 export * from './state'
 export * from './static'

--- a/packages/client/logic/lighthouse.test.ts
+++ b/packages/client/logic/lighthouse.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { lcpElementItems } from './lighthouse'
+
+describe('lcpElementItems (#375)', () => {
+  it('returns [] when the audit is notApplicable with no details', () => {
+    // shape Lighthouse 12 returns when no LCP element is detected
+    const audit = { id: 'largest-contentful-paint-element', score: null, notApplicable: true }
+    expect(lcpElementItems(audit)).toEqual([])
+  })
+
+  it('returns [] for a missing audit', () => {
+    expect(lcpElementItems(undefined)).toEqual([])
+  })
+
+  it('returns the element rows from the nested list detail (happy path)', () => {
+    const rows = [{ node: { type: 'node', snippet: '<img>' } }]
+    const audit = {
+      id: 'largest-contentful-paint-element',
+      details: { type: 'list', items: [{ type: 'table', items: rows }] },
+    }
+    expect(lcpElementItems(audit)).toBe(rows)
+  })
+
+  it('returns [] for the legacy flat table detail rather than throwing', () => {
+    const audit = {
+      id: 'largest-contentful-paint-element',
+      details: { type: 'table', items: [{ node: { type: 'node' } }] },
+    }
+    expect(lcpElementItems(audit)).toEqual([])
+  })
+})

--- a/packages/client/logic/lighthouse.ts
+++ b/packages/client/logic/lighthouse.ts
@@ -1,0 +1,11 @@
+/**
+ * Resolve the Largest Contentful Paint element rows from the `largest-contentful-paint-element` audit.
+ *
+ * Lighthouse omits `details` entirely when no LCP element is detected (it returns
+ * `{ score: null, notApplicable: true }` for blank, errored or non-contentful pages). The happy path
+ * is a nested `list` detail whose first table holds the element rows. Resolving defensively means a
+ * missing LCP element no longer throws while rendering, which previously blanked the whole column. (#375)
+ */
+export function lcpElementItems(audit: any): any[] {
+  return audit?.details?.items?.[0]?.items ?? []
+}

--- a/packages/core/src/puppeteer/tasks/lighthouse.ts
+++ b/packages/core/src/puppeteer/tasks/lighthouse.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { computeMedianRun } from 'lighthouse/core/lib/median-run.js'
+import { ReportGenerator } from 'lighthouse/report/generator/report-generator.js'
 import { map, pick, sumBy } from 'lodash-es'
 import { normalize, relative } from 'pathe'
 import { withQuery } from 'ufo'
@@ -92,6 +93,20 @@ export function normaliseLighthouseResult(route: UnlighthouseRouteReport, result
   }
 }
 
+/**
+ * Render the `lighthouse.html` and `lighthouse.json` artifacts from a single lighthouse result.
+ *
+ * The worker process writes both artifacts once per sample run, leaving the last run on disk. When
+ * sampling, the dashboard column renders the median run instead, so the detailed report and the
+ * column drift apart. Regenerating both artifacts from the same chosen result keeps them in sync. (#376)
+ */
+export function generateReportArtifacts(report: Result): { html: string, json: string } {
+  return {
+    html: ReportGenerator.generateReport(report, 'html') as string,
+    json: ReportGenerator.generateReport(report, 'json') as string,
+  }
+}
+
 export const runLighthouseTask: PuppeteerTask = async (props) => {
   const logger = useLogger()
   const { resolvedConfig, runtimeSettings } = useUnlighthouse()
@@ -176,6 +191,11 @@ export const runLighthouseTask: PuppeteerTask = async (props) => {
     catch (e) {
       logger.warn('Error when computing median score, possibly audit failed.', e)
     }
+    // the on-disk artifacts reflect the last sample run, but we display `report` (the median run);
+    // regenerate them from `report` so the detailed report matches the dashboard column. (#376)
+    const { html, json } = generateReportArtifacts(report)
+    await writeFile(join(routeReport.artifactPath, ReportArtifacts.reportHtml), html)
+    await writeFile(reportJsonPath, json)
   }
 
   // we need to export all base64 data to improve the stability of the client

--- a/packages/core/test/lighthouse-artifacts.test.ts
+++ b/packages/core/test/lighthouse-artifacts.test.ts
@@ -1,0 +1,46 @@
+import type { Result } from 'lighthouse'
+import { describe, expect, it } from 'vitest'
+import { generateReportArtifacts } from '../src/puppeteer/tasks/lighthouse'
+
+// minimal lighthouse result; ReportGenerator only inlines the JSON, it does not validate the shape
+const lhr = {
+  lighthouseVersion: '12.6.1',
+  requestedUrl: 'https://example.com',
+  finalDisplayedUrl: 'https://example.com',
+  fetchTime: '2026-06-08T00:00:00.000Z',
+  categories: { performance: { id: 'performance', title: 'Performance', score: 0.92 } },
+  audits: {
+    'largest-contentful-paint': {
+      id: 'largest-contentful-paint',
+      title: 'Largest Contentful Paint',
+      score: 0.81,
+      numericValue: 2531,
+      displayValue: '2.5 s',
+    },
+  },
+  configSettings: { formFactor: 'mobile' },
+} as unknown as Result
+
+describe('generateReportArtifacts (#376)', () => {
+  it('renders the html report and json from the same single result', () => {
+    const { html, json } = generateReportArtifacts(lhr)
+
+    // json is the source of truth, html embeds that same source
+    const parsed = JSON.parse(json)
+    expect(parsed.audits['largest-contentful-paint'].displayValue).toBe('2.5 s')
+    expect(parsed.audits['largest-contentful-paint'].numericValue).toBe(2531)
+
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('2.5 s')
+    expect(html).toContain('2531')
+  })
+
+  it('reflects the exact result passed in, not a previous run', () => {
+    const median = { ...lhr, audits: { ...lhr.audits, 'largest-contentful-paint': { ...lhr.audits['largest-contentful-paint'], numericValue: 4000, displayValue: '4.0 s' } } } as unknown as Result
+    const { html, json } = generateReportArtifacts(median)
+
+    expect(JSON.parse(json).audits['largest-contentful-paint'].numericValue).toBe(4000)
+    expect(html).toContain('4.0 s')
+    expect(html).not.toContain('2.5 s')
+  })
+})


### PR DESCRIPTION
Fixes #375
Fixes #376

Two related Core Web Vitals display bugs, both caused by metric data being sourced inconsistently.

## #375 — LCP column blank
`CellLargestContentfulPaint.vue` read `audits['largest-contentful-paint-element'].details.items[0].items` with no guards. Lighthouse 12 returns `{ score: null, notApplicable: true }` with **no `details`** for any page where it can't detect an LCP element (blank, errored, redirected or non-contentful pages). The deep access then threw mid-render, which crashed the entire cell, so even the LCP time on the line above disappeared and the whole column went blank.

Fix: resolve the element rows through a small pure `lcpElementItems()` helper that returns `[]` for the `notApplicable`/missing-details case (and the legacy flat-table shape). The LCP time always renders; the element thumbnail is shown only when present.

## #376 — detailed report value ≠ column value
The worker process writes `lighthouse.html` and `lighthouse.json` once per sample run, leaving the **last** run on disk. But when `scanner.samples > 1` the dashboard column renders `computeMedianRun(samples)`. The median run is generally not the last run, so the iframe report and the column showed different numbers.

Fix: after selecting the median result, regenerate both artifacts from that single result via `generateReportArtifacts()` (Lighthouse's `ReportGenerator`), so the detailed report and the column always read from one source. At `samples === 1` nothing changes.

## Tests
- `packages/client/logic/lighthouse.test.ts` — `lcpElementItems` across notApplicable / missing / nested-list / legacy-table shapes
- `packages/core/test/lighthouse-artifacts.test.ts` — html and json artifacts both derive from the same result

All existing core tests pass; lint clean on changed files.