### PR TITLE
fix: graceful shutdown on Ctrl+C + Git Bash docs (#378)

### DIFF
--- a/docs/1.guide/guides/common-errors.md
+++ b/docs/1.guide/guides/common-errors.md
@@ -8,6 +8,8 @@ keywords:
   - chrome connection refused
   - wsl lighthouse
   - lighthouse troubleshooting
+  - stop unlighthouse
+  - ctrl c not working git bash
 navigation:
   title: "Common Errors"
 relatedPages:
@@ -56,3 +58,19 @@ export default defineUnlighthouseConfig({
   },
 })
 ```
+
+## Can't stop the scan with `Ctrl+C`
+
+Unlighthouse keeps running after a scan so you can browse the dashboard. Press `Ctrl+C` in the terminal to stop it; this shuts down the dev server and closes Chrome.
+
+If `Ctrl+C` does nothing, you are almost certainly running inside **Git Bash (MinTTY)** on Windows. MinTTY does not forward `Ctrl+C` to native console programs such as Node, so the process keeps running and you have to kill it from Task Manager.
+
+**Solutions**
+
+- Wrap the command with [winpty](https://github.com/rprichard/winpty), which ships with Git for Windows:
+
+```bash
+winpty npx unlighthouse --site example.com
+```
+
+- Or run the command from **PowerShell**, **Command Prompt**, or **Windows Terminal** instead of Git Bash, where `Ctrl+C` works as expected.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,6 +50,22 @@ async function run() {
     process.exit(1)
   }
 
+  // Gracefully shut down on Ctrl+C so the dev server and Chrome instances are torn down instead of
+  // being orphaned. A second signal forces an immediate exit in case teardown hangs. (#378)
+  let shuttingDown = false
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      process.exit(1)
+    }
+    shuttingDown = true
+    logger.info(`Received ${signal}, shutting down Unlighthouse (press again to force quit)...`)
+    await unlighthouse.worker.cluster.close().catch(() => {})
+    await server.close().catch(() => {})
+    process.exit(0)
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+
   unlighthouse.hooks.hook('worker-finished', async () => {
     const end = new Date()
     const seconds = Math.round((end.getTime() - start.getTime()) / 1000)


### PR DESCRIPTION
Fixes #378

The reporter can't stop a scan with `Ctrl+C` in Git Bash and has to kill it from Task Manager.

## Root cause
Git Bash (MinTTY) does not forward `Ctrl+C` to native console programs like Node, so the signal never reaches the process. This is a terminal limitation, not something code can fix for that environment, so it's documented.

Separately, the CLI had **no** `SIGINT`/`SIGTERM` handlers at all, so even in terminals that do deliver the signal, quitting could leave orphaned Chrome instances from the puppeteer cluster.

## Changes
- **`packages/cli/src/cli.ts`** — add `SIGINT`/`SIGTERM` handlers that close the puppeteer cluster and the dev server before exiting. A second signal forces an immediate exit if teardown hangs.
- **`docs/1.guide/guides/common-errors.md`** — new "Can't stop the scan with `Ctrl+C`" section pointing Git Bash users to `winpty` or a Windows console (PowerShell / Command Prompt / Windows Terminal).

## Verification
`pnpm --filter @unlighthouse/cli build` passes; lint clean.

Note: the graceful-shutdown path benefits CMD/PowerShell/macOS/Linux; the Git Bash case is addressed by the docs.