### PR TITLE
fix: compare release versions by segment

### DIFF
--- a/packages/core/src/unlighthouse.ts
+++ b/packages/core/src/unlighthouse.ts
@@ -30,6 +30,7 @@ import { resolveUserConfig } from './resolveConfig'
 import { createApi, createBroadcastingEvents, createMockRouter, WS } from './router'
 import { normaliseHost } from './util'
 import { successBox } from './util/cliFormatting'
+import { isNewerVersion } from './util/version'
 
 const engineContext = createContext<UnlighthouseContext>()
 
@@ -338,7 +339,7 @@ export async function createUnlighthouse(userConfig: UserConfig, provider?: Prov
       const title = [
         `⛵\u200D  ${colorize('bold', colorize('blueBright', AppName))} ${colorize('dim', `${provider?.name} @ v${version}`)}`,
       ]
-      if (Number(latestTag.replace('v', '').replace('.', '')) > Number(version.replace('.', ''))) {
+      if (isNewerVersion(latestTag, version)) {
         title.push(...[
           '',
           `🎉 New version ${latestTag} available! Use the latest:`,

--- a/packages/core/src/util/version.ts
+++ b/packages/core/src/util/version.ts
@@ -1,0 +1,21 @@
+function parseVersion(version: string) {
+  const parts = version.replace(/^v/, '').split('.').map(Number)
+  return parts.some(Number.isNaN) ? null : parts
+}
+
+export function isNewerVersion(latest: string, current: string) {
+  const latestParts = parseVersion(latest)
+  const currentParts = parseVersion(current)
+  if (!latestParts || !currentParts)
+    return false
+
+  const length = Math.max(latestParts.length, currentParts.length)
+  for (let i = 0; i < length; i++) {
+    const latestPart = latestParts[i] ?? 0
+    const currentPart = currentParts[i] ?? 0
+    if (latestPart !== currentPart)
+      return latestPart > currentPart
+  }
+
+  return false
+}

--- a/packages/core/test/version.test.ts
+++ b/packages/core/test/version.test.ts
@@ -1,13 +1,28 @@
 import { describe, expect, it } from 'vitest'
 import { isNewerVersion } from '../src/util/version'
 
-describe('version comparison', () => {
-  it('compares stable version segments', () => {
+describe('isNewerVersion', () => {
+  it('handles a leading v prefix and compares minor versions', () => {
     expect(isNewerVersion('v1.10.0', '1.2.0')).toBe(true)
+  })
+
+  it('compares multi-digit patch versions', () => {
     expect(isNewerVersion('v1.2.10', '1.2.9')).toBe(true)
+  })
+
+  it('compares major versions before minor versions', () => {
     expect(isNewerVersion('v1.0.0', '0.18.0')).toBe(true)
+  })
+
+  it('returns false for equal versions', () => {
     expect(isNewerVersion('v1.2.0', '1.2.0')).toBe(false)
+  })
+
+  it('treats missing segments as zero', () => {
     expect(isNewerVersion('v1.2', '1.2.0')).toBe(false)
+  })
+
+  it('returns false when the latest version is older', () => {
     expect(isNewerVersion('v1.2.0', '1.2.1')).toBe(false)
   })
 })

--- a/packages/core/test/version.test.ts
+++ b/packages/core/test/version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { isNewerVersion } from '../src/util/version'
+
+describe('version comparison', () => {
+  it('compares stable version segments', () => {
+    expect(isNewerVersion('v1.10.0', '1.2.0')).toBe(true)
+    expect(isNewerVersion('v1.2.10', '1.2.9')).toBe(true)
+    expect(isNewerVersion('v1.0.0', '0.18.0')).toBe(true)
+    expect(isNewerVersion('v1.2.0', '1.2.0')).toBe(false)
+    expect(isNewerVersion('v1.2', '1.2.0')).toBe(false)
+    expect(isNewerVersion('v1.2.0', '1.2.1')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Compare stable release versions by numeric segment.

Closes #392.

## Root cause

The previous code removed one period from each version.
It then converted the remaining text to a number.
This produced incorrect ordering for multi-digit patch and major versions.

## Changes

- Add an internal stable-version comparison helper.
- Compare each version segment as an integer.
- Add tests for major, minor, patch, equal, and shorter versions.

## Impact

The CLI now shows update notices for the correct release versions.
This change adds no runtime dependency.

## Validation

- `pnpm exec vitest run packages/core/test/version.test.ts`
- `pnpm exec eslint packages/core/src/util/version.ts packages/core/test/version.test.ts packages/core/src/unlighthouse.ts`
- `pnpm typecheck`
- `git diff --check`
