### PR TITLE
docs: correct spelling errors

### DIFF
--- a/crux-api/server/app/services/crux.ts
+++ b/crux-api/server/app/services/crux.ts
@@ -84,7 +84,7 @@ interface NormalizedCrUXHistoryResult {
 }
 
 function normaliseCruxHistory(data: CrUXHistoryResult): NormalizedCrUXHistoryResult {
-  // we need to turn it into a time series data where we have each metric seperated into
+  // we need to turn it into a time series data where we have each metric separated into
   // an array like { value: number, time: number }[]
   // we also need to make sure that the data is sorted by time
   const { cumulative_layout_shift, largest_contentful_paint, interaction_to_next_paint } = data.metrics

--- a/docs/3.api-doc/config.md
+++ b/docs/3.api-doc/config.md
@@ -351,7 +351,7 @@ Note: If you have `robotsTxt` enabled it will load sitemap config from here.
 - **Type:** `boolean | string`{lang="ts"}
 - **Default:** `mobile`{lang="ts"}
 
-Alias to switch the viewport dimentions used for scanning. Set to `desktop` for a viewport of 1350×950. Set to `false` if you want to manually configure it through `lighthouseOptions.formFactor`.
+Alias to switch the viewport dimensions used for scanning. Set to `desktop` for a viewport of 1350×950. Set to `false` if you want to manually configure it through `lighthouseOptions.formFactor`.
 
 See [Device Configuration](/guide/guides/device) for more information.
 


### PR DESCRIPTION
## Summary

Correct two spelling errors in a source comment and the API configuration guide.

Closes #388.

## Validation

- Run the spelling check on `crux-api/server/app/services/crux.ts`.
- Run the spelling check on `docs/3.api-doc/config.md`.