### PR TITLE
fix(client): broken screenshot thumbnails in static reports (#275)

### DIFF
--- a/packages/client/components/Cell/CellScreenshotThumbnails.vue
+++ b/packages/client/components/Cell/CellScreenshotThumbnails.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { UnlighthouseColumn, UnlighthouseRouteReport } from '@unlighthouse/core'
-import { openThumbnailsModal } from '../../logic'
+import { openThumbnailsModal, resolveReportFileUrl } from '../../logic'
 
 const props = defineProps<{
   report: UnlighthouseRouteReport
@@ -18,7 +18,7 @@ function openModal() {
 <template>
   <btn-action v-if="screenshots.length > 0" title="Open page load timeline" class="w-full" @click="openModal">
     <div class="w-full flex justify-between">
-      <img v-for="(image, key) in screenshots" :key="key" loading="lazy" :src="image.data" height="120" class="max-w-[10%] max-h-[120px] h-auto w-[10%]" alt="">
+      <img v-for="(image, key) in screenshots" :key="key" loading="lazy" :src="resolveReportFileUrl(image.data)" height="120" class="max-w-[10%] max-h-[120px] h-auto w-[10%]" alt="">
     </div>
   </btn-action>
 </template>

--- a/packages/client/components/ModalThumbnails.vue
+++ b/packages/client/components/ModalThumbnails.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { useIntervalFn } from '@vueuse/core'
+import { resolveReportFileUrl } from '../logic'
 
 const props = defineProps<{
   screenshots: any[]
@@ -90,7 +91,7 @@ onUnmounted(() => {
           <div class="bg-white dark:bg-gray-900 rounded shadow-inner flex items-center justify-center overflow-hidden min-h-[400px]">
             <img
               v-if="currentScreenshot"
-              :src="currentScreenshot.data"
+              :src="resolveReportFileUrl(currentScreenshot.data)"
               class="w-auto h-auto max-w-full"
               :alt="`Screenshot at ${currentFrame * 300}ms`"
             >
@@ -192,7 +193,7 @@ onUnmounted(() => {
               @click="currentFrame = index; stop()"
             >
               <img
-                :src="image.data"
+                :src="resolveReportFileUrl(image.data)"
                 class="w-16 h-10 object-cover rounded-sm"
                 :alt="`Thumbnail ${index + 1}`"
               >

--- a/packages/client/logic/static.ts
+++ b/packages/client/logic/static.ts
@@ -67,6 +67,23 @@ export function resolveArtifactPath(report: UnlighthouseRouteReport, file: strin
   return joinURL(window.location.pathname, withoutBase, file) // dynamic base
 }
 
+/**
+ * Resolve a client-root-relative report file (e.g. a screenshot-thumbnail `data` path) to a URL.
+ *
+ * Lighthouse thumbnail paths are stored relative to the client root (`reports/.../x.jpeg`). Rendering
+ * them raw breaks when a static report is served from a sub-path without a trailing slash, since the
+ * browser resolves them against the parent directory. Prefixing the current pathname mirrors what
+ * `resolveArtifactPath` already does for the working full-page screenshot. (#275)
+ */
+export function resolveReportFileUrl(file: string) {
+  if (!file)
+    return ''
+  let pathname = window.location.pathname
+  if (isStatic)
+    pathname = pathname.replace(/\/index\.html$/, '')
+  return joinURL(pathname, file)
+}
+
 export { apiUrl, basePath, device, dynamicSampling, groupRoutesKey, lighthouseOptions, throttle, wsUrl }
 
 export const website = new $URL(site).origin


### PR DESCRIPTION
Fixes #275

Screenshot-timeline thumbnails are stored with a `data` path relative to the client root (`reports/<route>/__screenshot-thumbnails__/0.jpeg`) and were rendered raw. When a static report (`--build-static`) is served from a sub-path **without** a trailing slash, the browser resolves those relative paths against the parent directory, so every thumbnail 404s. The full-page screenshot works because it goes through `resolveArtifactPath`, which prefixes `window.location.pathname`.

## Fix
Add a `resolveReportFileUrl(file)` helper in `logic/static.ts` that prefixes the (cleaned) pathname, mirroring `resolveArtifactPath`'s logic, and use it for the thumbnails in:
- `CellScreenshotThumbnails.vue`
- `ModalThumbnails.vue` (main image + scrubber thumbnails)

Dynamic-mode behaviour is unchanged: `resolveArtifactPath` already joins `window.location.pathname` in dynamic mode for the working screenshot, so thumbnails now follow the same proven path.

## Verification
`pnpm --filter @unlighthouse/client build` passes; lint clean on changed files.