### PR TITLE
fix: enable CrUX caching in production

### DIFF
--- a/crux-api/server/api/[domain]/crux/history.get.ts
+++ b/crux-api/server/api/[domain]/crux/history.get.ts
@@ -20,7 +20,7 @@ export default defineCachedEventHandler(async (event) => {
 }, {
   base: 'crux2',
   swr: true,
-  shouldBypassCache: () => true, // !!import.meta.dev,
+  shouldBypassCache: () => import.meta.dev,
   getKey: event => getRouterParam(event, 'domain', { decode: true }),
   maxAge: 60 * 60,
   staleMaxAge: 24 * 60 * 60,


### PR DESCRIPTION
## Summary

Enable the existing CrUX response cache in production.

Closes #390.

## Root cause

`shouldBypassCache` always returned `true`.
Each request called the Google CrUX API.
The configured cache lifetime and stale lifetime had no effect.

## Changes

Use `import.meta.dev` as the cache bypass condition.
Development requests still bypass the cache.
Production requests now use the existing cache settings.

## Impact

Repeated requests for one domain reuse cached CrUX data.
This change reduces Google API requests and quota use.

## Validation

- `pnpm exec eslint 'crux-api/server/api/[domain]/crux/history.get.ts'`
- `git diff --check`
